### PR TITLE
Deployment audit fixes (Phases 0-3)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,10 +70,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Bump Railway template image pins to release tag
         run: |
           TAG="${{ github.ref_name }}"
+          # Validate tag format (semver v-prefix) to prevent sed injection
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "ERROR: tag '$TAG' does not match expected semver pattern (vX.Y.Z or vX.Y.Z-suffix)"
+            exit 1
+          fi
           sed -i "s|ghcr.io/syllogic-ai/syllogic-frontend:[^ ]*|ghcr.io/syllogic-ai/syllogic-frontend:${TAG}|g" deploy/railway/docker-compose.yml
           sed -i "s|ghcr.io/syllogic-ai/syllogic-backend:[^ ]*|ghcr.io/syllogic-ai/syllogic-backend:${TAG}|g" deploy/railway/docker-compose.yml
           # Fail if any :edge pins remain in the Railway file
@@ -94,7 +101,7 @@ jobs:
             git pull --ff-only origin main
             git checkout "${{ github.ref_name }}" -- deploy/railway/docker-compose.yml
             git add deploy/railway/docker-compose.yml
-            git commit -m "chore: bump Railway template pins to ${{ github.ref_name }}"
+            git commit -m "chore: bump Railway template pins to ${{ github.ref_name }} [skip ci]"
             git push origin main
           else
             echo "No pin changes to commit."

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -88,19 +88,22 @@ jobs:
             echo "ERROR: :edge pins remain in deploy/railway/docker-compose.yml after bump"
             exit 1
           fi
+          # Bump example-env APP_VERSION defaults
+          sed -i "s|^APP_VERSION=.*|APP_VERSION=${TAG}|g" deploy/compose/.env.example
+          sed -i "s|^APP_VERSION=.*|APP_VERSION=${TAG}|g" deploy/casaos/.env.example
 
       - name: Commit pin bump back to repo
         if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! git diff --quiet deploy/railway/docker-compose.yml; then
+          if ! git diff --quiet deploy/railway/docker-compose.yml deploy/compose/.env.example deploy/casaos/.env.example; then
             git config user.name "syllogic-bot"
             git config user.email "bot@syllogic.ai"
             git checkout main
             git pull --ff-only origin main
-            git checkout "${{ github.ref_name }}" -- deploy/railway/docker-compose.yml
-            git add deploy/railway/docker-compose.yml
+            git checkout "${{ github.ref_name }}" -- deploy/railway/docker-compose.yml deploy/compose/.env.example deploy/casaos/.env.example
+            git add deploy/railway/docker-compose.yml deploy/compose/.env.example deploy/casaos/.env.example
             git commit -m "chore: bump Railway template pins to ${{ github.ref_name }} [skip ci]"
             git push origin main
           else

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -71,6 +71,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Bump Railway template image pins to release tag
+        run: |
+          TAG="${{ github.ref_name }}"
+          sed -i "s|ghcr.io/syllogic-ai/syllogic-frontend:[^ ]*|ghcr.io/syllogic-ai/syllogic-frontend:${TAG}|g" deploy/railway/docker-compose.yml
+          sed -i "s|ghcr.io/syllogic-ai/syllogic-backend:[^ ]*|ghcr.io/syllogic-ai/syllogic-backend:${TAG}|g" deploy/railway/docker-compose.yml
+          # Fail if any :edge pins remain in the Railway file
+          if grep -qE 'ghcr.io/syllogic-ai/syllogic-(frontend|backend):edge' deploy/railway/docker-compose.yml; then
+            echo "ERROR: :edge pins remain in deploy/railway/docker-compose.yml after bump"
+            exit 1
+          fi
+
+      - name: Commit pin bump back to repo
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! git diff --quiet deploy/railway/docker-compose.yml; then
+            git config user.name "syllogic-bot"
+            git config user.email "bot@syllogic.ai"
+            git checkout main
+            git pull --ff-only origin main
+            git checkout "${{ github.ref_name }}" -- deploy/railway/docker-compose.yml
+            git add deploy/railway/docker-compose.yml
+            git commit -m "chore: bump Railway template pins to ${{ github.ref_name }}"
+            git push origin main
+          else
+            echo "No pin changes to commit."
+          fi
+
       - name: Create compose bundle
         run: |
           tar -czf compose-bundle.tar.gz -C deploy/compose .

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Syllogic is an open-source personal finance app for self-hosters who want contro
 **One-liner** (requires root, Docker, and Docker Compose):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/syllogic-ai/syllogic/main/deploy/install/install.sh | sudo bash
