### PR TITLE
feat: Enable Banking PSD2 Open Banking integration

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,11 +25,11 @@ KRAKEN_API_KEY=
 KRAKEN_PRIVATE_KEY=
 
 # Enable Banking (Open Banking / PSD2)
+# Sandbox vs production is determined by the app credentials, not a separate flag.
 ENABLE_BANKING_APP_ID=
 ENABLE_BANKING_PRIVATE_KEY=
 # OR use a file path instead:
 # ENABLE_BANKING_PRIVATE_KEY_PATH=/path/to/private-key.pem
-ENABLE_BANKING_ENVIRONMENT=sandbox
 ENABLE_BANKING_REDIRECT_URI=http://localhost:8080/api/enable-banking/callback
 
 # Demo environment controls

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,14 @@ PLAID_ENVIRONMENT=sandbox
 KRAKEN_API_KEY=
 KRAKEN_PRIVATE_KEY=
 
+# Enable Banking (Open Banking / PSD2)
+ENABLE_BANKING_APP_ID=
+ENABLE_BANKING_PRIVATE_KEY=
+# OR use a file path instead:
+# ENABLE_BANKING_PRIVATE_KEY_PATH=/path/to/private-key.pem
+ENABLE_BANKING_ENVIRONMENT=sandbox
+ENABLE_BANKING_REDIRECT_URI=http://localhost:8080/api/enable-banking/callback
+
 # Demo environment controls
 # Enable only in dedicated demo deployments.
 DEMO_MODE=false

--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -1,0 +1,125 @@
+"""
+Enable Banking adapter implementing the BankAdapter interface.
+
+Fetches accounts, transactions, and balances from the Enable Banking REST API.
+"""
+
+from typing import List, Optional
+from decimal import Decimal
+from datetime import datetime
+
+from app.integrations.base import BankAdapter, AccountData, TransactionData
+from app.integrations.enable_banking_auth import EnableBankingClient
+
+
+# Mapping from Enable Banking cash account types to our canonical types
+_ACCOUNT_TYPE_MAP = {
+    "CACC": "checking",   # Current Account
+    "SVGS": "savings",    # Savings Account
+    "TRAN": "checking",   # Transaction Account
+    "CASH": "checking",   # Cash Payment
+    "CARD": "credit",     # Card Account
+    "LOAN": "credit",     # Loan Account
+    "MGLD": "savings",    # Managed Account
+    "MOMA": "savings",    # Money Market Account
+}
+
+
+class EnableBankingAdapter(BankAdapter):
+    """Adapter for Enable Banking REST API."""
+
+    def __init__(self, session_id: str, client: Optional[EnableBankingClient] = None):
+        """
+        Args:
+            session_id: Enable Banking session ID (obtained from POST /sessions).
+            client: Optional pre-configured EnableBankingClient.
+        """
+        self.session_id = session_id
+        self.client = client or EnableBankingClient()
+
+    def _map_account_type(self, cash_account_type: Optional[str]) -> str:
+        """Map EB cash account type to our canonical type."""
+        if not cash_account_type:
+            return "checking"
+        return _ACCOUNT_TYPE_MAP.get(cash_account_type.upper(), "checking")
+
+    def fetch_accounts(self) -> List[AccountData]:
+        """Fetch accounts from the EB session."""
+        resp = self.client.get(f"/sessions/{self.session_id}")
+        session_data = resp.json()
+
+        aspsp_name = session_data.get("aspsp", {}).get("name", "")
+        accounts = []
+        for acc in session_data.get("accounts", []):
+            accounts.append(AccountData(
+                external_id=acc["uid"],
+                name=acc.get("account_name") or acc.get("iban") or "Unknown Account",
+                account_type=self._map_account_type(acc.get("cash_account_type")),
+                institution=aspsp_name,
+                currency=acc.get("currency", "EUR"),
+                balance_available=None,  # Fetched separately via fetch_balances
+            ))
+        return accounts
+
+    def fetch_transactions(
+        self,
+        account_external_id: str,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+    ) -> List[TransactionData]:
+        """Fetch transactions with pagination via continuation_key."""
+        all_transactions: List[TransactionData] = []
+        params: dict = {}
+        if start_date:
+            params["date_from"] = start_date.strftime("%Y-%m-%d")
+        if end_date:
+            params["date_to"] = end_date.strftime("%Y-%m-%d")
+
+        continuation_key = None
+        while True:
+            if continuation_key:
+                params["continuation_key"] = continuation_key
+
+            resp = self.client.get(
+                f"/accounts/{account_external_id}/transactions",
+                params=params,
+            )
+            data = resp.json()
+
+            for txn in data.get("transactions", []):
+                all_transactions.append(self.normalize_transaction(txn))
+
+            continuation_key = data.get("continuation_key")
+            if not continuation_key:
+                break
+
+        return all_transactions
+
+    def normalize_transaction(self, raw: dict) -> TransactionData:
+        """Map EB transaction to canonical format."""
+        amount = Decimal(str(raw["transaction_amount"]["amount"]))
+        # EB uses entry_reference as primary ID; fall back to transaction_id
+        external_id = raw.get("entry_reference") or raw.get("transaction_id", "")
+
+        return TransactionData(
+            external_id=external_id,
+            account_external_id=raw.get("account_id", ""),
+            amount=abs(amount),
+            currency=raw["transaction_amount"]["currency"],
+            description=raw.get("remittance_information_unstructured", ""),
+            merchant=raw.get("creditor_name") or raw.get("debtor_name"),
+            booked_at=datetime.fromisoformat(raw["booking_date"]),
+            transaction_type="debit" if amount < 0 else "credit",
+            pending=raw.get("status") == "PDNG",
+            metadata={"raw": raw},
+        )
+
+    def fetch_balances(self, account_uid: str) -> dict:
+        """
+        Fetch account balances.
+
+        Returns:
+            Raw balance response dict with "balances" list.
+        """
+        resp = self.client.get(f"/accounts/{account_uid}/balances")
+        return resp.json()

--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -104,7 +104,7 @@ class EnableBankingAdapter(BankAdapter):
         return TransactionData(
             external_id=external_id,
             account_external_id=raw.get("account_id", ""),
-            amount=abs(amount),
+            amount=amount,
             currency=raw["transaction_amount"]["currency"],
             description=raw.get("remittance_information_unstructured", ""),
             merchant=raw.get("creditor_name") or raw.get("debtor_name"),

--- a/backend/app/integrations/enable_banking_auth.py
+++ b/backend/app/integrations/enable_banking_auth.py
@@ -55,6 +55,7 @@ class EnableBankingClient:
         redirect_uri: Optional[str] = None,
     ):
         self.app_id = app_id or os.getenv("ENABLE_BANKING_APP_ID", "")
+        self.environment = environment or os.getenv("ENABLE_BANKING_ENVIRONMENT", "sandbox")
         self.redirect_uri = redirect_uri or os.getenv("ENABLE_BANKING_REDIRECT_URI", "")
         self.base_url = "https://api.enablebanking.com"
 

--- a/backend/app/integrations/enable_banking_auth.py
+++ b/backend/app/integrations/enable_banking_auth.py
@@ -51,12 +51,12 @@ class EnableBankingClient:
         self,
         app_id: Optional[str] = None,
         private_key_pem: Optional[str] = None,
-        environment: Optional[str] = None,
         redirect_uri: Optional[str] = None,
     ):
         self.app_id = app_id or os.getenv("ENABLE_BANKING_APP_ID", "")
-        self.environment = environment or os.getenv("ENABLE_BANKING_ENVIRONMENT", "sandbox")
         self.redirect_uri = redirect_uri or os.getenv("ENABLE_BANKING_REDIRECT_URI", "")
+        # Enable Banking uses the same API URL for sandbox and production;
+        # the application credentials determine the environment.
         self.base_url = "https://api.enablebanking.com"
 
         # Load private key from env var or file path

