### PR TITLE
feat: add recategorize endpoint for bulk re-categorization

### DIFF
--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -377,6 +377,61 @@ def map_accounts(
     )
 
 
+@router.post("/connections/{connection_id}/recategorize", response_model=SyncTriggerResponse)
+def recategorize_connection(
+    connection_id: str,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """
+    Re-run batch AI categorization for ALL transactions on a connection.
+
+    Useful after a categorization bug — overwrites wrong system-assigned categories
+    while preserving any user-assigned category_id overrides.
+    """
+    from app.models import Transaction
+
+    connection = db.query(BankConnection).filter(
+        BankConnection.id == connection_id,
+        BankConnection.user_id == user_id,
+    ).first()
+    if not connection:
+        raise HTTPException(status_code=404, detail="Connection not found")
+
+    account_ids = [
+        str(a.id)
+        for a in db.query(Account).filter(Account.bank_connection_id == connection.id).all()
+    ]
+    if not account_ids:
+        raise HTTPException(status_code=404, detail="No accounts found for this connection")
+
+    transaction_ids = [
+        str(t.id)
+        for t in db.query(Transaction.id).filter(
+            Transaction.user_id == user_id,
+            Transaction.account_id.in_(account_ids),
+        ).all()
+    ]
+
+    if not transaction_ids:
+        return SyncTriggerResponse(message="No transactions to re-categorize")
+
+    try:
+        from tasks.post_import_pipeline import post_import_pipeline
+        task = post_import_pipeline.delay(
+            user_id=user_id,
+            account_ids=account_ids,
+            transaction_ids=transaction_ids,
+            is_initial_sync=False,
+        )
+        return SyncTriggerResponse(
+            message=f"Re-categorization started for {len(transaction_ids)} transactions",
+            task_id=task.id,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to start re-categorization: {str(e)}")
+
+
 @router.post("/sync/{connection_id}", response_model=SyncTriggerResponse)
 def trigger_sync(
     connection_id: str,


### PR DESCRIPTION
## Summary

- Adds `POST /connections/{connection_id}/recategorize` endpoint to the Enable Banking routes
- Fetches all transaction IDs for the connection's accounts
- Dispatches `post_import_pipeline` Celery task (batch LLM categorization + balances)
- Preserves user-assigned `category_id` overrides; only overwrites `category_system_id`

## Use case

After the catch-all user override bug fix (PR #60), existing transactions still have the wrong `category_system_id`. This endpoint allows triggering a bulk re-categorization from the frontend without needing a full re-sync from the bank API.

## Test plan

- [ ] Call `POST /api/enable-banking/connections/{id}/recategorize` for the ABN AMRO connection
- [ ] Verify Celery worker picks up the task and runs batch LLM categorization
- [ ] Verify transaction categories are corrected in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `POST /connections/{connection_id}/recategorize` to bulk re-run categorization for all transactions on a connection. Fixes wrong `category_system_id` values without a full bank re-sync while keeping user overrides.

- **New Features**
  - New endpoint triggers `post_import_pipeline` for the connection’s transactions and returns a `task_id`.
  - Pulls all account and transaction IDs for the user’s connection.
  - Preserves user-assigned `category_id` and only updates `category_system_id`.
  - Returns helpful responses for missing connections, no accounts, or no transactions.

<sup>Written for commit d3675010898f05f075843f8df4e8fc7917a04b81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

