### PR TITLE
fix: anchor EB balance from CLBD when CLAV/ITAV missing (ABN AMRO)

### DIFF
--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -121,16 +121,36 @@ def sync_bank_connection(self, connection_id: str):
                 logger.warning(f"No external_id for account {account.id}, skipping")
                 continue
 
-            # Fetch and update balances
+            # Fetch and update balances.
+            # Priority order of ISO 20022 balance types:
+            #   CLAV/ITAV = (interim) available — most accurate "what you can spend"
+            #   CLBD      = closing booked — authoritative, excludes pending
+            #   XPCD      = expected — booked + pending
+            #   PRCD      = previously closed booked
+            #   OTHR      = bank-defined fallback
+            # ABN AMRO via Enable Banking does not return CLAV/ITAV, so fall through
+            # the priority list and finally pick the first returned balance.
             try:
                 balance_data = adapter.fetch_balances(account_uid)
                 balances = balance_data.get("balances", [])
-                for bal in balances:
-                    bal_type = bal.get("balance_type", "")
-                    if bal_type in ("CLAV", "ITAV"):  # Available balance
-                        account.balance_available = bal["balance_amount"]["amount"]
-                        account.balance_is_anchored = True
+                priority = ("CLAV", "ITAV", "CLBD", "XPCD", "PRCD", "OTHR")
+                chosen = None
+                for pref in priority:
+                    for bal in balances:
+                        if bal.get("balance_type", "").upper() == pref:
+                            chosen = bal
+                            break
+                    if chosen:
                         break
+                if chosen is None and balances:
+                    chosen = balances[0]
+                if chosen is not None:
+                    account.balance_available = chosen["balance_amount"]["amount"]
+                    account.balance_is_anchored = True
+                else:
+                    logger.warning(
+                        f"No balances returned by Enable Banking for account {account.id}"
+                    )
             except Exception as e:
                 logger.warning(f"Failed to fetch balances for account {account.id}: {e}")
 


### PR DESCRIPTION
## Summary
- Fixes the ABN AMRO balance chart showing phantom negative balances (-€802 baseline in 90D view) even though the account never went below zero.
- Root cause: `sync_bank_connection` only considered `CLAV` / `ITAV` balance types when setting `balance_available` + `balance_is_anchored`. ABN AMRO via Enable Banking returns `CLBD` (closing booked), so anchoring was skipped — `starting_balance` stayed at 0 and the `account_balances` timeseries became `cumulative_transactions`, drifting negative as expenses accumulated.
- Fix: widen the matcher to a prioritized list `(CLAV, ITAV, CLBD, XPCD, PRCD, OTHR)` with a first-returned fallback when no known type is present.

## Post-deploy
After merging and deploying, trigger a sync for the affected connection. The sync will now populate `balance_available`, run the existing back-calculation at [enable_banking_tasks.py:175](../blob/main/backend/tasks/enable_banking_tasks.py#L175) (`starting_balance = balance_available - sum(txns)`), and the post-import pipeline will rewrite the balance timeseries.

For faster backfill without waiting for the next sync, call the existing endpoints with the real current ABN AMRO balance:
\`\`\`
POST /accounts/{id}/recalculate-starting-balance?known_balance=<real_balance>&user_id=<uid>
POST /accounts/{id}/recalculate-timeseries?user_id=<uid>
\`\`\`

## Test plan
- [ ] Deploy to Railway staging/prod
- [ ] Trigger sync on the ABN AMRO connection
- [ ] Verify `accounts.balance_is_anchored = true` and `balance_available` matches the real bank balance
- [ ] Verify the 90D chart no longer shows negative baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchor ABN AMRO accounts using `CLBD` when `CLAV/ITAV` are missing from Enable Banking. Fixes phantom negative baselines by computing the correct starting balance.

- **Bug Fixes**
  - Pick the first available balance in priority order: `CLAV`, `ITAV`, `CLBD`, `XPCD`, `PRCD`, `OTHR`; fallback to the first returned balance.
  - Set `balance_available` and `balance_is_anchored` from the chosen balance.
  - Covers ABN AMRO where only `CLBD` is returned.

- **Migration**
  - After deploy, trigger a sync for affected ABN AMRO connections to backfill the anchor and rebuild the balance timeseries.
  - Optional fast backfill: POST /accounts/{id}/recalculate-starting-balance?known_balance=<real_balance>&user_id=<uid> then POST /accounts/{id}/recalculate-timeseries?user_id=<uid>.

<sup>Written for commit 67e1188a8ad78c5f6a4ae7ebf503ebe2c89349dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

