### PR TITLE
feat: add Fix Categories button to bank connections settings

### DIFF
--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -12,6 +12,7 @@ import {
   RiLinkUnlinkM,
   RiAddLine,
   RiAlertLine,
+  RiPriceTag3Line,
 } from "@remixicon/react";
 import {
   AlertDialog,
@@ -24,7 +25,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { triggerSync, disconnectBank } from "@/lib/actions/bank-connections";
+import { triggerSync, disconnectBank, triggerRecategorize } from "@/lib/actions/bank-connections";
 type BankConnectionItem = {
   id: string;
   aspspName: string;
@@ -52,6 +53,7 @@ type SyncProgress = {
 export function BankConnectionsManager({ connections }: BankConnectionsManagerProps) {
   const router = useRouter();
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
+  const [recategorizingIds, setRecategorizingIds] = useState<Set<string>>(new Set());
   const [disconnectingIds, setDisconnectingIds] = useState<Set<string>>(new Set());
   const [pollingIds, setPollingIds] = useState<Set<string>>(new Set());
   const [syncProgress, setSyncProgress] = useState<Map<string, SyncProgress>>(new Map());
@@ -192,6 +194,22 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
       startPolling(connectionId, currentLastSyncedAt);
     } catch {
       setSyncingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(connectionId);
+        return next;
+      });
+    }
+  };
+
+  const handleRecategorize = async (connectionId: string) => {
+    setRecategorizingIds((prev) => new Set(prev).add(connectionId));
+    try {
+      const result = await triggerRecategorize(connectionId);
+      if (!result.success) {
+        console.error("Re-categorization failed:", result.error);
+      }
+    } finally {
+      setRecategorizingIds((prev) => {
         const next = new Set(prev);
         next.delete(connectionId);
         return next;
@@ -351,6 +369,21 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                       }`}
                     />
                     {syncingIds.has(connection.id) ? "Syncing..." : "Sync Now"}
+                  </Button>
+                )}
+                {connection.status === "active" && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleRecategorize(connection.id)}
+                    disabled={recategorizingIds.has(connection.id)}
+                  >
+                    <RiPriceTag3Line
+                      className={`mr-1.5 h-4 w-4 ${
+                        recategorizingIds.has(connection.id) ? "animate-spin" : ""
+                      }`}
+                    />
+                    {recategorizingIds.has(connection.id) ? "Re-categorizing..." : "Fix Categories"}
                   </Button>
                 )}
                 <AlertDialog>

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -278,6 +278,46 @@ export async function submitAccountMappings(
   }
 }
 
+export async function triggerRecategorize(
+  connectionId: string
+): Promise<{ success: boolean; error?: string }> {
+  const session = await getAuthenticatedSession();
+  const userId = session?.user?.id;
+  if (!userId) return { success: false, error: "Not authenticated" };
+  if (isDemoRestrictedUserEmail(session.user.email)) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
+  }
+
+  try {
+    const backendBase = getBackendBaseUrl().replace(/\/+$/, "");
+    const pathWithQuery = `/api/enable-banking/connections/${connectionId}/recategorize`;
+    const url = `${backendBase}${pathWithQuery}`;
+
+    const signatureHeaders = createInternalAuthHeaders({
+      method: "POST",
+      pathWithQuery,
+      userId,
+    });
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...signatureHeaders,
+      },
+    });
+
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({ detail: "Re-categorization failed" }));
+      return { success: false, error: data.detail || "Re-categorization failed" };
+    }
+
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: "Failed to trigger re-categorization" };
+  }
+}
+
 export async function getConnectionStatus(
   connectionId: string
 ): Promise<{


### PR DESCRIPTION
## Summary

- Adds `triggerRecategorize` server action to `bank-connections.ts` — calls `POST /api/enable-banking/connections/{id}/recategorize`
- Adds **Fix Categories** button next to "Sync Now" for active bank connections in the settings UI
- Button shows spinner + "Re-categorizing..." while in flight, then resets
- Uses same internal auth signature pattern as `triggerSync`

## Why

After the catch-all user override bug fix (PR #60), 185 existing ABN AMRO transactions are still mis-categorized with "Food & Dining". This button triggers a full batch AI re-categorization of all connection transactions without needing a full re-sync from the bank API.

## Test plan

- [ ] Navigate to Settings → Banks tab
- [ ] Click "Fix Categories" on an active connection
- [ ] Verify button shows spinner during the call
- [ ] Verify Celery worker logs show batch LLM categorization running
- [ ] Verify transaction categories are corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Fix Categories button in Bank Connections settings to re-categorize all transactions for a connection without a full bank sync. Includes a new `triggerRecategorize` server action and inline loading state.

- **New Features**
  - Added `triggerRecategorize` in `frontend/lib/actions/bank-connections.ts` to POST `/api/enable-banking/connections/{id}/recategorize` with internal auth headers.
  - Added "Fix Categories" button next to "Sync Now" for active connections; shows spinner and “Re-categorizing...” while running, then resets.
  - Backend call triggers the batch re-categorization pipeline for the connection’s transactions.

<sup>Written for commit 5bda7839e33eab828bfd8dc23317f640a58b95f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

