### PR TITLE
fix(db): rename verification_tokens.token to value for better-auth

### DIFF
--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -132,7 +132,7 @@ except ImportError:  # pragma: no cover
 
 AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai")
 AS_JWKS_URI = os.environ.get(
-    "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/.well-known/jwks.json"
+    "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )
 MCP_AUDIENCE = os.environ.get("MCP_OAUTH_AUDIENCE", "https://mcp.syllogic.ai")
 

--- a/frontend/app/.well-known/oauth-authorization-server/route.ts
+++ b/frontend/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,4 @@
+import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oAuthDiscoveryMetadata(auth);

--- a/frontend/app/.well-known/oauth-authorization-server/route.ts
+++ b/frontend/app/.well-known/oauth-authorization-server/route.ts
@@ -1,4 +1,4 @@
-import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
 import { auth } from "@/lib/auth";
 
-export const GET = oAuthDiscoveryMetadata(auth);
+export const GET = oauthProviderAuthServerMetadata(auth);

--- a/frontend/app/.well-known/oauth-protected-resource/route.ts
+++ b/frontend/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,4 @@
+import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oAuthProtectedResourceMetadata(auth);

--- a/frontend/app/.well-known/oauth-protected-resource/route.ts
+++ b/frontend/app/.well-known/oauth-protected-resource/route.ts
@@ -1,4 +1,0 @@
-import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
-import { auth } from "@/lib/auth";
-
-export const GET = oAuthProtectedResourceMetadata(auth);

--- a/frontend/app/oauth/consent/consent-form.tsx
+++ b/frontend/app/oauth/consent/consent-form.tsx
@@ -15,10 +15,20 @@ export function ConsentForm({ params }: Props) {
     setPending(decision);
     setError(null);
     try {
+      const oauthQuery = new URLSearchParams(
+        Object.entries(params).flatMap(([k, v]) =>
+          typeof v === "string" ? [[k, v] as [string, string]] : []
+        )
+      ).toString();
+      const scope = typeof params.scope === "string" ? params.scope : undefined;
       const res = await fetch("/api/auth/oauth2/consent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...params, decision }),
+        body: JSON.stringify({
+          accept: decision === "allow",
+          ...(scope ? { scope } : {}),
+          oauth_query: oauthQuery,
+        }),
       });
       if (res.redirected) {
         window.location.assign(res.url);

--- a/frontend/lib/db/migrations/0017_verification_value_rename.sql
+++ b/frontend/lib/db/migrations/0017_verification_value_rename.sql
@@ -1,0 +1,8 @@
+-- Align verification_tokens table with better-auth's expected schema.
+-- better-auth's verification model reads/writes a `value` column; our table
+-- historically exposed the same column as `token` with a unique constraint,
+-- which broke oauth-provider's state storage (OAuth state, consent flow).
+-- Rename the column to `value` and drop the unique index.
+
+ALTER TABLE "verification_tokens" DROP CONSTRAINT IF EXISTS "verification_tokens_token_unique";
+ALTER TABLE "verification_tokens" RENAME COLUMN "token" TO "value";

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1776643200000,
       "tag": "0016_jwks_table",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1776729600000,
+      "tag": "0017_verification_value_rename",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -73,7 +73,7 @@ export const authAccounts = pgTable("auth_accounts", {
 export const verificationTokens = pgTable("verification_tokens", {
   id: text("id").primaryKey(),
   identifier: text("identifier").notNull(),
-  token: text("token").unique().notNull(),
+  value: text("value").notNull(),
   expiresAt: timestamp("expires_at").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),


### PR DESCRIPTION
## Summary
Clicking Allow on the OAuth consent page (Claude custom connector flow) returned 500. Server log:
> The field \"value\" does not exist in the \"verification\" Drizzle schema.

Better-auth's internal adapter reads/writes a `value` column on the verification model (used by `@better-auth/oauth-provider` to persist OAuth state across authorize → consent → token). Our table shipped the same data as `token` with a unique constraint, so state inserts/lookups failed.

- Rename `verification_tokens.token` → `value` (migration 0017).
- Drop the unique constraint (state rows are keyed by `identifier`, not `value`).
- Update drizzle schema to match.

Railway runs `node scripts/migrate.js` in `preDeployCommand`, so the rename runs before the app boots.

## Test plan
- [ ] After merge + redeploy, retry Claude custom connector → Allow → expect redirect back to Claude with authorization code (no 500).
- [ ] Existing sign-in flows still work (verification table is also used by password reset / email verification flows if enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500 errors after clicking Allow in the OAuth consent flow by aligning the verification token schema with `better-auth` and sending the consent payload the API expects. Also exposes authorization server discovery metadata and points JWKS to the correct endpoint to unblock the Claude custom connector flow.

- **Bug Fixes**
  - DB: rename `verification_tokens.token` → `value` and drop the unique index; update Drizzle schema (migration `0017`).
  - Consent: post `{ accept, scope?, oauth_query }` to `/api/auth/oauth2/consent` per `@better-auth/oauth-provider`.
  - Discovery: add `/.well-known/oauth-authorization-server` using `oauthProviderAuthServerMetadata(auth)`.
  - JWTs: default `MCP_OAUTH_JWKS_URI` to `/api/auth/jwks`.

<sup>Written for commit aa5c12f891b1bedcce52f673ee52bb4330214182. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