--- a/backend/app/integrations/enable_banking_auth.py
+++ b/backend/app/integrations/enable_banking_auth.py
@@ -1,0 +1,109 @@
+"""
+Enable Banking API authentication and HTTP client.
+
+Uses JWT (RS256) signed with the application's RSA private key.
+See: https://enablebanking.com/docs/api/reference/
+"""
+
+import os
+import time
+from typing import Optional
+
+import jwt
+import requests
+from cryptography.hazmat.primitives import serialization
+
+
+def create_eb_jwt(application_id: str, private_key_pem: str, ttl: int = 3600) -> str:
+    """
+    Create a JWT for Enable Banking API authentication.
+
+    Args:
+        application_id: Enable Banking application ID (used as kid header).
+        private_key_pem: RSA private key in PEM format.
+        ttl: Token time-to-live in seconds (max 86400).
+
+    Returns:
+        Signed JWT string.
+    """
+    private_key = serialization.load_pem_private_key(
+        private_key_pem.encode("utf-8"), password=None
+    )
+    now = int(time.time())
+    payload = {
+        "iss": "enablebanking.com",
+        "aud": "api.enablebanking.com",
+        "iat": now,
+        "exp": now + ttl,
+    }
+    headers = {
+        "typ": "JWT",
+        "alg": "RS256",
+        "kid": application_id,
+    }
+    return jwt.encode(payload, private_key, algorithm="RS256", headers=headers)
+
+
+class EnableBankingClient:
+    """HTTP client for Enable Banking REST API."""
+
+    def __init__(
+        self,
+        app_id: Optional[str] = None,
+        private_key_pem: Optional[str] = None,
+        environment: Optional[str] = None,
+        redirect_uri: Optional[str] = None,
+    ):
+        self.app_id = app_id or os.getenv("ENABLE_BANKING_APP_ID", "")
+        self.redirect_uri = redirect_uri or os.getenv("ENABLE_BANKING_REDIRECT_URI", "")
+        self.base_url = "https://api.enablebanking.com"
+
+        # Load private key from env var or file path
+        self._private_key_pem = private_key_pem
+        if not self._private_key_pem:
+            self._private_key_pem = os.getenv("ENABLE_BANKING_PRIVATE_KEY", "")
+        if not self._private_key_pem:
+            key_path = os.getenv("ENABLE_BANKING_PRIVATE_KEY_PATH", "")
+            if key_path and os.path.exists(key_path):
+                with open(key_path, "r") as f:
+                    self._private_key_pem = f.read()
+
+    def get_headers(self) -> dict:
+        """Get authorization headers with a fresh JWT."""
+        token = create_eb_jwt(self.app_id, self._private_key_pem)
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def get(self, path: str, params: Optional[dict] = None) -> requests.Response:
+        """Make an authenticated GET request."""
+        resp = requests.get(
+            f"{self.base_url}{path}",
+            headers=self.get_headers(),
+            params=params,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp
+
+    def post(self, path: str, json_data: Optional[dict] = None) -> requests.Response:
+        """Make an authenticated POST request."""
+        resp = requests.post(
+            f"{self.base_url}{path}",
+            headers=self.get_headers(),
+            json=json_data,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp
+
+    def delete(self, path: str) -> requests.Response:
+        """Make an authenticated DELETE request."""
+        resp = requests.delete(
+            f"{self.base_url}{path}",
+            headers=self.get_headers(),
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -75,6 +75,7 @@ class Account(Base):
             unique=True,
             postgresql_where=text("external_id_hash IS NOT NULL"),
         ),
+        Index("idx_accounts_bank_connection", "bank_connection_id"),
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -43,6 +43,7 @@ class Account(Base):
     external_id = Column(String(255), nullable=True)  # Provider's account ID
     external_id_ciphertext = Column(Text, nullable=True)
     external_id_hash = Column(String(64), nullable=True, index=True)
+    bank_connection_id = Column(UUID(as_uuid=True), ForeignKey("bank_connections.id", ondelete="SET NULL"), nullable=True, index=True)
     balance_available = Column(Numeric(15, 2), nullable=True)
     starting_balance = Column(Numeric(15, 2), default=Decimal("0"))  # Starting balance for calculation
     functional_balance = Column(Numeric(15, 2), nullable=True)  # Calculated balance (sum of transactions + starting_balance)
@@ -55,6 +56,7 @@ class Account(Base):
     # Relationships
     user = relationship("User", back_populates="accounts")
     logo = relationship("CompanyLogo", back_populates="accounts")
+    bank_connection = relationship("BankConnection", back_populates="accounts")
     transactions = relationship("Transaction", back_populates="account")
     csv_imports = relationship("CsvImport", back_populates="account")
     balances = relationship("AccountBalance", back_populates="account")
@@ -73,6 +75,41 @@ class Account(Base):
             unique=True,
             postgresql_where=text("external_id_hash IS NOT NULL"),
         ),
+    )
+
+
+class BankConnection(Base):
+    """
+    Bank connection model for Enable Banking sessions.
+    Tracks consent lifecycle and sync state.
+    """
+    __tablename__ = "bank_connections"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    provider = Column(String(50), nullable=False, default="enable_banking")
+    session_id = Column(String(255), nullable=False)
+    aspsp_name = Column(String(255), nullable=False)
+    aspsp_country = Column(String(2), nullable=False)
+    consent_expires_at = Column(DateTime, nullable=True)
+    consent_notified_at = Column(DateTime, nullable=True)
+    status = Column(String(20), nullable=False, default="active")
+    last_synced_at = Column(DateTime, nullable=True)
+    last_sync_error = Column(Text, nullable=True)
+    sync_cursor = Column(JSONB, nullable=True)
+    raw_session_data = Column(JSONB, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # Relationships
+    user = relationship("User", back_populates="bank_connections")
+    accounts = relationship("Account", back_populates="bank_connection")
+
+    __table_args__ = (
+        Index("idx_bank_connections_user", "user_id"),
+        Index("idx_bank_connections_status", "status"),
+        Index("idx_bank_connections_consent_expires", "consent_expires_at"),
+        UniqueConstraint("user_id", "session_id", name="bank_connections_user_session"),
     )
 
 
@@ -564,6 +601,7 @@ class User(Base):
     subscription_suggestions = relationship("SubscriptionSuggestion", back_populates="user", cascade="all, delete-orphan")
     api_keys = relationship("ApiKey", back_populates="user", cascade="all, delete-orphan")
     transaction_links = relationship("TransactionLink", back_populates="user", cascade="all, delete-orphan")
+    bank_connections = relationship("BankConnection", back_populates="user", cascade="all, delete-orphan")
 
 
 class ApiKey(Base):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -43,7 +43,7 @@ class Account(Base):
     external_id = Column(String(255), nullable=True)  # Provider's account ID
     external_id_ciphertext = Column(Text, nullable=True)
     external_id_hash = Column(String(64), nullable=True, index=True)
-    bank_connection_id = Column(UUID(as_uuid=True), ForeignKey("bank_connections.id", ondelete="SET NULL"), nullable=True, index=True)
+    bank_connection_id = Column(UUID(as_uuid=True), ForeignKey("bank_connections.id", ondelete="SET NULL"), nullable=True)
     balance_available = Column(Numeric(15, 2), nullable=True)
     starting_balance = Column(Numeric(15, 2), default=Decimal("0"))  # Starting balance for calculation
     functional_balance = Column(Numeric(15, 2), nullable=True)  # Calculated balance (sum of transactions + starting_balance)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.routes import accounts, categories, transactions, analytics, sync, transaction_import, subscriptions, events, csv_import, health
+from app.routes import accounts, categories, transactions, analytics, sync, transaction_import, subscriptions, events, csv_import, health, enable_banking
 
 api_router = APIRouter()
 
@@ -13,3 +13,4 @@ api_router.include_router(sync.router, prefix="/sync", tags=["sync"])
 api_router.include_router(subscriptions.router, prefix="/subscriptions", tags=["subscriptions"])
 api_router.include_router(events.router, prefix="/events", tags=["events"])
 api_router.include_router(csv_import.router, prefix="/csv-import", tags=["csv-import"])
+api_router.include_router(enable_banking.router, prefix="/enable-banking", tags=["enable-banking"])

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -1,0 +1,378 @@
+"""
+API routes for Enable Banking integration.
+
+Handles ASPSP listing, auth initiation, session exchange, sync triggers,
+connection status, and disconnection.
+"""
+
+import os
+import logging
+from typing import Optional
+from datetime import datetime, timedelta
+
+import redis
+import json
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from pydantic import BaseModel
+
+from app.database import get_db
+from app.db_helpers import get_user_id
+from app.models import BankConnection, Account
+from app.integrations.enable_banking_auth import EnableBankingClient
+from app.integrations.enable_banking_adapter import EnableBankingAdapter
+from app.services.sync_service import SyncService
+from app.security.data_encryption import encrypt_value, blind_index
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+ASPSP_CACHE_TTL = 86400  # 24 hours
+
+
+# --- Request/Response models ---
+
+class AuthRequest(BaseModel):
+    aspsp_name: str
+    aspsp_country: str
+
+class AuthResponse(BaseModel):
+    url: str
+
+class SessionRequest(BaseModel):
+    code: str
+
+class SessionResponse(BaseModel):
+    connection_id: str
+    accounts_count: int
+
+class ConnectionStatusResponse(BaseModel):
+    id: str
+    aspsp_name: str
+    aspsp_country: str
+    status: str
+    last_synced_at: Optional[str] = None
+    consent_expires_at: Optional[str] = None
+    last_sync_error: Optional[str] = None
+    accounts_count: int
+
+class SyncTriggerResponse(BaseModel):
+    message: str
+    task_id: Optional[str] = None
+
+
+# --- Helper ---
+
+def _get_eb_client() -> EnableBankingClient:
+    return EnableBankingClient()
+
+def _get_redis() -> redis.Redis:
+    return redis.from_url(REDIS_URL, decode_responses=True)
+
+
+# --- Routes ---
+
+@router.get("/aspsps")
+def list_aspsps(country: Optional[str] = None):
+    """
+    List available banks (ASPSPs), optionally filtered by country.
+    Results are cached in Redis for 24 hours.
+    """
+    cache_key = f"eb:aspsps:{country or 'all'}"
+
+    try:
+        r = _get_redis()
+        cached = r.get(cache_key)
+        if cached:
+            return json.loads(cached)
+    except Exception:
+        logger.warning("Redis unavailable for ASPSP cache, fetching from API")
+
+    client = _get_eb_client()
+    params = {}
+    if country:
+        params["country"] = country.upper()
+
+    try:
+        resp = client.get("/aspsps", params=params)
+        data = resp.json()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Enable Banking API error: {str(e)}")
+
+    # Cache the response
+    try:
+        r = _get_redis()
+        r.setex(cache_key, ASPSP_CACHE_TTL, json.dumps(data))
+    except Exception:
+        logger.warning("Failed to cache ASPSP list in Redis")
+
+    return data
+
+
+@router.post("/auth", response_model=AuthResponse)
+def initiate_auth(
+    body: AuthRequest,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Generate bank authorization URL for PSU redirect."""
+    client = _get_eb_client()
+
+    auth_payload = {
+        "access": {
+            "valid_until": (datetime.utcnow() + timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        },
+        "aspsp": {
+            "name": body.aspsp_name,
+            "country": body.aspsp_country.upper(),
+        },
+        "state": user_id,  # Pass user_id as state for callback validation
+        "redirect_url": client.redirect_uri,
+        "psu_type": "personal",
+    }
+
+    try:
+        resp = client.post("/auth", json_data=auth_payload)
+        data = resp.json()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Failed to initiate auth: {str(e)}")
+
+    return AuthResponse(url=data["url"])
+
+
+@router.post("/session", response_model=SessionResponse)
+def create_session(
+    body: SessionRequest,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """
+    Exchange authorization code for an Enable Banking session.
+    Creates a bank_connections row and upserts accounts.
+    """
+    client = _get_eb_client()
+
+    # Exchange code for session
+    try:
+        resp = client.post("/sessions", json_data={"code": body.code})
+        session_data = resp.json()
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Session exchange failed: {str(e)}")
+
+    session_id = session_data.get("session_id")
+    if not session_id:
+        raise HTTPException(status_code=502, detail="No session_id in response")
+
+    aspsp_info = session_data.get("aspsp", {})
+    aspsp_name = aspsp_info.get("name", "Unknown Bank")
+    aspsp_country = aspsp_info.get("country", "XX")
+
+    # Calculate consent expiry (EB returns valid_until or we default to 90 days)
+    consent_valid_until = session_data.get("access", {}).get("valid_until")
+    consent_expires_at = None
+    if consent_valid_until:
+        try:
+            consent_expires_at = datetime.fromisoformat(consent_valid_until.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            consent_expires_at = datetime.utcnow() + timedelta(days=90)
+    else:
+        consent_expires_at = datetime.utcnow() + timedelta(days=90)
+
+    # Create bank_connections row
+    connection = BankConnection(
+        user_id=user_id,
+        provider="enable_banking",
+        session_id=session_id,
+        aspsp_name=aspsp_name,
+        aspsp_country=aspsp_country,
+        consent_expires_at=consent_expires_at,
+        status="active",
+        raw_session_data=session_data,
+    )
+    db.add(connection)
+    db.flush()  # Get the ID
+
+    # Upsert accounts from session response
+    accounts_data = session_data.get("accounts", [])
+    for acc_data in accounts_data:
+        account_uid = acc_data["uid"]
+
+        # Check for existing account by external_id
+        existing = db.query(Account).filter(
+            Account.user_id == user_id,
+            Account.provider == "enable_banking",
+            Account.external_id == account_uid,
+        ).first()
+
+        if existing:
+            existing.bank_connection_id = connection.id
+            existing.name = acc_data.get("account_name") or acc_data.get("iban") or existing.name
+            existing.is_active = True
+        else:
+            new_account = Account(
+                user_id=user_id,
+                name=acc_data.get("account_name") or acc_data.get("iban") or "Unknown Account",
+                account_type=_map_account_type(acc_data.get("cash_account_type")),
+                institution=aspsp_name,
+                currency=acc_data.get("currency", "EUR"),
+                provider="enable_banking",
+                external_id=account_uid,
+                bank_connection_id=connection.id,
+            )
+            encrypted = encrypt_value(account_uid)
+            hashed = blind_index(account_uid)
+            new_account.external_id_hash = hashed
+            if encrypted:
+                new_account.external_id_ciphertext = encrypted
+            db.add(new_account)
+
+    db.commit()
+    db.refresh(connection)
+
+    # Dispatch initial sync task
+    try:
+        from tasks.enable_banking_tasks import sync_bank_connection
+        sync_bank_connection.delay(str(connection.id))
+    except Exception:
+        logger.warning("Failed to dispatch initial sync task", exc_info=True)
+
+    return SessionResponse(
+        connection_id=str(connection.id),
+        accounts_count=len(accounts_data),
+    )
+
+
+@router.post("/sync/{connection_id}", response_model=SyncTriggerResponse)
+def trigger_sync(
+    connection_id: str,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Trigger on-demand sync for a bank connection."""
+    connection = db.query(BankConnection).filter(
+        BankConnection.id == connection_id,
+        BankConnection.user_id == user_id,
+    ).first()
+    if not connection:
+        raise HTTPException(status_code=404, detail="Connection not found")
+
+    if connection.status not in ("active",):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot sync connection with status '{connection.status}'. Reconnect the bank first.",
+        )
+
+    try:
+        from tasks.enable_banking_tasks import sync_bank_connection
+        task = sync_bank_connection.delay(str(connection.id))
+        return SyncTriggerResponse(message="Sync started", task_id=task.id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to start sync: {str(e)}")
+
+
+@router.get("/status/{connection_id}", response_model=ConnectionStatusResponse)
+def connection_status(
+    connection_id: str,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Get connection status, last sync time, consent expiry."""
+    connection = db.query(BankConnection).filter(
+        BankConnection.id == connection_id,
+        BankConnection.user_id == user_id,
+    ).first()
+    if not connection:
+        raise HTTPException(status_code=404, detail="Connection not found")
+
+    accounts_count = db.query(Account).filter(
+        Account.bank_connection_id == connection.id,
+    ).count()
+
+    return ConnectionStatusResponse(
+        id=str(connection.id),
+        aspsp_name=connection.aspsp_name,
+        aspsp_country=connection.aspsp_country,
+        status=connection.status,
+        last_synced_at=connection.last_synced_at.isoformat() if connection.last_synced_at else None,
+        consent_expires_at=connection.consent_expires_at.isoformat() if connection.consent_expires_at else None,
+        last_sync_error=connection.last_sync_error,
+        accounts_count=accounts_count,
+    )
+
+
+@router.get("/connections")
+def list_connections(
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """List all bank connections for the current user."""
+    connections = db.query(BankConnection).filter(
+        BankConnection.user_id == user_id,
+    ).order_by(BankConnection.created_at.desc()).all()
+
+    results = []
+    for conn in connections:
+        accounts_count = db.query(Account).filter(
+            Account.bank_connection_id == conn.id,
+        ).count()
+        results.append({
+            "id": str(conn.id),
+            "aspsp_name": conn.aspsp_name,
+            "aspsp_country": conn.aspsp_country,
+            "status": conn.status,
+            "last_synced_at": conn.last_synced_at.isoformat() if conn.last_synced_at else None,
+            "consent_expires_at": conn.consent_expires_at.isoformat() if conn.consent_expires_at else None,
+            "last_sync_error": conn.last_sync_error,
+            "accounts_count": accounts_count,
+            "created_at": conn.created_at.isoformat() if conn.created_at else None,
+        })
+
+    return results
+
+
+@router.delete("/{connection_id}")
+def disconnect(
+    connection_id: str,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Disconnect bank: revoke EB session, mark connection as disconnected."""
+    connection = db.query(BankConnection).filter(
+        BankConnection.id == connection_id,
+        BankConnection.user_id == user_id,
+    ).first()
+    if not connection:
+        raise HTTPException(status_code=404, detail="Connection not found")
+
+    # Revoke session at Enable Banking (best-effort)
+    try:
+        client = _get_eb_client()
+        client.delete(f"/sessions/{connection.session_id}")
+    except Exception:
+        logger.warning(f"Failed to revoke EB session {connection.session_id}", exc_info=True)
+
+    connection.status = "disconnected"
+    db.commit()
+
+    return {"message": "Bank connection disconnected"}
+
+
+# --- Helpers ---
+
+def _map_account_type(cash_account_type: Optional[str]) -> str:
+    """Map EB cash account type to our canonical type."""
+    if not cash_account_type:
+        return "checking"
+    mapping = {
+        "CACC": "checking",
+        "SVGS": "savings",
+        "TRAN": "checking",
+        "CASH": "checking",
+        "CARD": "credit",
+        "LOAN": "credit",
+        "MGLD": "savings",
+        "MOMA": "savings",
+    }
+    return mapping.get(cash_account_type.upper(), "checking")

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -44,6 +44,7 @@ class AuthResponse(BaseModel):
 
 class SessionRequest(BaseModel):
     code: str
+    state: Optional[str] = None
 
 class SessionResponse(BaseModel):
     connection_id: str
@@ -161,6 +162,20 @@ def create_session(
     Exchange authorization code for an Enable Banking session.
     Creates a bank_connections row and upserts accounts.
     """
+    # Validate OAuth state nonce if provided
+    if body.state:
+        try:
+            r = _get_redis()
+            stored_user_id = r.get(f"eb:state:{body.state}")
+            if stored_user_id and stored_user_id != user_id:
+                raise HTTPException(status_code=403, detail="OAuth state mismatch")
+            # Clean up used nonce
+            r.delete(f"eb:state:{body.state}")
+        except HTTPException:
+            raise
+        except Exception:
+            logger.warning("Failed to validate OAuth state from Redis")
+
     client = _get_eb_client()
 
     # Exchange code for session

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -7,6 +7,7 @@ connection status, and disconnection.
 
 import os
 import logging
+import uuid as uuid_mod
 from typing import Optional
 from datetime import datetime, timedelta
 
@@ -20,7 +21,7 @@ from app.database import get_db
 from app.db_helpers import get_user_id
 from app.models import BankConnection, Account
 from app.integrations.enable_banking_auth import EnableBankingClient
-from app.integrations.enable_banking_adapter import EnableBankingAdapter
+from app.integrations.enable_banking_adapter import EnableBankingAdapter, _ACCOUNT_TYPE_MAP
 from app.services.sync_service import SyncService
 from app.security.data_encryption import encrypt_value, blind_index
 
@@ -75,7 +76,7 @@ def _get_redis() -> redis.Redis:
 # --- Routes ---
 
 @router.get("/aspsps")
-def list_aspsps(country: Optional[str] = None):
+def list_aspsps(country: Optional[str] = None, user_id: str = Depends(get_user_id)):
     """
     List available banks (ASPSPs), optionally filtered by country.
     Results are cached in Redis for 24 hours.
@@ -120,6 +121,14 @@ def initiate_auth(
     """Generate bank authorization URL for PSU redirect."""
     client = _get_eb_client()
 
+    # Generate a random state nonce (don't leak user_id in the redirect URL)
+    state_nonce = str(uuid_mod.uuid4())
+    try:
+        r = _get_redis()
+        r.setex(f"eb:state:{state_nonce}", 600, user_id)  # 10 min TTL
+    except Exception:
+        logger.warning("Failed to store OAuth state in Redis")
+
     auth_payload = {
         "access": {
             "valid_until": (datetime.utcnow() + timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
@@ -128,7 +137,7 @@ def initiate_auth(
             "name": body.aspsp_name,
             "country": body.aspsp_country.upper(),
         },
-        "state": user_id,  # Pass user_id as state for callback validation
+        "state": state_nonce,
         "redirect_url": client.redirect_uri,
         "psu_type": "personal",
     }
@@ -214,7 +223,7 @@ def create_session(
             new_account = Account(
                 user_id=user_id,
                 name=acc_data.get("account_name") or acc_data.get("iban") or "Unknown Account",
-                account_type=_map_account_type(acc_data.get("cash_account_type")),
+                account_type=_ACCOUNT_TYPE_MAP.get((acc_data.get("cash_account_type") or "").upper(), "checking"),
                 institution=aspsp_name,
                 currency=acc_data.get("currency", "EUR"),
                 provider="enable_banking",
@@ -357,22 +366,3 @@ def disconnect(
     db.commit()
 
     return {"message": "Bank connection disconnected"}
-
-
-# --- Helpers ---
-
-def _map_account_type(cash_account_type: Optional[str]) -> str:
-    """Map EB cash account type to our canonical type."""
-    if not cash_account_type:
-        return "checking"
-    mapping = {
-        "CACC": "checking",
-        "SVGS": "savings",
-        "TRAN": "checking",
-        "CASH": "checking",
-        "CARD": "credit",
-        "LOAN": "credit",
-        "MGLD": "savings",
-        "MOMA": "savings",
-    }
-    return mapping.get(cash_account_type.upper(), "checking")

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -13,7 +13,7 @@ celery_app = Celery(
     "finance_tasks",
     broker=REDIS_URL,
     backend=REDIS_URL,
-    include=["tasks.csv_import_tasks", "tasks.demo_tasks"],
+    include=["tasks.csv_import_tasks", "tasks.demo_tasks", "tasks.enable_banking_tasks"],
 )
 
 
@@ -60,6 +60,16 @@ def _build_beat_schedule() -> dict:
             "task": "tasks.demo_tasks.append_previous_day_demo_transactions",
             "schedule": crontab(minute=demo_daily_minute_utc, hour=demo_daily_hour_utc),
         }
+
+    # Enable Banking sync schedules (always active — tasks are no-ops if no connections exist)
+    schedule["sync-all-bank-connections"] = {
+        "task": "tasks.enable_banking_tasks.sync_all_bank_connections",
+        "schedule": crontab(minute=0, hour="*/6"),
+    }
+    schedule["check-consent-expiry"] = {
+        "task": "tasks.enable_banking_tasks.check_consent_expiry",
+        "schedule": crontab(minute=0, hour=9),
+    }
 
     return schedule
 

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -1,0 +1,191 @@
+"""
+Celery tasks for Enable Banking sync and consent management.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from celery import shared_task
+from sqlalchemy.orm import Session
+
+from app.database import SessionLocal
+from app.models import BankConnection, Account
+from app.integrations.enable_banking_adapter import EnableBankingAdapter
+from app.integrations.enable_banking_auth import EnableBankingClient
+from app.services.sync_service import SyncService
+from app.security.data_encryption import decrypt_with_fallback
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def sync_bank_connection(self, connection_id: str):
+    """
+    Sync a single bank connection: fetch balances + transactions for all accounts.
+    Runs through SyncService for categorization, enrichment, and subscription matching.
+    """
+    db: Session = SessionLocal()
+    try:
+        connection = db.query(BankConnection).filter(
+            BankConnection.id == connection_id,
+        ).first()
+
+        if not connection:
+            logger.error(f"Bank connection {connection_id} not found")
+            return {"error": "Connection not found"}
+
+        if connection.status not in ("active",):
+            logger.info(f"Skipping sync for connection {connection_id} with status {connection.status}")
+            return {"skipped": True, "reason": f"Status is {connection.status}"}
+
+        client = EnableBankingClient()
+        adapter = EnableBankingAdapter(
+            session_id=connection.session_id,
+            client=client,
+        )
+
+        # Determine date range for transactions
+        if connection.last_synced_at:
+            # Incremental: fetch since last sync (with 1 day overlap for safety)
+            start_date = connection.last_synced_at - timedelta(days=1)
+        else:
+            # Initial: fetch last 90 days
+            start_date = datetime.utcnow() - timedelta(days=90)
+
+        sync_service = SyncService(db, user_id=connection.user_id)
+
+        # Get accounts linked to this connection
+        accounts = db.query(Account).filter(
+            Account.bank_connection_id == connection.id,
+        ).all()
+
+        total_created = 0
+        total_updated = 0
+
+        for account in accounts:
+            account_uid = decrypt_with_fallback(
+                account.external_id_ciphertext,
+                account.external_id,
+            )
+            if not account_uid:
+                logger.warning(f"No external_id for account {account.id}, skipping")
+                continue
+
+            # Fetch and update balances
+            try:
+                balance_data = adapter.fetch_balances(account_uid)
+                balances = balance_data.get("balances", [])
+                for bal in balances:
+                    bal_type = bal.get("balance_type", "")
+                    if bal_type in ("CLAV", "ITAV"):  # Available balance
+                        account.balance_available = bal["balance_amount"]["amount"]
+                        account.balance_is_anchored = True
+                        break
+            except Exception as e:
+                logger.warning(f"Failed to fetch balances for account {account.id}: {e}")
+
+            # Sync transactions via SyncService
+            try:
+                created, updated, _ = sync_service.sync_transactions(
+                    adapter=adapter,
+                    account=account,
+                    start_date=start_date,
+                )
+                total_created += created
+                total_updated += updated
+            except Exception as e:
+                logger.error(f"Failed to sync transactions for account {account.id}: {e}")
+                raise
+
+            account.last_synced_at = datetime.utcnow()
+
+        connection.last_synced_at = datetime.utcnow()
+        connection.last_sync_error = None
+        db.commit()
+
+        logger.info(
+            f"Synced connection {connection_id}: "
+            f"{total_created} created, {total_updated} updated"
+        )
+        return {
+            "connection_id": connection_id,
+            "transactions_created": total_created,
+            "transactions_updated": total_updated,
+        }
+
+    except Exception as e:
+        logger.error(f"Sync failed for connection {connection_id}: {e}", exc_info=True)
+        # Mark error on connection
+        try:
+            connection = db.query(BankConnection).filter(
+                BankConnection.id == connection_id,
+            ).first()
+            if connection:
+                error_msg = str(e)
+                # Detect expired consent
+                if "401" in error_msg or "403" in error_msg or "consent" in error_msg.lower():
+                    connection.status = "expired"
+                    connection.last_sync_error = "Consent expired. Please reconnect."
+                else:
+                    connection.last_sync_error = error_msg[:500]
+                db.commit()
+        except Exception:
+            pass
+        raise self.retry(exc=e)
+    finally:
+        db.close()
+
+
+@shared_task
+def sync_all_bank_connections():
+    """
+    Periodic task: dispatch sync for all active bank connections.
+    Runs every 6 hours via Celery beat.
+    """
+    db: Session = SessionLocal()
+    try:
+        connections = db.query(BankConnection).filter(
+            BankConnection.status == "active",
+        ).all()
+
+        dispatched = 0
+        for conn in connections:
+            try:
+                sync_bank_connection.delay(str(conn.id))
+                dispatched += 1
+            except Exception as e:
+                logger.error(f"Failed to dispatch sync for connection {conn.id}: {e}")
+
+        logger.info(f"Dispatched sync for {dispatched} active connections")
+        return {"dispatched": dispatched}
+    finally:
+        db.close()
+
+
+@shared_task
+def check_consent_expiry():
+    """
+    Daily task: update status for connections with expired consents.
+    Frontend reads consent_expires_at directly for banner display.
+    """
+    db: Session = SessionLocal()
+    try:
+        now = datetime.utcnow()
+
+        # Mark expired connections
+        expired = db.query(BankConnection).filter(
+            BankConnection.status == "active",
+            BankConnection.consent_expires_at <= now,
+        ).all()
+
+        for conn in expired:
+            conn.status = "expired"
+            conn.last_sync_error = "Consent expired. Please reconnect your bank."
+            logger.info(f"Marked connection {conn.id} ({conn.aspsp_name}) as expired")
+
+        db.commit()
+
+        logger.info(f"Consent expiry check: marked {len(expired)} connections as expired")
+        return {"expired_count": len(expired)}
+    finally:
+        db.close()

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -4,6 +4,7 @@ Celery tasks for Enable Banking sync and consent management.
 
 import logging
 from datetime import datetime, timedelta
+from decimal import Decimal
 
 from celery import shared_task
 from sqlalchemy.orm import Session
@@ -100,6 +101,18 @@ def sync_bank_connection(self, connection_id: str):
                 raise
 
             account.last_synced_at = datetime.utcnow()
+
+        # Recompute functional_balance for all synced accounts
+        from sqlalchemy import func as sa_func
+        from app.models import Transaction
+        for account in accounts:
+            transaction_sum_result = db.query(sa_func.sum(Transaction.amount)).filter(
+                Transaction.user_id == connection.user_id,
+                Transaction.account_id == account.id,
+            ).scalar()
+            transaction_sum = Decimal(str(transaction_sum_result)) if transaction_sum_result else Decimal("0")
+            starting_balance = account.starting_balance or Decimal("0")
+            account.functional_balance = transaction_sum + starting_balance
 
         connection.last_synced_at = datetime.utcnow()
         connection.last_sync_error = None

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -51,6 +51,7 @@ def sync_bank_connection(self, connection_id: str):
         else:
             # Initial: fetch last 90 days
             start_date = datetime.utcnow() - timedelta(days=90)
+        end_date = datetime.utcnow()
 
         sync_service = SyncService(db, user_id=connection.user_id)
 
@@ -90,6 +91,7 @@ def sync_bank_connection(self, connection_id: str):
                     adapter=adapter,
                     account=account,
                     start_date=start_date,
+                    end_date=end_date,
                 )
                 total_created += created
                 total_updated += updated

--- a/backend/tests/test_enable_banking_adapter.py
+++ b/backend/tests/test_enable_banking_adapter.py
@@ -1,0 +1,94 @@
+"""Tests for Enable Banking adapter (transaction normalization + account mapping)."""
+
+import os
+import sys
+import unittest
+from decimal import Decimal
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.integrations.enable_banking_adapter import EnableBankingAdapter
+
+
+class TestNormalizeTransaction(unittest.TestCase):
+    def setUp(self):
+        # Adapter doesn't need real credentials for normalization tests
+        self.adapter = EnableBankingAdapter.__new__(EnableBankingAdapter)
+
+    def test_normalize_debit_transaction(self):
+        raw = {
+            "entry_reference": "txn-001",
+            "transaction_amount": {"amount": "-50.00", "currency": "EUR"},
+            "remittance_information_unstructured": "Albert Heijn payment",
+            "creditor_name": "Albert Heijn",
+            "booking_date": "2026-03-15",
+            "status": "BOOK",
+        }
+        result = self.adapter.normalize_transaction(raw)
+
+        self.assertEqual(result.external_id, "txn-001")
+        self.assertEqual(result.amount, Decimal("50.00"))
+        self.assertEqual(result.currency, "EUR")
+        self.assertEqual(result.transaction_type, "debit")
+        self.assertEqual(result.merchant, "Albert Heijn")
+        self.assertEqual(result.description, "Albert Heijn payment")
+        self.assertFalse(result.pending)
+
+    def test_normalize_credit_transaction(self):
+        raw = {
+            "entry_reference": "txn-002",
+            "transaction_amount": {"amount": "1200.00", "currency": "EUR"},
+            "remittance_information_unstructured": "Salary payment",
+            "debtor_name": "Employer BV",
+            "booking_date": "2026-03-01",
+            "status": "BOOK",
+        }
+        result = self.adapter.normalize_transaction(raw)
+
+        self.assertEqual(result.amount, Decimal("1200.00"))
+        self.assertEqual(result.transaction_type, "credit")
+        self.assertEqual(result.merchant, "Employer BV")
+
+    def test_normalize_pending_transaction(self):
+        raw = {
+            "transaction_id": "txn-pending-1",
+            "transaction_amount": {"amount": "-10.00", "currency": "EUR"},
+            "remittance_information_unstructured": "Card payment",
+            "booking_date": "2026-03-20",
+            "status": "PDNG",
+        }
+        result = self.adapter.normalize_transaction(raw)
+
+        self.assertEqual(result.external_id, "txn-pending-1")
+        self.assertTrue(result.pending)
+
+    def test_normalize_falls_back_to_transaction_id(self):
+        raw = {
+            "transaction_id": "fallback-id",
+            "transaction_amount": {"amount": "-5.00", "currency": "EUR"},
+            "remittance_information_unstructured": "Test",
+            "booking_date": "2026-03-20",
+            "status": "BOOK",
+        }
+        result = self.adapter.normalize_transaction(raw)
+        self.assertEqual(result.external_id, "fallback-id")
+
+
+class TestMapAccountType(unittest.TestCase):
+    def setUp(self):
+        self.adapter = EnableBankingAdapter.__new__(EnableBankingAdapter)
+
+    def test_maps_cacc_to_checking(self):
+        self.assertEqual(self.adapter._map_account_type("CACC"), "checking")
+
+    def test_maps_svgs_to_savings(self):
+        self.assertEqual(self.adapter._map_account_type("SVGS"), "savings")
+
+    def test_maps_unknown_to_checking(self):
+        self.assertEqual(self.adapter._map_account_type("XYZZ"), "checking")
+        self.assertEqual(self.adapter._map_account_type(None), "checking")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_enable_banking_adapter.py
+++ b/backend/tests/test_enable_banking_adapter.py
@@ -28,7 +28,7 @@ class TestNormalizeTransaction(unittest.TestCase):
         result = self.adapter.normalize_transaction(raw)
 
         self.assertEqual(result.external_id, "txn-001")
-        self.assertEqual(result.amount, Decimal("50.00"))
+        self.assertEqual(result.amount, Decimal("-50.00"))
         self.assertEqual(result.currency, "EUR")
         self.assertEqual(result.transaction_type, "debit")
         self.assertEqual(result.merchant, "Albert Heijn")

--- a/backend/tests/test_enable_banking_auth.py
+++ b/backend/tests/test_enable_banking_auth.py
@@ -1,0 +1,101 @@
+"""Tests for Enable Banking JWT authentication."""
+
+import os
+import sys
+import unittest
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Generate a test RSA key pair for testing
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+
+_test_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+TEST_PRIVATE_KEY_PEM = _test_private_key.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.PKCS8,
+    encryption_algorithm=serialization.NoEncryption(),
+).decode("utf-8")
+TEST_APP_ID = "test-app-id-123"
+
+
+class TestCreateEbJwt(unittest.TestCase):
+    def test_jwt_has_correct_claims(self):
+        from app.integrations.enable_banking_auth import create_eb_jwt
+        import jwt as pyjwt
+
+        token = create_eb_jwt(TEST_APP_ID, TEST_PRIVATE_KEY_PEM, ttl=3600)
+        # Decode without verification to check claims
+        decoded = pyjwt.decode(token, options={"verify_signature": False})
+
+        self.assertEqual(decoded["iss"], "enablebanking.com")
+        self.assertEqual(decoded["aud"], "api.enablebanking.com")
+        self.assertIn("iat", decoded)
+        self.assertIn("exp", decoded)
+        self.assertAlmostEqual(decoded["exp"] - decoded["iat"], 3600, delta=5)
+
+    def test_jwt_header_fields(self):
+        from app.integrations.enable_banking_auth import create_eb_jwt
+        import jwt as pyjwt
+
+        token = create_eb_jwt(TEST_APP_ID, TEST_PRIVATE_KEY_PEM)
+        header = pyjwt.get_unverified_header(token)
+
+        self.assertEqual(header["typ"], "JWT")
+        self.assertEqual(header["alg"], "RS256")
+        self.assertEqual(header["kid"], TEST_APP_ID)
+
+    def test_jwt_verifiable_with_public_key(self):
+        from app.integrations.enable_banking_auth import create_eb_jwt
+        import jwt as pyjwt
+
+        token = create_eb_jwt(TEST_APP_ID, TEST_PRIVATE_KEY_PEM)
+        public_key = _test_private_key.public_key()
+
+        decoded = pyjwt.decode(
+            token,
+            public_key,
+            algorithms=["RS256"],
+            audience="api.enablebanking.com",
+            issuer="enablebanking.com",
+        )
+        self.assertEqual(decoded["iss"], "enablebanking.com")
+
+
+class TestEbApiClient(unittest.TestCase):
+    def test_client_initializes_with_env_vars(self):
+        os.environ["ENABLE_BANKING_APP_ID"] = TEST_APP_ID
+        os.environ["ENABLE_BANKING_PRIVATE_KEY"] = TEST_PRIVATE_KEY_PEM
+        os.environ["ENABLE_BANKING_ENVIRONMENT"] = "sandbox"
+
+        from app.integrations.enable_banking_auth import EnableBankingClient
+
+        client = EnableBankingClient()
+        self.assertEqual(client.app_id, TEST_APP_ID)
+        self.assertEqual(client.base_url, "https://api.enablebanking.com")
+
+        # Cleanup
+        del os.environ["ENABLE_BANKING_APP_ID"]
+        del os.environ["ENABLE_BANKING_PRIVATE_KEY"]
+        del os.environ["ENABLE_BANKING_ENVIRONMENT"]
+
+    def test_client_get_headers_returns_bearer_jwt(self):
+        os.environ["ENABLE_BANKING_APP_ID"] = TEST_APP_ID
+        os.environ["ENABLE_BANKING_PRIVATE_KEY"] = TEST_PRIVATE_KEY_PEM
+        os.environ["ENABLE_BANKING_ENVIRONMENT"] = "sandbox"
+
+        from app.integrations.enable_banking_auth import EnableBankingClient
+
+        client = EnableBankingClient()
+        headers = client.get_headers()
+        self.assertIn("Authorization", headers)
+        self.assertTrue(headers["Authorization"].startswith("Bearer "))
+
+        del os.environ["ENABLE_BANKING_APP_ID"]
+        del os.environ["ENABLE_BANKING_PRIVATE_KEY"]
+        del os.environ["ENABLE_BANKING_ENVIRONMENT"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_enable_banking_auth.py
+++ b/backend/tests/test_enable_banking_auth.py
@@ -67,7 +67,6 @@ class TestEbApiClient(unittest.TestCase):
     def test_client_initializes_with_env_vars(self):
         os.environ["ENABLE_BANKING_APP_ID"] = TEST_APP_ID
         os.environ["ENABLE_BANKING_PRIVATE_KEY"] = TEST_PRIVATE_KEY_PEM
-        os.environ["ENABLE_BANKING_ENVIRONMENT"] = "sandbox"
 
         from app.integrations.enable_banking_auth import EnableBankingClient
 
@@ -78,12 +77,10 @@ class TestEbApiClient(unittest.TestCase):
         # Cleanup
         del os.environ["ENABLE_BANKING_APP_ID"]
         del os.environ["ENABLE_BANKING_PRIVATE_KEY"]
-        del os.environ["ENABLE_BANKING_ENVIRONMENT"]
 
     def test_client_get_headers_returns_bearer_jwt(self):
         os.environ["ENABLE_BANKING_APP_ID"] = TEST_APP_ID
         os.environ["ENABLE_BANKING_PRIVATE_KEY"] = TEST_PRIVATE_KEY_PEM
-        os.environ["ENABLE_BANKING_ENVIRONMENT"] = "sandbox"
 
         from app.integrations.enable_banking_auth import EnableBankingClient
 
@@ -94,7 +91,6 @@ class TestEbApiClient(unittest.TestCase):
 
         del os.environ["ENABLE_BANKING_APP_ID"]
         del os.environ["ENABLE_BANKING_PRIVATE_KEY"]
-        del os.environ["ENABLE_BANKING_ENVIRONMENT"]
 
 
 if __name__ == "__main__":

--- a/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
+++ b/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
@@ -140,7 +140,7 @@ export function BankPicker() {
 
       {/* Filters */}
       <div className="flex items-center gap-3">
-        <Select value={country} onValueChange={setCountry}>
+        <Select value={country} onValueChange={(v) => v && setCountry(v)}>
           <SelectTrigger className="w-[200px]">
             <SelectValue placeholder="Select country" />
           </SelectTrigger>

--- a/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
+++ b/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  RiSearchLine,
+  RiBankLine,
+  RiArrowLeftLine,
+  RiLoader4Line,
+  RiAlertLine,
+} from "@remixicon/react";
+import Link from "next/link";
+import { initiateAuth } from "@/lib/actions/bank-connections";
+
+// European countries with Enable Banking support
+const COUNTRIES = [
+  { code: "NL", name: "Netherlands" },
+  { code: "DE", name: "Germany" },
+  { code: "FR", name: "France" },
+  { code: "ES", name: "Spain" },
+  { code: "IT", name: "Italy" },
+  { code: "BE", name: "Belgium" },
+  { code: "AT", name: "Austria" },
+  { code: "FI", name: "Finland" },
+  { code: "SE", name: "Sweden" },
+  { code: "NO", name: "Norway" },
+  { code: "DK", name: "Denmark" },
+  { code: "PT", name: "Portugal" },
+  { code: "IE", name: "Ireland" },
+  { code: "LU", name: "Luxembourg" },
+  { code: "PL", name: "Poland" },
+  { code: "EE", name: "Estonia" },
+  { code: "LV", name: "Latvia" },
+  { code: "LT", name: "Lithuania" },
+];
+
+interface Aspsp {
+  name: string;
+  country: string;
+  logo?: string;
+  beta?: boolean;
+}
+
+export function BankPicker() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+
+  const [country, setCountry] = useState("NL");
+  const [search, setSearch] = useState("");
+  const [aspsps, setAspsps] = useState<Aspsp[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [connectingBank, setConnectingBank] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchAspsps() {
+      setLoading(true);
+      setFetchError(null);
+      try {
+        const resp = await fetch(`/api/enable-banking/aspsps?country=${country}`);
+        if (!resp.ok) throw new Error("Failed to load banks");
+        const data = await resp.json();
+        // EB returns aspsps as an array or as { aspsps: [...] }
+        const list = Array.isArray(data) ? data : data.aspsps || [];
+        setAspsps(list);
+      } catch (e) {
+        setFetchError("Failed to load available banks. Please try again.");
+        setAspsps([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchAspsps();
+  }, [country]);
+
+  const filtered = useMemo(() => {
+    if (!search) return aspsps;
+    const lower = search.toLowerCase();
+    return aspsps.filter((a) => a.name.toLowerCase().includes(lower));
+  }, [aspsps, search]);
+
+  const handleConnect = async (aspsp: Aspsp) => {
+    setConnectingBank(aspsp.name);
+    try {
+      const result = await initiateAuth(aspsp.name, aspsp.country || country);
+      if (result.success && result.url) {
+        window.location.href = result.url;
+      } else {
+        setFetchError(result.error || "Failed to initiate connection");
+        setConnectingBank(null);
+      }
+    } catch {
+      setFetchError("Failed to initiate connection. Please try again.");
+      setConnectingBank(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/settings?tab=bank-connections">
+          <RiArrowLeftLine className="mr-1.5 h-4 w-4" />
+          Back to Settings
+        </Link>
+      </Button>
+
+      {/* Error from callback */}
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+          <RiAlertLine className="h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* Header */}
+      <div>
+        <h2 className="text-lg font-semibold">Select Your Bank</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose your bank to connect via Open Banking. You&apos;ll be redirected to authorize access.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-3">
+        <Select value={country} onValueChange={setCountry}>
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder="Select country" />
+          </SelectTrigger>
+          <SelectContent>
+            {COUNTRIES.map((c) => (
+              <SelectItem key={c.code} value={c.code}>
+                {c.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="relative flex-1">
+          <RiSearchLine className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search banks..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </div>
+
+      {/* Bank grid */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <RiLoader4Line className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : fetchError ? (
+        <div className="rounded-lg border border-destructive bg-destructive/10 p-4 text-center text-sm text-destructive">
+          {fetchError}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-sm text-muted-foreground">
+          No banks found{search ? ` matching "${search}"` : ` for ${country}`}.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {filtered.map((aspsp) => (
+            <button
+              key={aspsp.name}
+              onClick={() => handleConnect(aspsp)}
+              disabled={connectingBank !== null}
+              className="flex items-center gap-3 rounded-lg border p-4 text-left transition-colors hover:bg-muted/50 disabled:opacity-50"
+            >
+              <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
+                <RiBankLine className="h-5 w-5" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-medium">
+                  {aspsp.name}
+                  {connectingBank === aspsp.name && (
+                    <RiLoader4Line className="ml-2 inline h-4 w-4 animate-spin" />
+                  )}
+                </p>
+                {aspsp.beta && (
+                  <span className="text-xs text-muted-foreground">Beta</span>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
+++ b/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -114,12 +114,13 @@ export function BankPicker() {
   return (
     <div className="space-y-6">
       {/* Back link */}
-      <Button variant="ghost" size="sm" asChild>
-        <Link href="/settings?tab=bank-connections">
-          <RiArrowLeftLine className="mr-1.5 h-4 w-4" />
-          Back to Settings
-        </Link>
-      </Button>
+      <Link
+        href="/settings?tab=bank-connections"
+        className={buttonVariants({ variant: "ghost", size: "sm" })}
+      >
+        <RiArrowLeftLine className="mr-1.5 h-4 w-4" />
+        Back to Settings
+      </Link>
 
       {/* Error from callback */}
       {error && (

--- a/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
+++ b/frontend/app/(dashboard)/settings/connect-bank/bank-picker.tsx
@@ -63,24 +63,30 @@ export function BankPicker() {
   const [connectingBank, setConnectingBank] = useState<string | null>(null);
 
   useEffect(() => {
+    const controller = new AbortController();
     async function fetchAspsps() {
       setLoading(true);
       setFetchError(null);
       try {
-        const resp = await fetch(`/api/enable-banking/aspsps?country=${country}`);
+        const resp = await fetch(`/api/enable-banking/aspsps?country=${country}`, {
+          signal: controller.signal,
+        });
         if (!resp.ok) throw new Error("Failed to load banks");
         const data = await resp.json();
-        // EB returns aspsps as an array or as { aspsps: [...] }
         const list = Array.isArray(data) ? data : data.aspsps || [];
         setAspsps(list);
       } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") return;
         setFetchError("Failed to load available banks. Please try again.");
         setAspsps([]);
       } finally {
-        setLoading(false);
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
       }
     }
     fetchAspsps();
+    return () => controller.abort();
   }, [country]);
 
   const filtered = useMemo(() => {

--- a/frontend/app/(dashboard)/settings/connect-bank/page.tsx
+++ b/frontend/app/(dashboard)/settings/connect-bank/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { Header } from "@/components/layout/header";
+import { requireAuth } from "@/lib/auth-helpers";
+import { BankPicker } from "./bank-picker";
+import { RiLoader4Line } from "@remixicon/react";
+
+export default async function ConnectBankPage() {
+  const userId = await requireAuth();
+  if (!userId) redirect("/login");
+
+  return (
+    <>
+      <Header title="Connect Bank" />
+      <div className="flex flex-1 flex-col p-4 pt-0">
+        <Suspense
+          fallback={
+            <div className="flex items-center justify-center py-12">
+              <RiLoader4Line className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          }
+        >
+          <BankPicker />
+        </Suspense>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,7 @@ import { getCurrentUserProfile } from "@/lib/actions/settings";
 import { getCategories } from "@/lib/actions/categories";
 import { listApiKeys } from "@/lib/actions/api-keys";
 import { getCsvImportHistory } from "@/lib/actions/csv-import";
+import { getBankConnections } from "@/lib/actions/bank-connections";
 import { resolveMcpServerUrlForSnippet } from "@/lib/mcp/server-url";
 import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
 
@@ -15,10 +16,11 @@ export default async function SettingsPage() {
     redirect("/login");
   }
 
-  const [categories, apiKeysResult, csvImports] = await Promise.all([
+  const [categories, apiKeysResult, csvImports, bankConnections] = await Promise.all([
     getCategories(),
     listApiKeys(),
     getCsvImportHistory(),
+    getBankConnections(),
   ]);
 
   const apiKeys = apiKeysResult.success && apiKeysResult.keys ? apiKeysResult.keys : [];
@@ -42,6 +44,7 @@ export default async function SettingsPage() {
           canCreateApiKeys={canCreateApiKeys}
           canDelete={canDelete}
           csvImports={csvImports}
+          bankConnections={bankConnections}
         />
       </div>
     </>

--- a/frontend/app/(dashboard)/settings/page.tsx
+++ b/frontend/app/(dashboard)/settings/page.tsx
@@ -9,19 +9,25 @@ import { getBankConnections } from "@/lib/actions/bank-connections";
 import { resolveMcpServerUrlForSnippet } from "@/lib/mcp/server-url";
 import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
 
-export default async function SettingsPage() {
+export default async function SettingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
   const user = await getCurrentUserProfile();
 
   if (!user) {
     redirect("/login");
   }
 
-  const [categories, apiKeysResult, csvImports, bankConnections] = await Promise.all([
-    getCategories(),
-    listApiKeys(),
-    getCsvImportHistory(),
-    getBankConnections(),
-  ]);
+  const [categories, apiKeysResult, csvImports, bankConnections, resolvedSearchParams] =
+    await Promise.all([
+      getCategories(),
+      listApiKeys(),
+      getCsvImportHistory(),
+      getBankConnections(),
+      searchParams,
+    ]);
 
   const apiKeys = apiKeysResult.success && apiKeysResult.keys ? apiKeysResult.keys : [];
   const canCreateApiKeys = !isDemoRestrictedUserEmail(user.email);
@@ -43,6 +49,7 @@ export default async function SettingsPage() {
           mcpServerUrl={mcpServerUrl}
           canCreateApiKeys={canCreateApiKeys}
           canDelete={canDelete}
+          defaultTab={resolvedSearchParams.tab || "profile"}
           csvImports={csvImports}
           bankConnections={bankConnections}
         />

--- a/frontend/app/api/enable-banking/callback/route.ts
+++ b/frontend/app/api/enable-banking/callback/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getBackendBaseUrl } from "@/lib/backend-url";
+import {
+  createInternalAuthHeaders,
+} from "@/lib/internal-auth";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * Enable Banking OAuth callback handler.
+ *
+ * After the user authorizes at their bank, they're redirected here with
+ * ?code=... or ?error=...
+ *
+ * On success: exchanges code via backend, then redirects to settings.
+ * On error: redirects to connect-bank page with error message.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const code = searchParams.get("code");
+  const error = searchParams.get("error");
+
+  const baseUrl = req.nextUrl.origin;
+
+  // Handle error from bank
+  if (error) {
+    const errorDesc = searchParams.get("error_description") || error;
+    return NextResponse.redirect(
+      `${baseUrl}/settings/connect-bank?error=${encodeURIComponent(errorDesc)}`
+    );
+  }
+
+  if (!code) {
+    return NextResponse.redirect(
+      `${baseUrl}/settings/connect-bank?error=${encodeURIComponent("No authorization code received")}`
+    );
+  }
+
+  // Get user session to authenticate the backend call
+  let userId: string;
+  try {
+    const { auth } = await import("@/lib/auth");
+    const session = await auth.api.getSession({ headers: req.headers });
+    if (!session?.user?.id) {
+      return NextResponse.redirect(
+        `${baseUrl}/login?redirect=${encodeURIComponent("/settings/connect-bank")}`
+      );
+    }
+    userId = session.user.id;
+  } catch {
+    return NextResponse.redirect(
+      `${baseUrl}/login?redirect=${encodeURIComponent("/settings/connect-bank")}`
+    );
+  }
+
+  // Exchange code at backend
+  try {
+    const backendBase = getBackendBaseUrl().replace(/\/+$/, "");
+    const upstreamUrl = `${backendBase}/api/enable-banking/session`;
+
+    const signatureHeaders = createInternalAuthHeaders({
+      method: "POST",
+      pathWithQuery: "/api/enable-banking/session",
+      userId,
+    });
+
+    const resp = await fetch(upstreamUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...signatureHeaders,
+      },
+      body: JSON.stringify({ code }),
+    });
+
+    if (!resp.ok) {
+      const errorData = await resp.json().catch(() => ({ detail: "Unknown error" }));
+      return NextResponse.redirect(
+        `${baseUrl}/settings/connect-bank?error=${encodeURIComponent(errorData.detail || "Failed to connect bank")}`
+      );
+    }
+
+    return NextResponse.redirect(
+      `${baseUrl}/settings?tab=bank-connections&connected=true`
+    );
+  } catch (e) {
+    return NextResponse.redirect(
+      `${baseUrl}/settings/connect-bank?error=${encodeURIComponent("Failed to connect bank. Please try again.")}`
+    );
+  }
+}

--- a/frontend/app/api/enable-banking/callback/route.ts
+++ b/frontend/app/api/enable-banking/callback/route.ts
@@ -19,6 +19,7 @@ export const dynamic = "force-dynamic";
 export async function GET(req: NextRequest) {
   const { searchParams } = req.nextUrl;
   const code = searchParams.get("code");
+  const state = searchParams.get("state");
   const error = searchParams.get("error");
 
   const baseUrl = req.nextUrl.origin;
@@ -71,7 +72,7 @@ export async function GET(req: NextRequest) {
         "Content-Type": "application/json",
         ...signatureHeaders,
       },
-      body: JSON.stringify({ code }),
+      body: JSON.stringify({ code, state }),
     });
 
     if (!resp.ok) {

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -215,16 +215,19 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                   </Button>
                 )}
                 <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={disconnectingIds.has(connection.id)}
-                    >
-                      <RiLinkUnlinkM className="mr-1.5 h-4 w-4" />
-                      Disconnect
-                    </Button>
-                  </AlertDialogTrigger>
+                  <AlertDialogTrigger
+                    disabled={disconnectingIds.has(connection.id)}
+                    render={
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={disconnectingIds.has(connection.id)}
+                      >
+                        <RiLinkUnlinkM className="mr-1.5 h-4 w-4" />
+                        Disconnect
+                      </Button>
+                    }
+                  />
                   <AlertDialogContent>
                     <AlertDialogHeader>
                       <AlertDialogTitle>Disconnect {connection.aspspName}?</AlertDialogTitle>

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -24,17 +24,19 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { triggerSync, disconnectBank } from "@/lib/actions/bank-connections";
+type BankConnectionItem = {
+  id: string;
+  aspspName: string;
+  aspspCountry: string;
+  status: string;
+  lastSyncedAt: Date | null;
+  lastSyncError: string | null;
+  consentExpiresAt: Date | null;
+  createdAt: Date | null;
+};
+
 interface BankConnectionsManagerProps {
-  connections: Array<{
-    id: string;
-    aspspName: string;
-    aspspCountry: string;
-    status: string;
-    lastSyncedAt: Date | null;
-    lastSyncError: string | null;
-    consentExpiresAt: Date | null;
-    createdAt: Date | null;
-  }>;
+  connections: BankConnectionItem[];
 }
 
 export function BankConnectionsManager({ connections }: BankConnectionsManagerProps) {
@@ -76,7 +78,7 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
     }
   };
 
-  const getStatusBadge = (connection: BankConnection) => {
+  const getStatusBadge = (connection: BankConnectionItem) => {
     switch (connection.status) {
       case "active":
         return <Badge variant="default">Active</Badge>;
@@ -91,7 +93,7 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
     }
   };
 
-  const isConsentExpiringSoon = (connection: BankConnection) => {
+  const isConsentExpiringSoon = (connection: BankConnectionItem) => {
     if (!connection.consentExpiresAt) return false;
     const daysUntilExpiry = Math.ceil(
       (new Date(connection.consentExpiresAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
@@ -99,7 +101,7 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
     return daysUntilExpiry <= 14 && daysUntilExpiry > 0;
   };
 
-  const daysUntilExpiry = (connection: BankConnection) => {
+  const daysUntilExpiry = (connection: BankConnectionItem) => {
     if (!connection.consentExpiresAt) return null;
     return Math.ceil(
       (new Date(connection.consentExpiresAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
   RiBankLine,
@@ -117,12 +117,13 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
             Connect your bank accounts via Open Banking to automatically sync transactions.
           </p>
         </div>
-        <Button asChild>
-          <Link href="/settings/connect-bank">
-            <RiAddLine className="mr-1.5 h-4 w-4" />
-            Connect Bank
-          </Link>
-        </Button>
+        <Link
+          href="/settings/connect-bank"
+          className={buttonVariants({ variant: "default", size: "default" })}
+        >
+          <RiAddLine className="mr-1.5 h-4 w-4" />
+          Connect Bank
+        </Link>
       </div>
 
       {activeConnections.length === 0 ? (

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -1,0 +1,243 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  RiBankLine,
+  RiRefreshLine,
+  RiLinkUnlinkM,
+  RiAddLine,
+  RiAlertLine,
+} from "@remixicon/react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { triggerSync, disconnectBank } from "@/lib/actions/bank-connections";
+import type { BankConnection } from "@/lib/db/schema";
+
+interface BankConnectionsManagerProps {
+  connections: BankConnection[];
+}
+
+export function BankConnectionsManager({ connections }: BankConnectionsManagerProps) {
+  const router = useRouter();
+  const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
+  const [disconnectingIds, setDisconnectingIds] = useState<Set<string>>(new Set());
+
+  const handleSync = async (connectionId: string) => {
+    setSyncingIds((prev) => new Set(prev).add(connectionId));
+    try {
+      const result = await triggerSync(connectionId);
+      if (!result.success) {
+        console.error("Sync failed:", result.error);
+      }
+      router.refresh();
+    } finally {
+      setSyncingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(connectionId);
+        return next;
+      });
+    }
+  };
+
+  const handleDisconnect = async (connectionId: string) => {
+    setDisconnectingIds((prev) => new Set(prev).add(connectionId));
+    try {
+      const result = await disconnectBank(connectionId);
+      if (!result.success) {
+        console.error("Disconnect failed:", result.error);
+      }
+      router.refresh();
+    } finally {
+      setDisconnectingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(connectionId);
+        return next;
+      });
+    }
+  };
+
+  const getStatusBadge = (connection: BankConnection) => {
+    switch (connection.status) {
+      case "active":
+        return <Badge variant="default">Active</Badge>;
+      case "expired":
+        return <Badge variant="destructive">Expired</Badge>;
+      case "error":
+        return <Badge variant="destructive">Error</Badge>;
+      case "disconnected":
+        return <Badge variant="secondary">Disconnected</Badge>;
+      default:
+        return <Badge variant="secondary">{connection.status}</Badge>;
+    }
+  };
+
+  const isConsentExpiringSoon = (connection: BankConnection) => {
+    if (!connection.consentExpiresAt) return false;
+    const daysUntilExpiry = Math.ceil(
+      (new Date(connection.consentExpiresAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+    );
+    return daysUntilExpiry <= 14 && daysUntilExpiry > 0;
+  };
+
+  const daysUntilExpiry = (connection: BankConnection) => {
+    if (!connection.consentExpiresAt) return null;
+    return Math.ceil(
+      (new Date(connection.consentExpiresAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
+    );
+  };
+
+  const activeConnections = connections.filter((c) => c.status !== "disconnected");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Bank Connections</h2>
+          <p className="text-sm text-muted-foreground">
+            Connect your bank accounts via Open Banking to automatically sync transactions.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/settings/connect-bank">
+            <RiAddLine className="mr-1.5 h-4 w-4" />
+            Connect Bank
+          </Link>
+        </Button>
+      </div>
+
+      {activeConnections.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center">
+          <RiBankLine className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            No bank connections yet. Connect a bank to start syncing transactions automatically.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {activeConnections.map((connection) => (
+            <div
+              key={connection.id}
+              className="flex items-center justify-between rounded-lg border p-4"
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
+                  <RiBankLine className="h-5 w-5" />
+                </div>
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">{connection.aspspName}</span>
+                    {getStatusBadge(connection)}
+                  </div>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>{connection.aspspCountry}</span>
+                    {connection.lastSyncedAt && (
+                      <>
+                        <span>·</span>
+                        <span>
+                          Last synced:{" "}
+                          {new Date(connection.lastSyncedAt).toLocaleDateString()}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  {isConsentExpiringSoon(connection) && (
+                    <div className="mt-1 flex items-center gap-1 text-xs text-amber-600">
+                      <RiAlertLine className="h-3 w-3" />
+                      <span>
+                        Connection expires in {daysUntilExpiry(connection)} days.{" "}
+                        <Link
+                          href="/settings/connect-bank"
+                          className="underline"
+                        >
+                          Reconnect
+                        </Link>
+                      </span>
+                    </div>
+                  )}
+                  {connection.status === "expired" && (
+                    <div className="mt-1 flex items-center gap-1 text-xs text-destructive">
+                      <RiAlertLine className="h-3 w-3" />
+                      <span>
+                        Connection expired.{" "}
+                        <Link
+                          href="/settings/connect-bank"
+                          className="underline"
+                        >
+                          Reconnect
+                        </Link>
+                      </span>
+                    </div>
+                  )}
+                  {connection.lastSyncError && connection.status === "error" && (
+                    <p className="mt-1 text-xs text-destructive">
+                      {connection.lastSyncError}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {connection.status === "active" && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleSync(connection.id)}
+                    disabled={syncingIds.has(connection.id)}
+                  >
+                    <RiRefreshLine
+                      className={`mr-1.5 h-4 w-4 ${
+                        syncingIds.has(connection.id) ? "animate-spin" : ""
+                      }`}
+                    />
+                    {syncingIds.has(connection.id) ? "Syncing..." : "Sync Now"}
+                  </Button>
+                )}
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={disconnectingIds.has(connection.id)}
+                    >
+                      <RiLinkUnlinkM className="mr-1.5 h-4 w-4" />
+                      Disconnect
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Disconnect {connection.aspspName}?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This will revoke access to your bank data. Your existing
+                        transactions will be kept, but no new data will be synced.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={() => handleDisconnect(connection.id)}
+                      >
+                        Disconnect
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -24,10 +24,17 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { triggerSync, disconnectBank } from "@/lib/actions/bank-connections";
-import type { BankConnection } from "@/lib/db/schema";
-
 interface BankConnectionsManagerProps {
-  connections: BankConnection[];
+  connections: Array<{
+    id: string;
+    aspspName: string;
+    aspspCountry: string;
+    status: string;
+    lastSyncedAt: Date | null;
+    lastSyncError: string | null;
+    consentExpiresAt: Date | null;
+    createdAt: Date | null;
+  }>;
 }
 
 export function BankConnectionsManager({ connections }: BankConnectionsManagerProps) {

--- a/frontend/components/settings/settings-tabs.tsx
+++ b/frontend/components/settings/settings-tabs.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
-import { RiUserLine, RiFolderLine, RiKeyLine, RiUploadLine } from "@remixicon/react";
+import { RiUserLine, RiFolderLine, RiKeyLine, RiUploadLine, RiBankLine } from "@remixicon/react";
 import { ProfileEditor } from "./profile-editor";
 import { CategoryManager } from "./category-manager";
 import { ApiKeysManager } from "./api-keys-manager";
 import { ImportHistoryManager } from "./import-history-manager";
-import type { User, Category } from "@/lib/db/schema";
+import { BankConnectionsManager } from "./bank-connections-manager";
+import type { User, Category, BankConnection } from "@/lib/db/schema";
 import type { CsvImportWithStats } from "@/lib/actions/csv-import";
 
 interface SettingsTabsProps {
@@ -24,6 +25,7 @@ interface SettingsTabsProps {
     createdAt: Date | null;
   }>;
   csvImports: CsvImportWithStats[];
+  bankConnections: BankConnection[];
 }
 
 export function SettingsTabs({
@@ -34,6 +36,7 @@ export function SettingsTabs({
   canCreateApiKeys,
   canDelete = true,
   csvImports,
+  bankConnections,
 }: SettingsTabsProps) {
   return (
     <Tabs defaultValue="profile" className="flex-1">
@@ -53,6 +56,10 @@ export function SettingsTabs({
         <TabsTrigger value="import-history" data-walkthrough="walkthrough-import-history">
           <RiUploadLine className="mr-1.5 h-4 w-4" />
           Import History
+        </TabsTrigger>
+        <TabsTrigger value="bank-connections">
+          <RiBankLine className="mr-1.5 h-4 w-4" />
+          Bank Connections
         </TabsTrigger>
       </TabsList>
 
@@ -74,6 +81,10 @@ export function SettingsTabs({
 
       <TabsContent value="import-history">
         <ImportHistoryManager initialImports={csvImports} canDelete={canDelete} />
+      </TabsContent>
+
+      <TabsContent value="bank-connections">
+        <BankConnectionsManager connections={bankConnections} />
       </TabsContent>
     </Tabs>
   );

--- a/frontend/components/settings/settings-tabs.tsx
+++ b/frontend/components/settings/settings-tabs.tsx
@@ -7,7 +7,7 @@ import { CategoryManager } from "./category-manager";
 import { ApiKeysManager } from "./api-keys-manager";
 import { ImportHistoryManager } from "./import-history-manager";
 import { BankConnectionsManager } from "./bank-connections-manager";
-import type { User, Category, BankConnection } from "@/lib/db/schema";
+import type { User, Category } from "@/lib/db/schema";
 import type { CsvImportWithStats } from "@/lib/actions/csv-import";
 
 interface SettingsTabsProps {
@@ -26,7 +26,16 @@ interface SettingsTabsProps {
     createdAt: Date | null;
   }>;
   csvImports: CsvImportWithStats[];
-  bankConnections: BankConnection[];
+  bankConnections: Array<{
+    id: string;
+    aspspName: string;
+    aspspCountry: string;
+    status: string;
+    lastSyncedAt: Date | null;
+    lastSyncError: string | null;
+    consentExpiresAt: Date | null;
+    createdAt: Date | null;
+  }>;
 }
 
 export function SettingsTabs({

--- a/frontend/components/settings/settings-tabs.tsx
+++ b/frontend/components/settings/settings-tabs.tsx
@@ -16,6 +16,7 @@ interface SettingsTabsProps {
   mcpServerUrl: string;
   canCreateApiKeys: boolean;
   canDelete?: boolean;
+  defaultTab?: string;
   apiKeys: Array<{
     id: string;
     name: string;
@@ -35,11 +36,12 @@ export function SettingsTabs({
   mcpServerUrl,
   canCreateApiKeys,
   canDelete = true,
+  defaultTab = "profile",
   csvImports,
   bankConnections,
 }: SettingsTabsProps) {
   return (
-    <Tabs defaultValue="profile" className="flex-1">
+    <Tabs defaultValue={defaultTab} className="flex-1">
       <TabsList variant="line" className="mb-6">
         <TabsTrigger value="profile" data-walkthrough="walkthrough-profile">
           <RiUserLine className="mr-1.5 h-4 w-4" />

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -1,0 +1,154 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { eq, and, desc } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { bankConnections, type BankConnection } from "@/lib/db/schema";
+import { requireAuth } from "@/lib/auth-helpers";
+import { getBackendBaseUrl } from "@/lib/backend-url";
+import { createInternalAuthHeaders } from "@/lib/internal-auth";
+
+export async function getBankConnections(): Promise<BankConnection[]> {
+  const userId = await requireAuth();
+  if (!userId) return [];
+
+  return db
+    .select()
+    .from(bankConnections)
+    .where(eq(bankConnections.userId, userId))
+    .orderBy(desc(bankConnections.createdAt));
+}
+
+export async function getActiveBankConnectionsWithExpiry(): Promise<
+  Array<{ id: string; aspspName: string; consentExpiresAt: Date | null; status: string }>
+> {
+  const userId = await requireAuth();
+  if (!userId) return [];
+
+  const connections = await db
+    .select({
+      id: bankConnections.id,
+      aspspName: bankConnections.aspspName,
+      consentExpiresAt: bankConnections.consentExpiresAt,
+      status: bankConnections.status,
+    })
+    .from(bankConnections)
+    .where(
+      and(
+        eq(bankConnections.userId, userId),
+        eq(bankConnections.status, "active"),
+      )
+    );
+
+  return connections;
+}
+
+export async function triggerSync(
+  connectionId: string
+): Promise<{ success: boolean; error?: string }> {
+  const userId = await requireAuth();
+  if (!userId) return { success: false, error: "Not authenticated" };
+
+  try {
+    const backendBase = getBackendBaseUrl().replace(/\/+$/, "");
+    const url = `${backendBase}/api/enable-banking/sync/${connectionId}`;
+
+    const signatureHeaders = createInternalAuthHeaders({
+      method: "POST",
+      pathWithQuery: `/api/enable-banking/sync/${connectionId}`,
+      userId,
+    });
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...signatureHeaders,
+      },
+    });
+
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({ detail: "Sync failed" }));
+      return { success: false, error: data.detail || "Sync failed" };
+    }
+
+    revalidatePath("/settings");
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: "Failed to trigger sync" };
+  }
+}
+
+export async function disconnectBank(
+  connectionId: string
+): Promise<{ success: boolean; error?: string }> {
+  const userId = await requireAuth();
+  if (!userId) return { success: false, error: "Not authenticated" };
+
+  try {
+    const backendBase = getBackendBaseUrl().replace(/\/+$/, "");
+    const url = `${backendBase}/api/enable-banking/${connectionId}`;
+
+    const signatureHeaders = createInternalAuthHeaders({
+      method: "DELETE",
+      pathWithQuery: `/api/enable-banking/${connectionId}`,
+      userId,
+    });
+
+    const resp = await fetch(url, {
+      method: "DELETE",
+      headers: signatureHeaders,
+    });
+
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({ detail: "Disconnect failed" }));
+      return { success: false, error: data.detail || "Disconnect failed" };
+    }
+
+    revalidatePath("/settings");
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: "Failed to disconnect bank" };
+  }
+}
+
+export async function initiateAuth(
+  aspspName: string,
+  aspspCountry: string
+): Promise<{ success: boolean; url?: string; error?: string }> {
+  const userId = await requireAuth();
+  if (!userId) return { success: false, error: "Not authenticated" };
+
+  try {
+    const backendBase = getBackendBaseUrl().replace(/\/+$/, "");
+    const url = `${backendBase}/api/enable-banking/auth`;
+
+    const signatureHeaders = createInternalAuthHeaders({
+      method: "POST",
+      pathWithQuery: "/api/enable-banking/auth",
+      userId,
+    });
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...signatureHeaders,
+      },
+      body: JSON.stringify({
+        aspsp_name: aspspName,
+        aspsp_country: aspspCountry,
+      }),
+    });
+
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({ detail: "Auth failed" }));
+      return { success: false, error: data.detail || "Auth failed" };
+    }
+
+    const data = await resp.json();
+    return { success: true, url: data.url };
+  } catch (e) {
+    return { success: false, error: "Failed to initiate bank connection" };
+  }
+}

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -3,17 +3,29 @@
 import { revalidatePath } from "next/cache";
 import { eq, and, desc } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { bankConnections, type BankConnection } from "@/lib/db/schema";
+import { bankConnections } from "@/lib/db/schema";
 import { requireAuth } from "@/lib/auth-helpers";
 import { getBackendBaseUrl } from "@/lib/backend-url";
 import { createInternalAuthHeaders } from "@/lib/internal-auth";
 
-export async function getBankConnections(): Promise<BankConnection[]> {
+export async function getBankConnections() {
   const userId = await requireAuth();
   if (!userId) return [];
 
   return db
-    .select()
+    .select({
+      id: bankConnections.id,
+      userId: bankConnections.userId,
+      provider: bankConnections.provider,
+      aspspName: bankConnections.aspspName,
+      aspspCountry: bankConnections.aspspCountry,
+      consentExpiresAt: bankConnections.consentExpiresAt,
+      status: bankConnections.status,
+      lastSyncedAt: bankConnections.lastSyncedAt,
+      lastSyncError: bankConnections.lastSyncError,
+      createdAt: bankConnections.createdAt,
+      updatedAt: bankConnections.updatedAt,
+    })
     .from(bankConnections)
     .where(eq(bankConnections.userId, userId))
     .orderBy(desc(bankConnections.createdAt));

--- a/frontend/lib/db/migrations/0011_enable_banking_connections.sql
+++ b/frontend/lib/db/migrations/0011_enable_banking_connections.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS "bank_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"provider" varchar(50) DEFAULT 'enable_banking' NOT NULL,
+	"session_id" varchar(255) NOT NULL,
+	"aspsp_name" varchar(255) NOT NULL,
+	"aspsp_country" char(2) NOT NULL,
+	"consent_expires_at" timestamp,
+	"consent_notified_at" timestamp,
+	"status" varchar(20) DEFAULT 'active' NOT NULL,
+	"last_synced_at" timestamp,
+	"last_sync_error" text,
+	"sync_cursor" jsonb,
+	"raw_session_data" jsonb,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "bank_connections_user_session" UNIQUE("user_id","session_id")
+);
+--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "bank_connection_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "bank_connections" ADD CONSTRAINT "bank_connections_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_bank_connection_id_bank_connections_id_fk" FOREIGN KEY ("bank_connection_id") REFERENCES "public"."bank_connections"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bank_connections_user" ON "bank_connections" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bank_connections_status" ON "bank_connections" USING btree ("status");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_bank_connections_consent_expires" ON "bank_connections" USING btree ("consent_expires_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_accounts_bank_connection" ON "accounts" USING btree ("bank_connection_id");

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772395200000,
       "tag": "0010_transaction_deletion_flows",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1744502400000,
+      "tag": "0011_enable_banking_connections",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -119,6 +119,7 @@ export const accounts = pgTable(
     externalId: varchar("external_id", { length: 255 }), // Provider's account ID
     externalIdCiphertext: text("external_id_ciphertext"),
     externalIdHash: varchar("external_id_hash", { length: 64 }),
+    bankConnectionId: uuid("bank_connection_id").references(() => bankConnections.id, { onDelete: "set null" }),
     balanceAvailable: decimal("balance_available", { precision: 15, scale: 2 }),
     startingBalance: decimal("starting_balance", { precision: 15, scale: 2 }).default("0"), // Starting balance for calculation
     functionalBalance: decimal("functional_balance", { precision: 15, scale: 2 }), // Calculated balance (sum of transactions + starting_balance)
@@ -130,6 +131,7 @@ export const accounts = pgTable(
   },
   (table) => [
     index("idx_accounts_user").on(table.userId),
+    index("idx_accounts_bank_connection").on(table.bankConnectionId),
     unique("accounts_user_provider_external_id").on(
       table.userId,
       table.provider,
@@ -140,6 +142,35 @@ export const accounts = pgTable(
       table.provider,
       table.externalIdHash
     ),
+  ]
+);
+
+export const bankConnections = pgTable(
+  "bank_connections",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    provider: varchar("provider", { length: 50 }).notNull().default("enable_banking"),
+    sessionId: varchar("session_id", { length: 255 }).notNull(),
+    aspspName: varchar("aspsp_name", { length: 255 }).notNull(),
+    aspspCountry: char("aspsp_country", { length: 2 }).notNull(),
+    consentExpiresAt: timestamp("consent_expires_at"),
+    consentNotifiedAt: timestamp("consent_notified_at"),
+    status: varchar("status", { length: 20 }).notNull().default("active"),
+    lastSyncedAt: timestamp("last_synced_at"),
+    lastSyncError: text("last_sync_error"),
+    syncCursor: jsonb("sync_cursor"),
+    rawSessionData: jsonb("raw_session_data"),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => [
+    index("idx_bank_connections_user").on(table.userId),
+    index("idx_bank_connections_status").on(table.status),
+    index("idx_bank_connections_consent_expires").on(table.consentExpiresAt),
+    unique("bank_connections_user_session").on(table.userId, table.sessionId),
   ]
 );
 
@@ -465,6 +496,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   subscriptionSuggestions: many(subscriptionSuggestions),
   apiKeys: many(apiKeys),
   transactionLinks: many(transactionLinks),
+  bankConnections: many(bankConnections),
 }));
 
 export const apiKeysRelations = relations(apiKeys, ({ one }) => ({
@@ -497,10 +529,22 @@ export const accountsRelations = relations(accounts, ({ one, many }) => ({
     fields: [accounts.logoId],
     references: [companyLogos.id],
   }),
+  bankConnection: one(bankConnections, {
+    fields: [accounts.bankConnectionId],
+    references: [bankConnections.id],
+  }),
   transactions: many(transactions),
   csvImports: many(csvImports),
   balances: many(accountBalances),
   recurringTransactions: many(recurringTransactions),
+}));
+
+export const bankConnectionsRelations = relations(bankConnections, ({ one, many }) => ({
+  user: one(users, {
+    fields: [bankConnections.userId],
+    references: [users.id],
+  }),
+  accounts: many(accounts),
 }));
 
 export const accountBalancesRelations = relations(accountBalances, ({ one }) => ({
@@ -701,3 +745,6 @@ export type NewTransactionLink = typeof transactionLinks.$inferInsert;
 
 export type CompanyLogo = typeof companyLogos.$inferSelect;
 export type NewCompanyLogo = typeof companyLogos.$inferInsert;
+
+export type BankConnection = typeof bankConnections.$inferSelect;
+export type NewBankConnection = typeof bankConnections.$inferInsert;


### PR DESCRIPTION
## Summary

- Adds Enable Banking (PSD2) Open Banking integration for connecting European bank accounts
- Backend: JWT auth module, BankAdapter implementation, 7 FastAPI endpoints, 3 Celery tasks (periodic sync every 6h, consent expiry checks daily)
- Frontend: OAuth callback route, server actions, Bank Connections Manager in Settings, bank picker page with country filter and search
- New `bank_connections` table (Drizzle + SQLAlchemy) tracking consent lifecycle and sync state

## Before merging

- [ ] Run `pnpm db:push` in `frontend/` to create the `bank_connections` table and add `bank_connection_id` FK on `accounts`
- [ ] Set environment variables: `ENABLE_BANKING_APP_ID`, `ENABLE_BANKING_PRIVATE_KEY`, `ENABLE_BANKING_REDIRECT_URI`
- [ ] Manual sandbox testing: connect a test bank, verify sync, verify disconnect

## Test plan

- [ ] Backend unit tests pass: `cd backend && python -m pytest tests/test_enable_banking_auth.py tests/test_enable_banking_adapter.py -v`
- [ ] Navigate to Settings > Bank Connections tab — empty state renders
- [ ] Click "Connect Bank" — bank picker page loads with NL banks
- [ ] Country selector and search filter work
- [ ] Select a sandbox bank — redirect to bank auth page
- [ ] After authorization, callback redirects to Settings with Bank Connections tab active
- [ ] Connected bank shows with "Active" badge
- [ ] "Sync Now" triggers sync (check Celery worker logs)
- [ ] "Disconnect" shows confirmation dialog, then marks connection as disconnected
- [ ] Consent expiry warning banner appears for connections expiring within 14 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Banking (PSD2) integration to connect and sync European bank accounts. Adds backend auth/APIs, scheduled sync, a Settings UI (bank picker + connection management), and a Drizzle migration; requires `pnpm db:push` and env vars (`ENABLE_BANKING_APP_ID`, `ENABLE_BANKING_PRIVATE_KEY` or `ENABLE_BANKING_PRIVATE_KEY_PATH`, `ENABLE_BANKING_REDIRECT_URI`).

- **New Features**
  - Backend: JWT auth client, adapter, FastAPI routes (`aspsps`, `auth`, `session`, `sync/{id}`, `status/{id}`, `connections`, `DELETE /{id}`), Celery tasks (sync every 6h, consent expiry daily), `bank_connections` table + account FK, Redis-cached ASPSP list.
  - Frontend: OAuth callback at `/api/enable-banking/callback`, bank picker with country filter/search, Settings > Bank Connections tab with Connect/Sync/Disconnect and consent warnings, server actions for list/sync/disconnect/initiate.
  - Database: Drizzle migration `0011_enable_banking_connections.sql` creating `bank_connections` and `accounts.bank_connection_id`.

- **Bug Fixes**
  - Validate and clean up OAuth state nonce to prevent mismatches and race conditions.
  - Normalize signed amounts; fix transaction date range end_date; recompute functional balances after sync.
  - Optimize connections listing (partial selects); single index for `bank_connection_id`; remove unused `ENABLE_BANKING_ENVIRONMENT`; DRY account type mapping.
  - UI: replace unsupported Button asChild with `Link` + `buttonVariants`, guard `Select` onValueChange nulls, extract `BankConnectionItem` type alias, use render prop on `AlertDialogTrigger`.
  - Respect `tab` query param to set the default Settings tab.

<sup>Written for commit 5ef209bb285863be6b8ae352e37a7151f03b5499. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

