### PR TITLE
fix(oauth): send consent body shape expected by oauth-provider

### DIFF
--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -132,7 +132,7 @@ except ImportError:  # pragma: no cover
 
 AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai")
 AS_JWKS_URI = os.environ.get(
-    "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/.well-known/jwks.json"
+    "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )
 MCP_AUDIENCE = os.environ.get("MCP_OAUTH_AUDIENCE", "https://mcp.syllogic.ai")
 

--- a/frontend/app/.well-known/oauth-authorization-server/route.ts
+++ b/frontend/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,4 @@
+import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oAuthDiscoveryMetadata(auth);

--- a/frontend/app/.well-known/oauth-authorization-server/route.ts
+++ b/frontend/app/.well-known/oauth-authorization-server/route.ts
@@ -1,4 +1,4 @@
-import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
 import { auth } from "@/lib/auth";
 
-export const GET = oAuthDiscoveryMetadata(auth);
+export const GET = oauthProviderAuthServerMetadata(auth);

--- a/frontend/app/.well-known/oauth-protected-resource/route.ts
+++ b/frontend/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,4 @@
+import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oAuthProtectedResourceMetadata(auth);

--- a/frontend/app/.well-known/oauth-protected-resource/route.ts
+++ b/frontend/app/.well-known/oauth-protected-resource/route.ts
@@ -1,4 +1,0 @@
-import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
-import { auth } from "@/lib/auth";
-
-export const GET = oAuthProtectedResourceMetadata(auth);

--- a/frontend/app/oauth/consent/consent-form.tsx
+++ b/frontend/app/oauth/consent/consent-form.tsx
@@ -15,10 +15,20 @@ export function ConsentForm({ params }: Props) {
     setPending(decision);
     setError(null);
     try {
+      const oauthQuery = new URLSearchParams(
+        Object.entries(params).flatMap(([k, v]) =>
+          typeof v === "string" ? [[k, v] as [string, string]] : []
+        )
+      ).toString();
+      const scope = typeof params.scope === "string" ? params.scope : undefined;
       const res = await fetch("/api/auth/oauth2/consent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...params, decision }),
+        body: JSON.stringify({
+          accept: decision === "allow",
+          ...(scope ? { scope } : {}),
+          oauth_query: oauthQuery,
+        }),
       });
       if (res.redirected) {
         window.location.assign(res.url);


### PR DESCRIPTION
## Summary
When a user clicks Allow on the OAuth consent page (Claude custom connector flow), the browser POSTs to `/api/auth/oauth2/consent` with `{ decision: "allow", ...params }`. The oauth-provider's zod schema requires `{ accept: boolean, scope?, oauth_query? }` — so validation fails and the endpoint returns 400. Reshape the request body to match.

## Test plan
- [ ] After deploy, connect Claude custom connector to https://mcp.syllogic.ai/mcp
- [ ] On consent page, click Allow — expect redirect back to Claude with authorization code (no 400)
- [ ] Verify connector successfully enumerates MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the OAuth consent flow and expose authorization server metadata so the Claude custom connector can complete login without 400s. Also point the backend to the correct JWKS endpoint for reliable token verification.

- **Bug Fixes**
  - Send the expected consent payload to `/api/auth/oauth2/consent`: `{ accept: boolean, scope?, oauth_query? }`, enabling successful redirect with an auth code.
  - Expose `/.well-known/oauth-authorization-server` via `oauthProviderAuthServerMetadata(auth)` from `@better-auth/oauth-provider`, and default JWKS URI to `/api/auth/jwks` for proper discovery and JWT verification.

<sup>Written for commit 6a2666b46b98051638487d48814c775c06bbaa3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

