### PR TITLE
hotfix: generate synthetic external_id for EB transactions with no reference

### DIFF
--- a/backend/app/integrations/base.py
+++ b/backend/app/integrations/base.py
@@ -27,6 +27,8 @@ class TransactionData(BaseModel):
     currency: str
     description: str
     merchant: Optional[str] = None
+    creditor: Optional[str] = None   # Counterparty name for debits (payee)
+    debtor: Optional[str] = None     # Counterparty name for credits (payer)
     booked_at: datetime
     transaction_type: str  # debit, credit
     pending: bool = False

--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -120,7 +120,7 @@ class EnableBankingAdapter(BankAdapter):
         if not external_id:
             import hashlib as _hashlib
             _ri = raw.get("remittance_information")
-            _ri_str = (_ri[0] if isinstance(_ri, list) and _ri else _ri) or ""
+            _ri_str = "|".join(_ri) if isinstance(_ri, list) and _ri else (_ri or "")
             _parts = "|".join([
                 raw.get("booking_date") or raw.get("value_date") or "",
                 str(raw["transaction_amount"]["amount"]),

--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -112,8 +112,22 @@ class EnableBankingAdapter(BankAdapter):
         _log = _logging.getLogger(__name__)
 
         amount = Decimal(str(raw["transaction_amount"]["amount"]))
-        # EB uses entry_reference as primary ID; fall back to transaction_id
-        external_id = raw.get("entry_reference") or raw.get("transaction_id", "")
+        # EB uses entry_reference as primary ID; fall back to transaction_id.
+        # Some banks (e.g. ABN AMRO fee transactions) provide neither — generate a
+        # deterministic synthetic ID so Pydantic validation never fails and repeated
+        # syncs produce the same ID for the same transaction.
+        external_id = raw.get("entry_reference") or raw.get("transaction_id") or None
+        if not external_id:
+            import hashlib as _hashlib
+            _ri = raw.get("remittance_information")
+            _ri_str = (_ri[0] if isinstance(_ri, list) and _ri else _ri) or ""
+            _parts = "|".join([
+                raw.get("booking_date") or raw.get("value_date") or "",
+                str(raw["transaction_amount"]["amount"]),
+                raw["transaction_amount"].get("currency", ""),
+                _ri_str,
+            ])
+            external_id = "synth-" + _hashlib.sha256(_parts.encode()).hexdigest()[:16]
 
         # Log raw text fields to debug missing descriptions (TEMPORARY - remove after diagnosis)
         _log.info(

--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -165,17 +165,34 @@ class EnableBankingAdapter(BankAdapter):
             else (remittance_info if isinstance(remittance_info, str) else None)
         )
 
-        # Build description from all possible EB text fields, most specific first
+        # Build a rich description by combining all available EB text fields.
+        # Previously used `or` (first non-null wins); now we concatenate so all
+        # structured remittance lines, additional info, and notes are preserved.
+        desc_parts: list[str] = []
+
+        riu = raw.get("remittance_information_unstructured")
+        if riu:
+            desc_parts.append(riu)
+
+        for item in (raw.get("remittance_information_unstructured_array") or []):
+            if item and item not in desc_parts:
+                desc_parts.append(item)
+
+        if remittance_info_text and remittance_info_text not in desc_parts:
+            desc_parts.append(remittance_info_text)
+
+        ai_info = raw.get("additional_information")
+        if ai_info and ai_info not in desc_parts:
+            desc_parts.append(ai_info)
+
+        note = raw.get("note")
+        if note and note not in desc_parts:
+            desc_parts.append(note)
+
         description = (
-            raw.get("remittance_information_unstructured")
-            or (raw.get("remittance_information_unstructured_array") or [""])[0]
-            or remittance_info_text
-            or raw.get("additional_information")
-            or raw.get("note")
-            or creditor_name
-            or debtor_name
-            or raw.get("reference_number")
-            or ""
+            " | ".join(desc_parts)
+            if desc_parts
+            else (creditor_name or debtor_name or raw.get("reference_number") or "")
         )
 
         merchant = creditor_name or debtor_name
@@ -194,6 +211,8 @@ class EnableBankingAdapter(BankAdapter):
             currency=raw["transaction_amount"]["currency"],
             description=description,
             merchant=merchant,
+            creditor=creditor_name,
+            debtor=debtor_name,
             booked_at=datetime.fromisoformat(_date_str) if (_date_str := (
                 raw.get("booking_date")
                 or raw.get("value_date")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -167,6 +167,8 @@ class Transaction(Base):
     functional_amount = Column(Numeric(15, 2), nullable=True)  # Amount converted to user's functional currency
     description = Column(Text)
     merchant = Column(String(255))
+    creditor = Column(String(255), nullable=True)   # Counterparty name for debits (payee)
+    debtor = Column(String(255), nullable=True)     # Counterparty name for credits (payer)
     category_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True, index=True)  # User-overridden category
     category_system_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True, index=True)  # AI-assigned category
     booked_at = Column(DateTime, nullable=False, index=True)

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -499,6 +499,21 @@ def disconnect(
         logger.warning(f"Failed to revoke EB session {connection.session_id}", exc_info=True)
 
     connection.status = "disconnected"
+
+    # Unlink accounts so they can be re-linked to a new connection later
+    db.query(Account).filter(
+        Account.bank_connection_id == connection.id,
+    ).update(
+        {
+            Account.bank_connection_id: None,
+            Account.provider: None,
+            Account.external_id: None,
+            Account.external_id_ciphertext: None,
+            Account.external_id_hash: None,
+        },
+        synchronize_session=False,
+    )
+
     db.commit()
 
     return {"message": "Bank connection disconnected"}

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -244,6 +244,8 @@ class SyncService:
                 if transaction_data.description:
                     existing_transaction.description = transaction_data.description
                 existing_transaction.merchant = merchant or transaction_data.merchant
+                existing_transaction.creditor = transaction_data.creditor
+                existing_transaction.debtor = transaction_data.debtor
                 existing_transaction.booked_at = transaction_data.booked_at
                 existing_transaction.transaction_type = transaction_data.transaction_type
                 existing_transaction.pending = transaction_data.pending
@@ -268,6 +270,8 @@ class SyncService:
                     if transaction_data.description:
                         pending_match.description = transaction_data.description
                     pending_match.merchant = merchant or transaction_data.merchant
+                    pending_match.creditor = transaction_data.creditor
+                    pending_match.debtor = transaction_data.debtor
                     if not pending_match.category_id and not pending_match.category_system_id and category:
                         pending_match.category_system_id = category.id
                     if not pending_match.recurring_transaction_id and matched_subscription:
@@ -306,6 +310,8 @@ class SyncService:
                 currency=transaction_data.currency,
                 description=transaction_data.description,
                 merchant=merchant or transaction_data.merchant,
+                creditor=transaction_data.creditor,
+                debtor=transaction_data.debtor,
                 booked_at=transaction_data.booked_at,
                 pending=transaction_data.pending,
                 category_system_id=category.id if category else None,

--- a/frontend/components/transactions/transaction-sheet.tsx
+++ b/frontend/components/transactions/transaction-sheet.tsx
@@ -344,6 +344,18 @@ export function TransactionSheet({
                 <span className="text-muted-foreground">Merchant</span>
                 <span>{transaction.merchant || "-"}</span>
               </div>
+              {transaction.creditor && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Creditor</span>
+                  <span className="text-right max-w-[60%] break-words">{transaction.creditor}</span>
+                </div>
+              )}
+              {transaction.debtor && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Debtor</span>
+                  <span className="text-right max-w-[60%] break-words">{transaction.debtor}</span>
+                </div>
+              )}
               <div className="flex justify-between">
                 <span className="text-muted-foreground">Account</span>
                 <span>{transaction.account?.name || "Unknown"}</span>

--- a/frontend/lib/actions/category-spending.ts
+++ b/frontend/lib/actions/category-spending.ts
@@ -116,6 +116,8 @@ interface CategorySpendingTransactionRowWithRelations {
   accountId: string;
   description: string | null;
   merchant: string | null;
+  creditor: string | null;
+  debtor: string | null;
   amount: string;
   currency: string | null;
   categoryId: string | null;
@@ -426,6 +428,8 @@ function mapCategorySpendingTransactionRowsForUi(
         },
         description: tx.description,
         merchant: tx.merchant,
+        creditor: tx.creditor,
+        debtor: tx.debtor,
         amount: parseFloat(tx.amount),
         currency: tx.currency,
         categoryId: tx.categoryId,

--- a/frontend/lib/actions/transactions.ts
+++ b/frontend/lib/actions/transactions.ts
@@ -351,6 +351,8 @@ export interface TransactionWithRelations {
   } | null;
   description: string | null;
   merchant: string | null;
+  creditor: string | null;
+  debtor: string | null;
   amount: number;
   currency: string | null;
   categoryId: string | null;
@@ -440,6 +442,8 @@ interface TransactionRowWithRelations {
   accountId: string;
   description: string | null;
   merchant: string | null;
+  creditor: string | null;
+  debtor: string | null;
   amount: string;
   currency: string | null;
   categoryId: string | null;
@@ -517,6 +521,8 @@ function mapTransactionRowsForUi(
         },
         description: tx.description,
         merchant: tx.merchant,
+        creditor: tx.creditor,
+        debtor: tx.debtor,
         amount: parseFloat(tx.amount),
         currency: tx.currency,
         categoryId: tx.categoryId,

--- a/frontend/lib/db/migrations/0013_transaction_creditor_debtor.sql
+++ b/frontend/lib/db/migrations/0013_transaction_creditor_debtor.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "transactions" ADD COLUMN "creditor" varchar(255);
+ALTER TABLE "transactions" ADD COLUMN "debtor" varchar(255);

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1744588800000,
       "tag": "0012_bank_connection_initial_sync_days",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1776470400000,
+      "tag": "0013_transaction_creditor_debtor",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -249,6 +249,8 @@ export const transactions = pgTable(
     functionalAmount: decimal("functional_amount", { precision: 15, scale: 2 }), // Amount converted to user's functional currency
     description: text("description"),
     merchant: varchar("merchant", { length: 255 }),
+    creditor: varchar("creditor", { length: 255 }), // Counterparty name for debits (payee)
+    debtor: varchar("debtor", { length: 255 }), // Counterparty name for credits (payer)
     categoryId: uuid("category_id").references(() => categories.id), // User-overridden category
     categorySystemId: uuid("category_system_id").references(() => categories.id), // AI-assigned category (never updated by user)
     bookedAt: timestamp("booked_at").notNull(),


### PR DESCRIPTION
## Problem

ABN AMRO fee transactions (e.g. monthly account charges) provide neither `entry_reference` nor `transaction_id` in the Enable Banking API response. This caused a Pydantic `ValidationError` on `TransactionData.external_id` which aborted the entire account sync:

```
1 validation error for TransactionData
external_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

## Fix

When both reference fields are null, generate a **deterministic synthetic ID** from `booking_date + amount + currency + remittance_info` (SHA-256, first 16 hex chars, prefixed `synth-`). The same transaction always produces the same ID, so repeated syncs are idempotent and don't create duplicates.

## Test plan

- [ ] Trigger ABN AMRO sync — verify it completes without errors
- [ ] Trigger a second sync — verify fee transactions are updated (not duplicated) via the synthetic ID match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crashes in Enable Banking syncs by generating a deterministic synthetic `external_id` when both `entry_reference` and `transaction_id` are missing, and enriches transactions with creditor/debtor and clearer descriptions. Also fixes a frontend type error by wiring the new fields through category-spending.

- **Updates**
  - Generate `external_id` as `synth-` + first 16 hex of SHA-256 over `booking_date|amount|currency|remittance_info` (falls back to `value_date`); hashes all remittance list items joined by `|` to avoid collisions; covers ABN AMRO fee transactions and prevents crashes/duplicates.
  - Add `creditor`/`debtor` fields across models, sync, and UI, and build a pipe-separated description from all EB text fields; propagate fields to category-spending mappers to resolve a TypeScript build error.

<sup>Written for commit b80355682c320723eb43281c688c57b5660f6f65. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

