### PR TITLE
fix(oauth): navigate to url field in consent response

### DIFF
--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -130,7 +130,7 @@ except ImportError:  # pragma: no cover
     JWTVerifier = None  # type: ignore
 
 
-AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai")
+AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai/api/auth")
 AS_JWKS_URI = os.environ.get(
     "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )

--- a/frontend/app/oauth/consent/consent-form.tsx
+++ b/frontend/app/oauth/consent/consent-form.tsx
@@ -29,18 +29,21 @@ export function ConsentForm({ params }: Props) {
           ...(scope ? { scope } : {}),
           oauth_query: oauthQuery,
         }),
+        redirect: "manual",
       });
-      if (res.redirected) {
-        window.location.assign(res.url);
-        return;
-      }
       const body = await res.json().catch(() => ({}));
-      if (body.redirect_uri) {
-        window.location.assign(body.redirect_uri);
+      const target =
+        typeof body?.url === "string"
+          ? body.url
+          : typeof body?.redirect_uri === "string"
+            ? body.redirect_uri
+            : undefined;
+      if (target) {
+        window.location.assign(target);
         return;
       }
       if (!res.ok) {
-        throw new Error(body.error ?? `Request failed (${res.status})`);
+        throw new Error(body?.error ?? `Request failed (${res.status})`);
       }
     } catch (err) {
       setError(


### PR DESCRIPTION
## Summary

- After clicking **Allow** on `/oauth/consent`, the browser stayed on the consent page — the Claude callback URL was only visible in the network tab.
- Root cause: `@better-auth/oauth-provider`'s consent endpoint returns JSON `{ redirect: true, url }` but `consent-form.tsx` was reading `body.redirect_uri` (wrong field).
- Also set `redirect: "manual"` on the fetch so the browser doesn't try to auto-follow the 3xx into `claude.ai` (CORS swallows the target).

## Test plan

- [ ] Start Claude custom connector flow → land on consent page
- [ ] Click Allow → browser navigates to `https://claude.ai/api/organizations/.../mcp/callback?...`
- [ ] Connector reports connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth consent redirect and aligns JWT issuer so tokens validate. Clicking Allow now navigates to the provider callback, and MCP accepts the issued tokens.

- **Bug Fixes**
  - Consent: read `url` from `@better-auth/oauth-provider` JSON (fallback `redirect_uri`) and use `fetch` with `redirect: "manual"` to avoid CORS-swallowed 3xx.
  - MCP: default issuer to `https://app.syllogic.ai/api/auth` to match `@better-auth/oauth-provider`; resolves `invalid_token` after code exchange.

<sup>Written for commit 416d2f8d3e0a71c573c6f88112264117f38e80a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

