### PR TITLE
fix(oauth): switch jwt plugin to RS256 for FastMCP compatibility

### DIFF
--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -130,7 +130,7 @@ except ImportError:  # pragma: no cover
     JWTVerifier = None  # type: ignore
 
 
-AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai")
+AS_ISSUER = os.environ.get("MCP_OAUTH_ISSUER", "https://app.syllogic.ai/api/auth")
 AS_JWKS_URI = os.environ.get(
     "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )

--- a/frontend/app/oauth/consent/consent-form.tsx
+++ b/frontend/app/oauth/consent/consent-form.tsx
@@ -29,18 +29,21 @@ export function ConsentForm({ params }: Props) {
           ...(scope ? { scope } : {}),
           oauth_query: oauthQuery,
         }),
+        redirect: "manual",
       });
-      if (res.redirected) {
-        window.location.assign(res.url);
-        return;
-      }
       const body = await res.json().catch(() => ({}));
-      if (body.redirect_uri) {
-        window.location.assign(body.redirect_uri);
+      const target =
+        typeof body?.url === "string"
+          ? body.url
+          : typeof body?.redirect_uri === "string"
+            ? body.redirect_uri
+            : undefined;
+      if (target) {
+        window.location.assign(target);
         return;
       }
       if (!res.ok) {
-        throw new Error(body.error ?? `Request failed (${res.status})`);
+        throw new Error(body?.error ?? `Request failed (${res.status})`);
       }
     } catch (err) {
       setError(

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -50,7 +50,11 @@ export const auth = betterAuth({
   }),
   plugins: [
     admin(),
-    jwt(),
+    jwt({
+      jwks: {
+        keyPairConfig: { alg: "RS256", modulusLength: 2048 },
+      },
+    }),
     oauthProvider({
       scopes: ["mcp:access"],
       accessTokenExpiresIn: 60 * 60, // 1 hour
@@ -63,10 +67,22 @@ export const auth = betterAuth({
       // Syllogic MCP server as the JWT audience via RFC 8707. Without this,
       // better-auth rejects the resource parameter and falls back to an
       // opaque token that the MCP JWTVerifier can't validate.
-      validAudiences: [
-        "https://mcp.syllogic.ai/mcp",
-        "https://mcp.syllogic.ai",
-      ],
+      validAudiences: Array.from(
+        new Set(
+          [
+            "https://mcp.syllogic.ai/mcp",
+            "https://mcp.syllogic.ai",
+            ...(process.env.MCP_LOCAL_AUDIENCE
+              ? [process.env.MCP_LOCAL_AUDIENCE]
+              : []),
+            ...(process.env.MCP_VALID_AUDIENCES
+              ? process.env.MCP_VALID_AUDIENCES.split(",").map((v) =>
+                  v.trim()
+                )
+              : []),
+          ].filter(Boolean)
+        )
+      ),
     }),
   ],
   emailAndPassword: {

--- a/scripts/test_oauth_e2e.py
+++ b/scripts/test_oauth_e2e.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Headless end-to-end test of the Syllogic OAuth 2.1 + MCP flow.
+
+Simulates exactly what Claude's custom connector does:
+  1. Dynamic Client Registration (DCR)
+  2. Sign up / sign in a test user
+  3. /oauth2/authorize with PKCE + resource indicator
+  4. /oauth2/consent (accept)
+  5. /oauth2/token exchange
+  6. POST /mcp with the JWT
+
+Usage:
+    python scripts/test_oauth_e2e.py
+
+Env overrides:
+    FRONTEND_BASE (default http://localhost:3000)
+    MCP_BASE (default http://localhost:8001)
+"""
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sys
+import urllib.parse
+import requests
+
+FRONTEND = os.environ.get("FRONTEND_BASE", "http://localhost:3000")
+MCP = os.environ.get("MCP_BASE", "http://localhost:8001")
+EMAIL = "e2e-tester@syllogic.local"
+PASSWORD = "e2e-tester-password-1234"
+NAME = "E2E Tester"
+
+
+def log(step, data=""):
+    print(f"\n=== {step} ===")
+    if data:
+        print(data if isinstance(data, str) else json.dumps(data, indent=2)[:2000])
+
+
+def pkce():
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    return verifier, challenge
+
+
+def decode_jwt_payload(token):
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    pad = "=" * (-len(parts[1]) % 4)
+    return json.loads(base64.urlsafe_b64decode(parts[1] + pad))
+
+
+def main():
+    s = requests.Session()
+
+    # 1. Sign up test user (idempotent; ignore if exists)
+    log("Sign up / sign in")
+    r = s.post(
+        f"{FRONTEND}/api/auth/sign-up/email",
+        json={"email": EMAIL, "password": PASSWORD, "name": NAME},
+    )
+    if r.status_code not in (200, 201):
+        # Probably already exists → sign in
+        r = s.post(
+            f"{FRONTEND}/api/auth/sign-in/email",
+            json={"email": EMAIL, "password": PASSWORD},
+        )
+    r.raise_for_status()
+    log("session cookies", dict(s.cookies))
+
+    # 2. DCR (use a fresh session — unauthenticated DCR)
+    log("Dynamic Client Registration")
+    r = requests.post(
+        f"{FRONTEND}/api/auth/oauth2/register",
+        json={
+            "client_name": "E2E Test Client",
+            "redirect_uris": ["http://localhost:9999/callback"],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "scope": "mcp:access",
+        },
+    )
+    r.raise_for_status()
+    client = r.json()
+    log("client", client)
+    client_id = client["client_id"]
+
+    # 3. Authorize (with PKCE + resource indicator)
+    verifier, challenge = pkce()
+    state = secrets.token_urlsafe(16)
+    resource = f"{MCP}/mcp"
+    auth_params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": "http://localhost:9999/callback",
+        "scope": "mcp:access",
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "resource": resource,
+    }
+    log("GET /oauth2/authorize", urllib.parse.urlencode(auth_params))
+    r = s.get(
+        f"{FRONTEND}/api/auth/oauth2/authorize",
+        params=auth_params,
+        allow_redirects=False,
+    )
+    log("authorize status", f"{r.status_code} loc={r.headers.get('location')}")
+
+    # Expect redirect to /oauth/consent?... or direct to callback if auto-approved
+    loc = r.headers.get("location", "")
+    if "/oauth/consent" in loc:
+        # Parse oauth_query back out
+        consent_url = urllib.parse.urlparse(loc)
+        oauth_query = urllib.parse.parse_qs(consent_url.query)
+        # Better-auth expects the entire query string as oauth_query
+        raw_q = consent_url.query
+        log("POST /oauth2/consent", raw_q[:300])
+        r = s.post(
+            f"{FRONTEND}/api/auth/oauth2/consent",
+            json={
+                "accept": True,
+                "scope": "mcp:access",
+                "oauth_query": raw_q,
+            },
+            headers={"Origin": FRONTEND},
+            allow_redirects=False,
+        )
+        log("consent status", f"{r.status_code} body={r.text[:500]}")
+        try:
+            body = r.json()
+        except Exception:
+            body = {}
+        # Expect {redirect: true, url: "http://localhost:9999/callback?code=..."}
+        cb_url = body.get("url") or body.get("redirect_uri")
+        if not cb_url:
+            # Maybe direct 302
+            cb_url = r.headers.get("location")
+        if not cb_url:
+            print("!! no redirect url in consent response")
+            sys.exit(1)
+    elif "code=" in loc:
+        cb_url = loc
+    else:
+        print(f"!! unexpected authorize redirect: {loc}")
+        sys.exit(1)
+
+    log("callback URL", cb_url)
+    parsed = urllib.parse.urlparse(cb_url)
+    code = urllib.parse.parse_qs(parsed.query).get("code", [None])[0]
+    if not code:
+        print("!! no code in callback URL")
+        sys.exit(1)
+
+    # 4. Token exchange
+    log("POST /oauth2/token")
+    r = requests.post(
+        f"{FRONTEND}/api/auth/oauth2/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "http://localhost:9999/callback",
+            "client_id": client_id,
+            "code_verifier": verifier,
+            "resource": resource,
+        },
+    )
+    log("token status", r.status_code)
+    r.raise_for_status()
+    tok = r.json()
+    log("token response", {k: v for k, v in tok.items() if k != "access_token"})
+    access_token = tok["access_token"]
+    claims = decode_jwt_payload(access_token)
+    log("JWT claims", claims)
+
+    # 5. Call MCP
+    log("POST /mcp")
+    r = requests.post(
+        f"{MCP}/mcp",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {},
+        },
+    )
+    log("mcp status", f"{r.status_code}")
+    log("mcp body", r.text[:1500])
+    if r.status_code != 200:
+        sys.exit(1)
+    print("\n✅ E2E flow succeeded")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Even after PR #70 landed, MCP kept returning \`invalid_token\` on every request. Root cause, found via headless e2e reproduction:

- better-auth's \`jwt()\` plugin defaults to **EdDSA (Ed25519)**.
- FastMCP's \`JWTVerifier\` only supports **RS/HS/ES/PS** families — it cannot verify EdDSA.
- Every token we issued was structurally valid but unverifiable by MCP.

Switching the plugin to \`RS256\` via \`keyPairConfig\` makes tokens verifiable. Also makes \`validAudiences\` env-driven (\`MCP_LOCAL_AUDIENCE\`, \`MCP_VALID_AUDIENCES\`) so local dev can add \`http://localhost:8001/mcp\` without editing code.

## Deployment notes

⚠️ **Existing rows in the \`jwks\` table must be deleted** after deploying. The plugin only generates a new RSA keypair when the table is empty; otherwise it keeps serving the old Ed25519 key with \`alg: RS256\` stamped on it (which still fails verification).

Run after deploy:
\`\`\`sql
DELETE FROM jwks;
\`\`\`

## Test plan

- \`scripts/test_oauth_e2e.py\` now runs end-to-end locally (DCR → authorize → consent → token → MCP \`tools/list\`) in ~5 seconds. Verified the JWT is issued with \`alg: RS256\`, correct \`iss\`/\`aud\`, and MCP accepts it (returns MCP-protocol 400 "Missing session ID" — expected for a bare \`tools/list\` without \`initialize\`, meaning auth passed).

- [ ] After deploy + \`DELETE FROM jwks\`: Claude custom connector completes OAuth and issues tool calls successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch JWT signing to RS256 and align the issuer so FastMCP can verify our tokens. Also fixes consent redirects and adds a headless e2e test; JWT audiences are now env-driven for local dev.

- **Bug Fixes**
  - Use `better-auth` `jwt()` with RSA keypair (`RS256`) for FastMCP compatibility.
  - Align default issuer to `/api/auth` so the `iss` claim matches what `@better-auth/oauth-provider` publishes.
  - Make `validAudiences` configurable via `MCP_LOCAL_AUDIENCE` and `MCP_VALID_AUDIENCES`.
  - Fix consent flow to read the `url` field and use `redirect: "manual"` to navigate correctly.
  - Add `scripts/test_oauth_e2e.py` to run the full OAuth → MCP flow locally.

- **Migration**
  - After deploy, clear existing JWKS so a new RSA keypair is generated: run "DELETE FROM jwks;".

<sup>Written for commit a124232c48c4875fd219e9be2be1c41973321290. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