+curl -fsSL https://github.com/syllogic-ai/syllogic/releases/latest/download/install.sh | sudo bash
 ```
 
 **Or manually:**

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -27,7 +27,7 @@ Syllogic gives self-hosters a finance app they can actually run themselves:
 ### 2. Self-host with Docker
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/syllogic-ai/syllogic/main/deploy/install/install.sh | sudo bash
+curl -fsSL https://github.com/syllogic-ai/syllogic/releases/latest/download/install.sh | sudo bash
 ```
 
 For the manual setup, use [README.md](README.md#quick-start).

--- a/deploy/casaos/.env.example
+++ b/deploy/casaos/.env.example
@@ -10,7 +10,7 @@
 # Image channel policy:
 # - edge: development/testing only
 # - vX.Y.Z: production pinning
-APP_VERSION=edge
+APP_VERSION=v1.0.0
 
 # Where you access the app from your browser
 APP_URL=http://localhost:8080

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -1,7 +1,7 @@
 # Image channel
 # - edge: development/testing only
 # - vX.Y.Z: production/self-host releases
-APP_VERSION=edge
+APP_VERSION=v1.0.0
 
 # Public URL for the app (single source of truth for auth + CORS defaults)
 APP_URL=http://localhost:8080

--- a/deploy/railway/docker-compose.yml
+++ b/deploy/railway/docker-compose.yml
@@ -57,8 +57,8 @@ services:
 
   # ── Backend API (FastAPI) ─────────────────────────────────
   backend:
-    # Template maintainers: replace :edge with a pinned release tag for production templates.
-    image: ghcr.io/syllogic-ai/syllogic-backend:edge
+    # Template maintainers: this tag is auto-bumped by CI on each vX.Y.Z release.
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
     environment:
       NODE_ENV: production
       PORT: "8080"
@@ -76,7 +76,7 @@ services:
 
   # ── MCP Server (FastMCP) ──────────────────────────────────
   mcp:
-    image: ghcr.io/syllogic-ai/syllogic-backend:edge
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
     command: uvicorn mcp_server:app --host 0.0.0.0 --port 8001
     healthcheck:
       test:
@@ -100,7 +100,7 @@ services:
 
   # ── Celery Worker ─────────────────────────────────────────
   worker:
-    image: ghcr.io/syllogic-ai/syllogic-backend:edge
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
     command: celery -A celery_app worker --loglevel=info --concurrency=4
     environment:
       NODE_ENV: production
@@ -117,7 +117,7 @@ services:
 
   # ── Celery Beat (scheduler) ───────────────────────────────
   beat:
-    image: ghcr.io/syllogic-ai/syllogic-backend:edge
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
     command: celery -A celery_app beat --loglevel=info
     environment:
       NODE_ENV: production
@@ -136,7 +136,7 @@ services:
   # Migrations run automatically at startup before Next.js boot.
   # Keep PORT=3000 so Railway proxy routes traffic correctly.
   app:
-    image: ghcr.io/syllogic-ai/syllogic-frontend:edge
+    image: ghcr.io/syllogic-ai/syllogic-frontend:v1.0.0
     command: /bin/sh -lc "mkdir -p /app/public/uploads/profile /app/public/uploads/logos /app/public/uploads/imports && chmod -R u+rwX,g+rwX /app/public/uploads && node scripts/migrate.js && exec node_modules/.bin/next start -p 3000 -H 0.0.0.0"
     healthcheck:
       test:

--- a/landing/components/principles-section.tsx
+++ b/landing/components/principles-section.tsx
@@ -42,7 +42,7 @@ const SERVICES = [
 ];
 
 const INSTALL_CMD =
-  "curl -fsSL https://raw.githubusercontent.com/syllogic-ai/syllogic/main/deploy/install/install.sh | sudo bash";
+  "curl -fsSL https://github.com/syllogic-ai/syllogic/releases/latest/download/install.sh | sudo bash";
 
 function CopyIcon() {
   return (


### PR DESCRIPTION
## Summary

Phased rollout of the 2026-04-18 deployment audit. Twenty-five fixes across four phases targeting the two primary first-install surfaces: the **Railway one-click button** (non-technical users) and the **VPS `install.sh` one-liner** (competent VPS users), plus landing-page copy and supporting CI/docs.

### Progress

- **Phase 0 — Critical (complete):** C1, C2, L-C1, X-H2 fixed.
  - Install.sh one-liner now sources from `releases/latest/download/install.sh` (not `main`).
  - Railway template images pinned to `v1.0.0` (no longer shipping `:edge` to production users).
  - `.env.example` files default to `v1.0.0`.
  - New CI step auto-bumps all pins + defaults on every `v*.*.*` tag push, with `[skip ci]` to avoid double-builds and a semver tag-format guard.
- **Phase 1 — High impact (in progress):** Railway template UI reconfiguration (user action), Railway README §5 simplification, worker/beat verification, RAILWAY_STATIC_URL verification, install.sh package-manager detection + docker-group setup + self-verify.
- **Phase 2 — Medium polish (pending):** optional API key prompts, lan-tls mode, uninstall.sh, healthcheck path alignment, uploads-init consolidation, APP_VERSION=edge runtime warning, TLS policy docs.
- **Phase 3 — Docs & hygiene (pending):** install.sh hygiene, SHA256 sidecars, SSOT Quick Start, install_help.yml enrichment, encryption-key docs, landing RAILWAY_FEATURES copy fix, dynamic release version, /start Docker card split.

### Release cut

This PR pins `v1.0.0` as a placeholder because no tag exists yet. Before merging to main, cut a `v1.0.0` release so the CI auto-bump step runs for real and published GHCR images match what the Railway template advertises.

## Test plan

- [ ] Manual: fresh Railway deploy from the button → verify zero-terminal experience (after Task 4 Railway-UI reconfiguration lands)
- [ ] Manual: fresh `install.sh` on a Debian/Ubuntu VPS → verify health self-check, password reveal, OS detection
- [ ] Manual: fresh `install.sh` on a Fedora or Alpine VPS → verify fail-fast or success after Task 8 lands
- [ ] Manual: landing page build → verify all copy changes render cleanly
- [ ] Manual: cut a `v1.0.1` test tag → verify CI bump-back step commits to main with `[skip ci]` and no double-build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins production deploys to release tags and serves the installer from GitHub Releases to stop `:edge` drift and mismatched bundles. Adds CI to auto-bump Railway image tags and `APP_VERSION` defaults on every `vX.Y.Z` tag.

- **New Features**
  - Switched `install.sh` URL to `releases/latest/download/install.sh` in README, START_HERE, and landing copy.
  - Pinned Railway template images to `v1.0.0` for `backend`, `mcp`, `worker`, `beat`, and `app`.
  - Added CI step that on `vX.Y.Z` tags validates semver, rewrites Railway image tags and `.env.example` `APP_VERSION`, fails if any `:edge` remains, and commits back to `main` with `[skip ci]`.
  - Set `.env.example` `APP_VERSION` default to `v1.0.0`.

- **Migration**
  - Cut a `v1.0.0` release before merging so the CI bump runs and GHCR images match the Railway template.

<sup>Written for commit 7bb73d9e40b64f721756ae559ae0bba3466d77ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

