### PR TITLE
feat: real-time progress bar for bank sync

### DIFF
--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -4,9 +4,12 @@ Enable Banking adapter implementing the BankAdapter interface.
 Fetches accounts, transactions, and balances from the Enable Banking REST API.
 """
 
+import logging
 from typing import List, Optional
 from decimal import Decimal
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 from app.integrations.base import BankAdapter, AccountData, TransactionData
 from app.integrations.enable_banking_auth import EnableBankingClient

--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -76,7 +76,10 @@ class EnableBankingAdapter(BankAdapter):
             params["date_to"] = end_date.strftime("%Y-%m-%d")
 
         continuation_key = None
-        while True:
+        max_pages = 200  # guard against infinite loops from broken continuation keys
+        page = 0
+        while page < max_pages:
+            page += 1
             if continuation_key:
                 params["continuation_key"] = continuation_key
 
@@ -92,6 +95,11 @@ class EnableBankingAdapter(BankAdapter):
             continuation_key = data.get("continuation_key")
             if not continuation_key:
                 break
+        else:
+            logger.warning(
+                f"[EB] Pagination guard hit for account {account_external_id} "
+                f"after {max_pages} pages — stopping early"
+            )
 
         return all_transactions
 

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -9,7 +9,7 @@ import os
 import logging
 import uuid as uuid_mod
 from typing import Optional, List
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import redis
 import json
@@ -156,7 +156,7 @@ def initiate_auth(
 
     auth_payload = {
         "access": {
-            "valid_until": (datetime.utcnow() + timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            "valid_until": (datetime.now(timezone.utc) + timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
         },
         "aspsp": {
             "name": body.aspsp_name,
@@ -224,9 +224,9 @@ def create_session(
         try:
             consent_expires_at = datetime.fromisoformat(consent_valid_until.replace("Z", "+00:00"))
         except (ValueError, TypeError):
-            consent_expires_at = datetime.utcnow() + timedelta(days=90)
+            consent_expires_at = datetime.now(timezone.utc) + timedelta(days=90)
     else:
-        consent_expires_at = datetime.utcnow() + timedelta(days=90)
+        consent_expires_at = datetime.now(timezone.utc) + timedelta(days=90)
 
     # Create bank_connections row (status=pending_setup; accounts mapped in a separate step)
     connection = BankConnection(

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -50,6 +50,14 @@ class SessionResponse(BaseModel):
     connection_id: str
     accounts_count: int
 
+class SyncProgress(BaseModel):
+    stage: str  # "syncing" | "done"
+    accounts_done: int
+    accounts_total: int
+    transactions_created: int
+    transactions_updated: int
+    started_at: Optional[str] = None
+
 class ConnectionStatusResponse(BaseModel):
     id: str
     aspsp_name: str
@@ -59,6 +67,7 @@ class ConnectionStatusResponse(BaseModel):
     consent_expires_at: Optional[str] = None
     last_sync_error: Optional[str] = None
     accounts_count: int
+    sync_progress: Optional[SyncProgress] = None
 
 class SyncTriggerResponse(BaseModel):
     message: str
@@ -414,6 +423,17 @@ def connection_status(
         Account.bank_connection_id == connection.id,
     ).count()
 
+    # Read live sync progress from Redis (set by Celery worker)
+    sync_progress = None
+    try:
+        r = redis.from_url(REDIS_URL, decode_responses=True)
+        raw = r.get(f"sync_progress:{connection_id}")
+        if raw:
+            data = json.loads(raw)
+            sync_progress = SyncProgress(**data)
+    except Exception:
+        pass
+
     return ConnectionStatusResponse(
         id=str(connection.id),
         aspsp_name=connection.aspsp_name,
@@ -423,6 +443,7 @@ def connection_status(
         consent_expires_at=connection.consent_expires_at.isoformat() if connection.consent_expires_at else None,
         last_sync_error=connection.last_sync_error,
         accounts_count=accounts_count,
+        sync_progress=sync_progress,
     )
 
 

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -5,7 +5,7 @@ Celery tasks for Enable Banking sync and consent management.
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import redis
@@ -81,11 +81,11 @@ def sync_bank_connection(self, connection_id: str):
         if connection.last_synced_at is None:
             # First sync: use user-configured lookback
             sync_days = connection.initial_sync_days or 90
-            start_date = (datetime.utcnow() - timedelta(days=sync_days)).date()
+            start_date = (datetime.now(timezone.utc) - timedelta(days=sync_days)).date()
         else:
             # Incremental sync: from last sync minus 1 day overlap
             start_date = (connection.last_synced_at - timedelta(days=1)).date()
-        end_date = datetime.utcnow()
+        end_date = datetime.now(timezone.utc)
 
         sync_service = SyncService(db, user_id=connection.user_id)
 
@@ -100,7 +100,7 @@ def sync_bank_connection(self, connection_id: str):
         synced_account_ids: list[str] = []
 
         accounts_total = len(accounts)
-        sync_started_at = datetime.utcnow().isoformat()
+        sync_started_at = datetime.now(timezone.utc).isoformat()
         _set_sync_progress(connection_id, {
             "stage": "syncing",
             "accounts_done": 0,
@@ -148,7 +148,7 @@ def sync_bank_connection(self, connection_id: str):
                 logger.error(f"Failed to sync transactions for account {account.id}: {e}")
                 raise
 
-            account.last_synced_at = datetime.utcnow()
+            account.last_synced_at = datetime.now(timezone.utc)
             _set_sync_progress(connection_id, {
                 "stage": "syncing",
                 "accounts_done": i + 1,
@@ -170,7 +170,7 @@ def sync_bank_connection(self, connection_id: str):
             starting_balance = account.starting_balance or Decimal("0")
             account.functional_balance = transaction_sum + starting_balance
 
-        connection.last_synced_at = datetime.utcnow()
+        connection.last_synced_at = datetime.now(timezone.utc)
         connection.last_sync_error = None
         db.commit()
         _clear_sync_progress(connection_id)
@@ -256,7 +256,7 @@ def check_consent_expiry():
     """
     db: Session = SessionLocal()
     try:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         # Mark expired connections
         expired = db.query(BankConnection).filter(

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -100,13 +100,14 @@ def sync_bank_connection(self, connection_id: str):
         synced_account_ids: list[str] = []
 
         accounts_total = len(accounts)
+        sync_started_at = datetime.utcnow().isoformat()
         _set_sync_progress(connection_id, {
             "stage": "syncing",
             "accounts_done": 0,
             "accounts_total": accounts_total,
             "transactions_created": 0,
             "transactions_updated": 0,
-            "started_at": datetime.utcnow().isoformat(),
+            "started_at": sync_started_at,
         })
 
         for i, account in enumerate(accounts):
@@ -154,7 +155,7 @@ def sync_bank_connection(self, connection_id: str):
                 "accounts_total": accounts_total,
                 "transactions_created": total_created,
                 "transactions_updated": total_updated,
-                "started_at": datetime.utcnow().isoformat(),
+                "started_at": sync_started_at,
             })
 
         # Recompute functional_balance for all synced accounts

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -2,10 +2,13 @@
 Celery tasks for Enable Banking sync and consent management.
 """
 
+import json
 import logging
+import os
 from datetime import datetime, timedelta
 from decimal import Decimal
 
+import redis
 from sqlalchemy.orm import Session
 
 from celery_app import celery_app
@@ -18,6 +21,31 @@ from app.security.data_encryption import decrypt_with_fallback
 from tasks.post_import_pipeline import post_import_pipeline
 
 logger = logging.getLogger(__name__)
+
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+_redis_client = None
+
+
+def _get_redis():
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+    return _redis_client
+
+
+def _set_sync_progress(connection_id: str, data: dict) -> None:
+    try:
+        key = f"sync_progress:{connection_id}"
+        _get_redis().setex(key, 3600, json.dumps(data))
+    except Exception as e:
+        logger.warning(f"Failed to write sync progress to Redis: {e}")
+
+
+def _clear_sync_progress(connection_id: str) -> None:
+    try:
+        _get_redis().delete(f"sync_progress:{connection_id}")
+    except Exception:
+        pass
 
 
 @celery_app.task(bind=True, max_retries=3, default_retry_delay=60)
@@ -71,7 +99,17 @@ def sync_bank_connection(self, connection_id: str):
         all_created_ids: list[str] = []
         synced_account_ids: list[str] = []
 
-        for account in accounts:
+        accounts_total = len(accounts)
+        _set_sync_progress(connection_id, {
+            "stage": "syncing",
+            "accounts_done": 0,
+            "accounts_total": accounts_total,
+            "transactions_created": 0,
+            "transactions_updated": 0,
+            "started_at": datetime.utcnow().isoformat(),
+        })
+
+        for i, account in enumerate(accounts):
             account_uid = decrypt_with_fallback(
                 account.external_id_ciphertext,
                 account.external_id,
@@ -110,6 +148,14 @@ def sync_bank_connection(self, connection_id: str):
                 raise
 
             account.last_synced_at = datetime.utcnow()
+            _set_sync_progress(connection_id, {
+                "stage": "syncing",
+                "accounts_done": i + 1,
+                "accounts_total": accounts_total,
+                "transactions_created": total_created,
+                "transactions_updated": total_updated,
+                "started_at": datetime.utcnow().isoformat(),
+            })
 
         # Recompute functional_balance for all synced accounts
         from sqlalchemy import func as sa_func
@@ -126,6 +172,7 @@ def sync_bank_connection(self, connection_id: str):
         connection.last_synced_at = datetime.utcnow()
         connection.last_sync_error = None
         db.commit()
+        _clear_sync_progress(connection_id)
 
         # Chain to shared post-processing pipeline (run if any transactions were touched)
         if all_created_ids or total_updated > 0:
@@ -168,6 +215,7 @@ def sync_bank_connection(self, connection_id: str):
                 db.commit()
         except Exception:
             pass
+        _clear_sync_progress(connection_id)
         raise self.retry(exc=e)
     finally:
         db.close()

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
 import {
   RiBankLine,
   RiRefreshLine,
@@ -39,18 +40,31 @@ interface BankConnectionsManagerProps {
   connections: BankConnectionItem[];
 }
 
+type SyncProgress = {
+  stage: string;
+  accounts_done: number;
+  accounts_total: number;
+  transactions_created: number;
+  transactions_updated: number;
+  started_at?: string;
+};
+
 export function BankConnectionsManager({ connections }: BankConnectionsManagerProps) {
   const router = useRouter();
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
   const [disconnectingIds, setDisconnectingIds] = useState<Set<string>>(new Set());
   const [pollingIds, setPollingIds] = useState<Set<string>>(new Set());
+  const [syncProgress, setSyncProgress] = useState<Map<string, SyncProgress>>(new Map());
+  const [elapsedSeconds, setElapsedSeconds] = useState<Map<string, number>>(new Map());
   const pollingTimers = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  const elapsedTimers = useRef<Map<string, NodeJS.Timeout>>(new Map());
   const initialSyncTimes = useRef<Map<string, string | null>>(new Map());
 
   // Cleanup all timers on unmount
   useEffect(() => {
     return () => {
       pollingTimers.current.forEach((timer) => clearTimeout(timer));
+      elapsedTimers.current.forEach((timer) => clearInterval(timer));
     };
   }, []);
 
@@ -59,6 +73,11 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
     if (timer) {
       clearTimeout(timer);
       pollingTimers.current.delete(connectionId);
+    }
+    const elapsedTimer = elapsedTimers.current.get(connectionId);
+    if (elapsedTimer) {
+      clearInterval(elapsedTimer);
+      elapsedTimers.current.delete(connectionId);
     }
     setPollingIds((prev) => {
       const next = new Set(prev);
@@ -70,6 +89,16 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
       next.delete(connectionId);
       return next;
     });
+    setSyncProgress((prev) => {
+      const next = new Map(prev);
+      next.delete(connectionId);
+      return next;
+    });
+    setElapsedSeconds((prev) => {
+      const next = new Map(prev);
+      next.delete(connectionId);
+      return next;
+    });
   }, []);
 
   const startPolling = useCallback(
@@ -77,10 +106,23 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
       initialSyncTimes.current.set(connectionId, currentLastSyncedAt);
       setPollingIds((prev) => new Set([...prev, connectionId]));
 
+      // Start elapsed seconds ticker (clear any stale one first)
+      const existingElapsed = elapsedTimers.current.get(connectionId);
+      if (existingElapsed) clearInterval(existingElapsed);
+      setElapsedSeconds((prev) => new Map(prev).set(connectionId, 0));
+      const elapsedInterval = setInterval(() => {
+        setElapsedSeconds((prev) => {
+          const next = new Map(prev);
+          next.set(connectionId, (next.get(connectionId) ?? 0) + 1);
+          return next;
+        });
+      }, 1000);
+      elapsedTimers.current.set(connectionId, elapsedInterval);
+
       let elapsed = 0;
       const poll = async () => {
         elapsed += 3000;
-        if (elapsed > 60000) {
+        if (elapsed > 600000) {
           stopPolling(connectionId);
           return;
         }
@@ -89,6 +131,10 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
           const resp = await fetch(`/api/enable-banking/status/${connectionId}`);
           if (!resp.ok) throw new Error(`Status ${resp.status}`);
           const data = await resp.json();
+
+          if (data.sync_progress) {
+            setSyncProgress((prev) => new Map(prev).set(connectionId, data.sync_progress));
+          }
 
           const startedAt = initialSyncTimes.current.get(connectionId);
           if (data.last_synced_at && data.last_synced_at !== startedAt) {
@@ -232,8 +278,9 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
           {activeConnections.map((connection) => (
             <div
               key={connection.id}
-              className="flex items-center justify-between rounded-lg border p-4"
+              className="rounded-lg border p-4"
             >
+              <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
                   <RiBankLine className="h-5 w-5" />
@@ -339,6 +386,32 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                   </AlertDialogContent>
                 </AlertDialog>
               </div>
+              </div>
+              {syncingIds.has(connection.id) && (
+                <div className="mt-3 space-y-1.5">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>
+                      {(() => {
+                        const progress = syncProgress.get(connection.id);
+                        if (progress && progress.accounts_total > 0) {
+                          return `Syncing account ${progress.accounts_done} of ${progress.accounts_total} · ${progress.transactions_created} transactions imported`;
+                        }
+                        return "Preparing sync...";
+                      })()}
+                    </span>
+                    <span>{elapsedSeconds.get(connection.id) ?? 0}s elapsed</span>
+                  </div>
+                  <Progress
+                    value={(() => {
+                      const progress = syncProgress.get(connection.id);
+                      if (progress && progress.accounts_total > 0) {
+                        return (progress.accounts_done / progress.accounts_total) * 100;
+                      }
+                      return 0;
+                    })()}
+                  />
+                </div>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary

- **Backend**: Celery worker writes per-account sync progress to Redis (`sync_progress:{connection_id}`) at task start and after each account completes; `/status/{id}` endpoint returns this as `sync_progress` in the response
- **Frontend**: Settings page polls the status endpoint every 3s, reads `sync_progress`, and renders a live progress bar + elapsed timer below the connection row while a sync is running
- Polling timeout extended from 60s → 10min to handle large initial syncs (90 days × 4 accounts)

## What the UI shows

```
Rabobank    [Active]
Greece · Last synced: 4/18/2026

Syncing account 2 of 4 · 143 transactions imported    31s elapsed
[████████████░░░░░░░░░░░░]  50%
```

- Shows "Preparing sync..." for the first ~6s while the worker initialises
- Progress bar fills as each account finishes
- Everything clears automatically when sync completes or errors

## Test plan

- [ ] Click **Sync Now** on an active bank connection — progress bar appears within ~6s
- [ ] Label counts up accounts and transactions in real time
- [ ] Elapsed counter ticks every second
- [ ] On sync completion, bar disappears and `Last synced` date updates
- [ ] On sync error, bar disappears and error message shows
- [ ] Navigating away and back mid-sync does not leave dangling timers (unmount cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-time progress bar for bank syncs in Settings so users can see per-account progress, transaction counts, and elapsed time. Also hardens the EB sync with timezone-safe datetimes, a pagination guard, and proper logging.

- **New Features**
  - `Celery` worker writes per-connection progress to `Redis` as `sync_progress:{connection_id}` and clears it on success or error.
  - `/status/{id}` returns `sync_progress` for active syncs.
  - Settings page shows a live progress bar and seconds elapsed; polling runs every 3s for up to 10 minutes.

- **Bug Fixes**
  - Preserve `started_at` across per-account updates so elapsed time reflects total sync duration.
  - Use timezone-aware datetimes (`datetime.now(timezone.utc)`) in EB routes and tasks to avoid crashes from naive/aware comparisons.
  - Add a 200-page guard to EB transaction pagination to prevent infinite loops on malformed continuation keys.
  - Define a module `logger` in the EB adapter so the pagination guard’s warning doesn’t raise a NameError.

<sup>Written for commit d2cc970742a3c3257d5761f19e848208e3592672. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

