### PR TITLE
fix(oauth): accept MCP resource indicator and verify matching JWT aud

### DIFF
--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -132,7 +132,7 @@ except ImportError:  # pragma: no cover
 
 AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai")
 AS_JWKS_URI = os.environ.get(
-    "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/.well-known/jwks.json"
+    "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )
 MCP_AUDIENCE = os.environ.get("MCP_OAUTH_AUDIENCE", "https://mcp.syllogic.ai")
 

--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -134,7 +134,7 @@ AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai")
 AS_JWKS_URI = os.environ.get(
     "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )
-MCP_AUDIENCE = os.environ.get("MCP_OAUTH_AUDIENCE", "https://mcp.syllogic.ai")
+MCP_AUDIENCE = os.environ.get("MCP_OAUTH_AUDIENCE", "https://mcp.syllogic.ai/mcp")
 
 
 class CompositeAuthProvider(AuthProvider):

--- a/frontend/app/.well-known/oauth-authorization-server/route.ts
+++ b/frontend/app/.well-known/oauth-authorization-server/route.ts
@@ -1,0 +1,4 @@
+import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oAuthDiscoveryMetadata(auth);

--- a/frontend/app/.well-known/oauth-authorization-server/route.ts
+++ b/frontend/app/.well-known/oauth-authorization-server/route.ts
@@ -1,4 +1,4 @@
-import { oAuthDiscoveryMetadata } from "better-auth/plugins";
+import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
 import { auth } from "@/lib/auth";
 
-export const GET = oAuthDiscoveryMetadata(auth);
+export const GET = oauthProviderAuthServerMetadata(auth);

--- a/frontend/app/.well-known/oauth-protected-resource/route.ts
+++ b/frontend/app/.well-known/oauth-protected-resource/route.ts
@@ -1,0 +1,4 @@
+import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
+import { auth } from "@/lib/auth";
+
+export const GET = oAuthProtectedResourceMetadata(auth);

--- a/frontend/app/.well-known/oauth-protected-resource/route.ts
+++ b/frontend/app/.well-known/oauth-protected-resource/route.ts
@@ -1,4 +1,0 @@
-import { oAuthProtectedResourceMetadata } from "better-auth/plugins";
-import { auth } from "@/lib/auth";
-
-export const GET = oAuthProtectedResourceMetadata(auth);

--- a/frontend/app/oauth/consent/consent-form.tsx
+++ b/frontend/app/oauth/consent/consent-form.tsx
@@ -15,10 +15,20 @@ export function ConsentForm({ params }: Props) {
     setPending(decision);
     setError(null);
     try {
+      const oauthQuery = new URLSearchParams(
+        Object.entries(params).flatMap(([k, v]) =>
+          typeof v === "string" ? [[k, v] as [string, string]] : []
+        )
+      ).toString();
+      const scope = typeof params.scope === "string" ? params.scope : undefined;
       const res = await fetch("/api/auth/oauth2/consent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...params, decision }),
+        body: JSON.stringify({
+          accept: decision === "allow",
+          ...(scope ? { scope } : {}),
+          oauth_query: oauthQuery,
+        }),
       });
       if (res.redirected) {
         window.location.assign(res.url);

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -59,6 +59,14 @@ export const auth = betterAuth({
       allowUnauthenticatedClientRegistration: true,
       loginPage: "/login",
       consentPage: "/oauth/consent",
+      // Allow MCP clients (e.g. Claude custom connectors) to request the
+      // Syllogic MCP server as the JWT audience via RFC 8707. Without this,
+      // better-auth rejects the resource parameter and falls back to an
+      // opaque token that the MCP JWTVerifier can't validate.
+      validAudiences: [
+        "https://mcp.syllogic.ai/mcp",
+        "https://mcp.syllogic.ai",
+      ],
     }),
   ],
   emailAndPassword: {

--- a/frontend/lib/db/migrations/0017_verification_value_rename.sql
+++ b/frontend/lib/db/migrations/0017_verification_value_rename.sql
@@ -1,0 +1,8 @@
+-- Align verification_tokens table with better-auth's expected schema.
+-- better-auth's verification model reads/writes a `value` column; our table
+-- historically exposed the same column as `token` with a unique constraint,
+-- which broke oauth-provider's state storage (OAuth state, consent flow).
+-- Rename the column to `value` and drop the unique index.
+
+ALTER TABLE "verification_tokens" DROP CONSTRAINT IF EXISTS "verification_tokens_token_unique";
+ALTER TABLE "verification_tokens" RENAME COLUMN "token" TO "value";

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1776643200000,
       "tag": "0016_jwks_table",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1776729600000,
+      "tag": "0017_verification_value_rename",
+      "breakpoints": true
     }
   ]
 }

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -73,7 +73,7 @@ export const authAccounts = pgTable("auth_accounts", {
 export const verificationTokens = pgTable("verification_tokens", {
   id: text("id").primaryKey(),
   identifier: text("identifier").notNull(),
-  token: text("token").unique().notNull(),
+  value: text("value").notNull(),
   expiresAt: timestamp("expires_at").notNull(),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),


### PR DESCRIPTION
## Summary
End-of-flow for Claude custom connector failed: the consent step now succeeds, but the subsequent MCP request returned 401 \"invalid_token\" (ref: ofid_80e13e7d973a35db).

Root cause: better-auth's oauth-provider only emits a JWT when the client sends an RFC 8707 `resource=<mcp-url>` parameter **AND** that resource appears in its `validAudiences` allowlist. We never configured `validAudiences`, so the token endpoint either rejected the request or returned an opaque token — which the MCP backend's `JWTVerifier` cannot validate.

- frontend/lib/auth.ts: add `validAudiences: [\"https://mcp.syllogic.ai/mcp\", \"https://mcp.syllogic.ai\"]` so Claude's resource indicator passes the allowlist and better-auth signs a JWT with the canonical MCP URL as `aud`.
- backend/app/mcp/auth.py: update `MCP_AUDIENCE` default to `https://mcp.syllogic.ai/mcp` (matches the `resource` value advertised in the protected-resource metadata).

## Test plan
- [ ] After merge + redeploy, reconnect Claude custom connector → Allow → expect Claude to complete authorization (no \"Authorization with the MCP server failed\").
- [ ] Verify `curl -i https://mcp.syllogic.ai/mcp` still returns 401 for anonymous (baseline unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Claude MCP OAuth flow by accepting the RFC 8707 resource indicator and issuing JWTs with the correct `aud`, so MCP requests no longer return 401.

- **Bug Fixes**
  - Allow JWT issuance by adding `validAudiences` for `https://mcp.syllogic.ai/mcp` and `https://mcp.syllogic.ai` in `better-auth` (`@better-auth/oauth-provider`).
  - Set backend defaults: `MCP_OAUTH_JWKS_URI` → `https://app.syllogic.ai/api/auth/jwks`, `MCP_OAUTH_AUDIENCE` → `https://mcp.syllogic.ai/mcp`.
  - Expose AS discovery at `/.well-known/oauth-authorization-server` via `oauthProviderAuthServerMetadata`.
  - Fix consent POST body to `{ accept, scope?, oauth_query? }` as required by `@better-auth/oauth-provider`.

- **Migration**
  - Rename `verification_tokens.token` → `value` and drop the unique index to match `better-auth` expectations.
  - Run migration `0017_verification_value_rename`; no manual data changes required.

<sup>Written for commit 515921d3562eb2a51c1a94cfe46a4b6a02ac0b8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

