### PR TITLE
feat: IBAN-based pocket account tracking (Workstream 1)

### DIFF
--- a/backend/app/integrations/base.py
+++ b/backend/app/integrations/base.py
@@ -29,6 +29,7 @@ class TransactionData(BaseModel):
     merchant: Optional[str] = None
     creditor: Optional[str] = None   # Counterparty name for debits (payee)
     debtor: Optional[str] = None     # Counterparty name for credits (payer)
+    counterparty_iban: Optional[str] = None  # IBAN of the other party (stripped, upper-cased)
     booked_at: datetime
     transaction_type: str  # debit, credit
     pending: bool = False

--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -15,6 +15,26 @@ from app.integrations.base import BankAdapter, AccountData, TransactionData
 from app.integrations.enable_banking_auth import EnableBankingClient
 
 
+def _extract_iban(account_obj: Optional[dict]) -> Optional[str]:
+    """Extract a normalized IBAN string from an EB account object.
+
+    EB returns counterparty accounts either flat as ``{"iban": "..."}`` or in
+    scheme form as ``{"scheme_name": "IBAN", "identification": "..."}``.
+    Non-IBAN schemes (BBAN, SORT, etc.) and partial objects return None.
+    Returns the IBAN with spaces removed and upper-cased, or None.
+    """
+    if not isinstance(account_obj, dict):
+        return None
+    iban = account_obj.get("iban")
+    if isinstance(iban, str) and iban:
+        return iban.replace(" ", "").upper()
+    if (account_obj.get("scheme_name") or "").upper() == "IBAN":
+        ident = account_obj.get("identification")
+        if isinstance(ident, str) and ident:
+            return ident.replace(" ", "").upper()
+    return None
+
+
 # Mapping from Enable Banking cash account types to our canonical types
 _ACCOUNT_TYPE_MAP = {
     "CACC": "checking",   # Current Account
@@ -201,6 +221,19 @@ class EnableBankingAdapter(BankAdapter):
         # credit_debit_indicator ("CRDT" = money in, "DBIT" = money out).
         # Normalise to signed amounts so downstream categorisation works correctly.
         credit_debit = raw.get("credit_debit_indicator", "CRDT").upper()
+
+        # Resolve counterparty IBAN: for debits the counterparty is the creditor;
+        # for credits the counterparty is the debtor.
+        creditor_iban = (
+            _extract_iban(raw.get("creditor_account"))
+            or _extract_iban(raw.get("creditor"))
+        )
+        debtor_iban = (
+            _extract_iban(raw.get("debtor_account"))
+            or _extract_iban(raw.get("debtor"))
+        )
+        counterparty_iban = creditor_iban if credit_debit == "DBIT" else debtor_iban
+
         if credit_debit == "DBIT" and amount > 0:
             amount = -amount
 
@@ -213,6 +246,7 @@ class EnableBankingAdapter(BankAdapter):
             merchant=merchant,
             creditor=creditor_name,
             debtor=debtor_name,
+            counterparty_iban=counterparty_iban,
             booked_at=datetime.fromisoformat(_date_str) if (_date_str := (
                 raw.get("booking_date")
                 or raw.get("value_date")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -59,7 +59,12 @@ class Account(Base):
     user = relationship("User", back_populates="accounts")
     logo = relationship("CompanyLogo", back_populates="accounts")
     bank_connection = relationship("BankConnection", back_populates="accounts")
-    transactions = relationship("Transaction", back_populates="account")
+    transactions = relationship(
+        "Transaction",
+        back_populates="account",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
     csv_imports = relationship("CsvImport", back_populates="account")
     balances = relationship("AccountBalance", back_populates="account")
     recurring_transactions = relationship("RecurringTransaction", back_populates="account")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -175,7 +175,11 @@ class Transaction(Base):
     debtor = Column(String(255), nullable=True)     # Counterparty name for credits (payer)
     counterparty_iban_ciphertext = Column(Text, nullable=True)
     counterparty_iban_hash = Column(String(64), nullable=True)
-    internal_transfer_id = Column(UUID(as_uuid=True), nullable=True)  # FK constraint added in Task 3
+    internal_transfer_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("internal_transfers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     category_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True, index=True)  # User-overridden category
     category_system_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True, index=True)  # AI-assigned category
     booked_at = Column(DateTime, nullable=False, index=True)
@@ -208,6 +212,49 @@ class Transaction(Base):
         Index("idx_transactions_csv_import", "csv_import_id"),
         UniqueConstraint("account_id", "external_id", name="transactions_account_external_id"),
         Index("idx_transactions_user_counterparty_iban", "user_id", "counterparty_iban_hash"),
+    )
+
+
+class InternalTransfer(Base):
+    """
+    Internal transfer model matching Drizzle schema.
+    Links a source transaction on a synced account to a mirror transaction
+    on a manually-registered pocket account, matched by counterparty IBAN.
+    """
+    __tablename__ = "internal_transfers"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()"))
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    source_txn_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("transactions.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    mirror_txn_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("transactions.id", ondelete="SET NULL"),
+        nullable=True,
+        unique=True,
+    )
+    source_account_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    pocket_account_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    amount = Column(Numeric(15, 2), nullable=False)
+    currency = Column(String(3), nullable=False)
+    detected_at = Column(DateTime, server_default=text("now()"))
+    created_at = Column(DateTime, server_default=text("now()"))
+
+    __table_args__ = (
+        Index("idx_internal_transfers_user", "user_id"),
+        Index("idx_internal_transfers_pocket", "pocket_account_id"),
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -173,6 +173,9 @@ class Transaction(Base):
     merchant = Column(String(255))
     creditor = Column(String(255), nullable=True)   # Counterparty name for debits (payee)
     debtor = Column(String(255), nullable=True)     # Counterparty name for credits (payer)
+    counterparty_iban_ciphertext = Column(Text, nullable=True)
+    counterparty_iban_hash = Column(String(64), nullable=True)
+    internal_transfer_id = Column(UUID(as_uuid=True), nullable=True)  # FK constraint added in Task 3
     category_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True, index=True)  # User-overridden category
     category_system_id = Column(UUID(as_uuid=True), ForeignKey("categories.id"), nullable=True, index=True)  # AI-assigned category
     booked_at = Column(DateTime, nullable=False, index=True)
@@ -204,6 +207,7 @@ class Transaction(Base):
         Index("idx_transactions_recurring", "recurring_transaction_id"),
         Index("idx_transactions_csv_import", "csv_import_id"),
         UniqueConstraint("account_id", "external_id", name="transactions_account_external_id"),
+        Index("idx_transactions_user_counterparty_iban", "user_id", "counterparty_iban_hash"),
     )
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -43,6 +43,8 @@ class Account(Base):
     external_id = Column(String(255), nullable=True)  # Provider's account ID
     external_id_ciphertext = Column(Text, nullable=True)
     external_id_hash = Column(String(64), nullable=True, index=True)
+    iban_ciphertext = Column(Text, nullable=True)
+    iban_hash = Column(String(64), nullable=True, index=False)  # composite index defined in __table_args__
     bank_connection_id = Column(UUID(as_uuid=True), ForeignKey("bank_connections.id", ondelete="SET NULL"), nullable=True)
     balance_available = Column(Numeric(15, 2), nullable=True)
     starting_balance = Column(Numeric(15, 2), default=Decimal("0"))  # Starting balance for calculation
@@ -76,6 +78,7 @@ class Account(Base):
             postgresql_where=text("external_id_hash IS NOT NULL"),
         ),
         Index("idx_accounts_bank_connection", "bank_connection_id"),
+        Index("idx_accounts_user_iban_hash", "user_id", "iban_hash"),
     )
 
 

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -287,9 +287,10 @@ def delete_account(
     For pocket accounts (``provider="manual"``) with linked internal transfers,
     unlink the source transactions first (restoring ``include_in_analytics=True``
     and clearing ``internal_transfer_id``) so the cascade that follows doesn't
-    leave orphan sources with stale analytics flags. Mirror transactions on the
-    pocket are deleted by the ``ON DELETE CASCADE`` on ``transactions.account_id``
-    when the account row is removed.
+    leave orphan sources with stale analytics flags. Child transactions are
+    removed by the ``ON DELETE CASCADE`` on ``transactions.account_id``;
+    ``Account.transactions`` uses ``passive_deletes=True`` so SQLAlchemy defers
+    to the DB cascade instead of trying to NULL the children.
 
     For non-pocket accounts ``unlink_all_for_pocket`` is a no-op (no links point
     at them by definition).
@@ -302,25 +303,7 @@ def delete_account(
     if account is None:
         raise HTTPException(status_code=404, detail="Account not found")
 
-    # Unlink any internal transfers pointing to this account before cascade
     InternalTransferService(db, user_id=user_id).unlink_all_for_pocket(account_id)
-
-    # Explicitly delete the account's transactions. The DB has ON DELETE CASCADE
-    # on transactions.account_id, but SQLAlchemy's default relationship behavior
-    # (no passive_deletes=True on Account.transactions) tries to NULL the
-    # children first, which violates the NOT NULL constraint. Bulk-delete them
-    # ourselves to mirror what the cascade would do.
-    #
-    # NOTE: This bulk delete bypasses ORM-level `before_delete` events on
-    # Transaction. All current Transaction children (transaction_links,
-    # internal_transfers, recurring_transaction refs, csv_import refs) rely on
-    # DB-level ON DELETE CASCADE / SET NULL, so this is safe today. If anyone
-    # later adds a Python-level event listener or cascade="delete-orphan" on
-    # Transaction, this path must switch to per-row deletion.
-    db.query(Transaction).filter(
-        Transaction.user_id == user_id,
-        Transaction.account_id == account_id,
-    ).delete(synchronize_session=False)
 
     db.delete(account)
     db.commit()
@@ -336,9 +319,8 @@ def delete_revolut_default_accounts(
     Permanently delete all "Revolut default" accounts for the current user.
     This is a hard delete - use with caution.
     """
-    from app.models import Transaction
     user_id = get_user_id(user_id)
-    
+
     # Find all revolut_default accounts for this user
     default_accounts = db.query(Account).filter(
         Account.user_id == user_id,
@@ -347,18 +329,12 @@ def delete_revolut_default_accounts(
             Account.external_id_hash.in_(blind_index_candidates("revolut_default")),
         )
     ).all()
-    
+
     deleted_count = 0
     for account in default_accounts:
-        # Delete associated transactions first (due to foreign key constraint)
-        db.query(Transaction).filter(
-            Transaction.user_id == user_id,
-            Transaction.account_id == account.id
-        ).delete()
-        # Then delete the account
         db.delete(account)
         deleted_count += 1
-    
+
     db.commit()
     
     return {

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 from sqlalchemy import or_
+from sqlalchemy.exc import IntegrityError
 from typing import List, Optional
 from uuid import UUID
 
@@ -104,7 +105,17 @@ def create_pocket_account(
         is_active=True,
     )
     db.add(account)
-    db.flush()
+    try:
+        db.flush()
+    except IntegrityError:
+        # Race condition: two concurrent pocket-create requests slipped past the
+        # application-level SELECT check. The partial unique index
+        # `accounts_user_iban_hash_manual_uq` catches this at the DB layer.
+        db.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail="A pocket account with this IBAN is already registered",
+        )
 
     # Backfill: find existing transactions whose counterparty matches this IBAN
     candidate_ids = [
@@ -121,14 +132,14 @@ def create_pocket_account(
     # internally when it actually persists matches (detected > 0). We still
     # commit here unconditionally so the new Account row is persisted even on
     # the zero-match path. A redundant commit on a clean session is a no-op.
-    backfilled = (
-        InternalTransferService(db, user_id=user_id).detect_for_transactions(candidate_ids)
-        if candidate_ids
-        else 0
-    )
+    if candidate_ids:
+        result = InternalTransferService(db, user_id=user_id).detect_for_transactions(candidate_ids)
+        backfilled_count = result["detected"]
+    else:
+        backfilled_count = 0
     db.commit()
 
-    return CreatePocketResponse(account_id=account.id, backfilled_count=backfilled)
+    return CreatePocketResponse(account_id=account.id, backfilled_count=backfilled_count)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -1,16 +1,134 @@
+import re
+from decimal import Decimal
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 from sqlalchemy import or_
 from typing import List, Optional
 from uuid import UUID
 
 from app.database import get_db
-from app.models import Account
+from app.models import Account, Transaction
 from app.db_helpers import get_user_id
 from app.schemas import AccountCreate, AccountResponse, AccountUpdate
-from app.security.data_encryption import blind_index_candidates, decrypt_with_fallback
+from app.security.data_encryption import (
+    blind_index,
+    blind_index_candidates,
+    decrypt_with_fallback,
+    encrypt_value,
+)
+from app.services.internal_transfer_service import InternalTransferService
 
 router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Pocket account registration
+# ---------------------------------------------------------------------------
+
+_IBAN_RE = re.compile(r"^[A-Z]{2}\d{2}[A-Z0-9]{10,30}$")
+
+
+class CreatePocketRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    account_type: str = "savings"
+    currency: str = "EUR"
+    starting_balance: Decimal = Decimal("0")
+    iban: str
+
+    @field_validator("iban")
+    @classmethod
+    def _normalize_iban(cls, v: str) -> str:
+        norm = v.replace(" ", "").upper()
+        if not (15 <= len(norm) <= 34) or not _IBAN_RE.match(norm):
+            raise ValueError("Invalid IBAN format")
+        return norm
+
+
+class CreatePocketResponse(BaseModel):
+    account_id: UUID
+    backfilled_count: int
+
+
+@router.post("/pocket", response_model=CreatePocketResponse)
+def create_pocket_account(
+    payload: CreatePocketRequest,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a manual pocket account identified by IBAN and immediately backfill
+    any pre-existing transactions whose counterparty IBAN matches.
+
+    Pockets are user-owned, manually-registered accounts (provider="manual")
+    used to represent money parked in a non-synced account the user transfers
+    to/from from a synced account. Matching is done via blind-indexed IBAN
+    hash so the plaintext IBAN is never compared directly.
+    """
+    iban_hash = blind_index(payload.iban)
+    if iban_hash is None:
+        raise HTTPException(
+            status_code=500,
+            detail="Encryption not configured — cannot register pocket",
+        )
+
+    # Scope the duplicate check to manual pockets only. If the user's synced
+    # bank accounts ever gain an iban_hash (not today), we still want this
+    # endpoint to refuse only pocket-vs-pocket collisions — not block a
+    # pocket from sharing an IBAN with a synced account.
+    existing = (
+        db.query(Account)
+        .filter(
+            Account.user_id == user_id,
+            Account.iban_hash == iban_hash,
+            Account.provider == "manual",
+        )
+        .first()
+    )
+    if existing is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="A pocket account with this IBAN is already registered",
+        )
+
+    account = Account(
+        user_id=user_id,
+        name=payload.name,
+        account_type=payload.account_type,
+        currency=payload.currency,
+        provider="manual",
+        starting_balance=payload.starting_balance,
+        functional_balance=payload.starting_balance,
+        iban_ciphertext=encrypt_value(payload.iban),
+        iban_hash=iban_hash,
+        is_active=True,
+    )
+    db.add(account)
+    db.flush()
+
+    # Backfill: find existing transactions whose counterparty matches this IBAN
+    candidate_ids = [
+        row[0]
+        for row in db.query(Transaction.id)
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.counterparty_iban_hash == iban_hash,
+            Transaction.internal_transfer_id.is_(None),
+        )
+        .all()
+    ]
+    # Commit semantics: InternalTransferService.detect_for_transactions commits
+    # internally when it actually persists matches (detected > 0). We still
+    # commit here unconditionally so the new Account row is persisted even on
+    # the zero-match path. A redundant commit on a clean session is a no-op.
+    backfilled = (
+        InternalTransferService(db, user_id=user_id).detect_for_transactions(candidate_ids)
+        if candidate_ids
+        else 0
+    )
+    db.commit()
+
+    return CreatePocketResponse(account_id=account.id, backfilled_count=backfilled)
 
 
 def _serialize_account(account: Account) -> AccountResponse:

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -1,6 +1,6 @@
 import re
 from decimal import Decimal
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 from sqlalchemy import or_
@@ -131,6 +131,33 @@ def create_pocket_account(
     return CreatePocketResponse(account_id=account.id, backfilled_count=backfilled)
 
 
+# ---------------------------------------------------------------------------
+# Internal transfer unlink
+# ---------------------------------------------------------------------------
+
+
+@router.delete(
+    "/internal-transfers/{transfer_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def unlink_internal_transfer(
+    transfer_id: UUID,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Unlink a detected internal transfer.
+
+    Deletes the mirror transaction, clears the source's ``internal_transfer_id``
+    and sets ``include_in_analytics=True``, then deletes the ``internal_transfers``
+    row. The ``InternalTransferService.unlink`` method silently no-ops if the id
+    is unknown or belongs to a different user, so we return 204 unconditionally
+    — this is intentional and does not leak info (users can't learn whether a
+    link exists for another user).
+    """
+    InternalTransferService(db, user_id=user_id).unlink(transfer_id)
+    return None
+
+
 def _serialize_account(account: Account) -> AccountResponse:
     return AccountResponse(
         id=account.id,
@@ -249,22 +276,53 @@ def update_account(
     return _serialize_account(account)
 
 
-@router.delete("/{account_id}", status_code=204)
+@router.delete("/{account_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_account(
     account_id: UUID,
-    user_id: Optional[str] = None,
-    db: Session = Depends(get_db)
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
 ):
-    """Delete (deactivate) an account."""
-    user_id = get_user_id(user_id)
-    account = db.query(Account).filter(
-        Account.id == account_id,
-        Account.user_id == user_id
-    ).first()
-    if not account:
+    """Hard-delete an account.
+
+    For pocket accounts (``provider="manual"``) with linked internal transfers,
+    unlink the source transactions first (restoring ``include_in_analytics=True``
+    and clearing ``internal_transfer_id``) so the cascade that follows doesn't
+    leave orphan sources with stale analytics flags. Mirror transactions on the
+    pocket are deleted by the ``ON DELETE CASCADE`` on ``transactions.account_id``
+    when the account row is removed.
+
+    For non-pocket accounts ``unlink_all_for_pocket`` is a no-op (no links point
+    at them by definition).
+    """
+    account = (
+        db.query(Account)
+        .filter(Account.id == account_id, Account.user_id == user_id)
+        .one_or_none()
+    )
+    if account is None:
         raise HTTPException(status_code=404, detail="Account not found")
 
-    account.is_active = False
+    # Unlink any internal transfers pointing to this account before cascade
+    InternalTransferService(db, user_id=user_id).unlink_all_for_pocket(account_id)
+
+    # Explicitly delete the account's transactions. The DB has ON DELETE CASCADE
+    # on transactions.account_id, but SQLAlchemy's default relationship behavior
+    # (no passive_deletes=True on Account.transactions) tries to NULL the
+    # children first, which violates the NOT NULL constraint. Bulk-delete them
+    # ourselves to mirror what the cascade would do.
+    #
+    # NOTE: This bulk delete bypasses ORM-level `before_delete` events on
+    # Transaction. All current Transaction children (transaction_links,
+    # internal_transfers, recurring_transaction refs, csv_import refs) rely on
+    # DB-level ON DELETE CASCADE / SET NULL, so this is safe today. If anyone
+    # later adds a Python-level event listener or cascade="delete-orphan" on
+    # Transaction, this path must switch to per-row deletion.
+    db.query(Transaction).filter(
+        Transaction.user_id == user_id,
+        Transaction.account_id == account_id,
+    ).delete(synchronize_session=False)
+
+    db.delete(account)
     db.commit()
     return None
 

--- a/backend/app/services/internal_transfer_service.py
+++ b/backend/app/services/internal_transfer_service.py
@@ -1,0 +1,256 @@
+"""Detect and manage internal transfers between the user's synced accounts
+and their manually-registered pocket accounts.
+
+Matching is done by counterparty IBAN blind index: transactions whose
+`counterparty_iban_hash` matches a manual account's `iban_hash` are linked to
+that pocket, and a mirror transaction is created on the pocket side.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.models import Account, Category, InternalTransfer, Transaction
+
+logger = logging.getLogger(__name__)
+
+
+class InternalTransferService:
+    """Service for detecting and managing internal transfers.
+
+    Constructor intentionally mirrors the minimal convention used by other
+    services: ``(db, user_id)``. No feature flags.
+    """
+
+    def __init__(self, db: Session, user_id: str):
+        self.db = db
+        self.user_id = user_id
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_pocket_map(self) -> Dict[str, Account]:
+        """Return ``{iban_hash: pocket_account}`` for this user's active manual
+        accounts that have an IBAN hash recorded.
+        """
+        pockets = (
+            self.db.query(Account)
+            .filter(
+                Account.user_id == self.user_id,
+                Account.provider == "manual",
+                Account.iban_hash.isnot(None),
+                Account.is_active.is_(True),
+            )
+            .all()
+        )
+        return {p.iban_hash: p for p in pockets}
+
+    def _resolve_transfer_category_id(self) -> Optional[UUID]:
+        cat = (
+            self.db.query(Category)
+            .filter(
+                Category.user_id == self.user_id,
+                Category.category_type == "transfer",
+            )
+            .order_by(Category.is_system.desc(), Category.created_at.asc())
+            .first()
+        )
+        return cat.id if cat else None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def detect_for_transactions(self, transaction_ids: List[UUID]) -> int:
+        """Inspect the given transactions and, for each whose counterparty IBAN
+        matches one of the user's pocket accounts, create a mirror transaction
+        on the pocket and an ``internal_transfers`` link row.
+
+        Returns the number of transfers detected (newly linked).
+        """
+        if not transaction_ids:
+            return 0
+
+        pocket_map = self._load_pocket_map()
+        if not pocket_map:
+            return 0
+
+        # Eager-load the source account so we can build a descriptive mirror
+        # description without extra queries per-source.
+        sources = (
+            self.db.query(Transaction)
+            .options(joinedload(Transaction.account))
+            .filter(
+                Transaction.id.in_(transaction_ids),
+                Transaction.user_id == self.user_id,
+                Transaction.counterparty_iban_hash.isnot(None),
+                Transaction.internal_transfer_id.is_(None),
+            )
+            .all()
+        )
+
+        transfer_category_id = self._resolve_transfer_category_id()
+        if transfer_category_id is None:
+            logger.warning(
+                "[INTERNAL_TRANSFER] No Transfer category found for user %s — "
+                "mirror transactions will be created without a system category",
+                self.user_id,
+            )
+        detected = 0
+
+        for src in sources:
+            pocket = pocket_map.get(src.counterparty_iban_hash)
+            if pocket is None or pocket.id == src.account_id:
+                continue
+
+            mirror_amount = -src.amount
+            mirror_functional = (
+                -src.functional_amount if src.functional_amount is not None else None
+            )
+
+            src_account_name = getattr(src.account, "name", None) or "account"
+            description = (
+                f"Transfer from {src_account_name}"
+                if mirror_amount > 0
+                else f"Transfer to {src_account_name}"
+            )
+
+            mirror = Transaction(
+                user_id=self.user_id,
+                account_id=pocket.id,
+                external_id=f"mirror-{src.id}",
+                amount=mirror_amount,
+                currency=src.currency,
+                functional_amount=mirror_functional,
+                description=description,
+                merchant=src_account_name,
+                booked_at=src.booked_at,
+                transaction_type="credit" if mirror_amount > 0 else "debit",
+                category_system_id=transfer_category_id,
+                include_in_analytics=False,
+            )
+            self.db.add(mirror)
+            self.db.flush()  # assigns mirror.id
+
+            link = InternalTransfer(
+                user_id=self.user_id,
+                source_txn_id=src.id,
+                mirror_txn_id=mirror.id,
+                source_account_id=src.account_id,
+                pocket_account_id=pocket.id,
+                amount=abs(src.amount),
+                currency=src.currency,
+            )
+            self.db.add(link)
+            self.db.flush()  # assigns link.id (server_default gen_random_uuid())
+
+            src.include_in_analytics = False
+            src.internal_transfer_id = link.id
+            # Detection is authoritative: overwrite any prior LLM-assigned
+            # system category with Transfer. We only defer to the user's
+            # explicit category_id override (left untouched below).
+            if transfer_category_id and src.category_id is None:
+                src.category_system_id = transfer_category_id
+
+            detected += 1
+
+        if detected:
+            self.db.commit()
+
+        logger.info(
+            "[INTERNAL_TRANSFER] Detected %d transfer(s) for user %s",
+            detected,
+            self.user_id,
+        )
+        return detected
+
+    def unlink(self, internal_transfer_id: UUID) -> None:
+        """Reverse a single detection: restore the source, delete the mirror,
+        and delete the ``internal_transfers`` row.
+        """
+        link = (
+            self.db.query(InternalTransfer)
+            .filter(
+                InternalTransfer.id == internal_transfer_id,
+                InternalTransfer.user_id == self.user_id,
+            )
+            .one_or_none()
+        )
+        if link is None:
+            return
+
+        src = (
+            self.db.query(Transaction)
+            .filter(Transaction.id == link.source_txn_id)
+            .one_or_none()
+        )
+        if src is not None:
+            src.include_in_analytics = True
+            src.internal_transfer_id = None
+
+        if link.mirror_txn_id is not None:
+            mirror = (
+                self.db.query(Transaction)
+                .filter(Transaction.id == link.mirror_txn_id)
+                .one_or_none()
+            )
+            if mirror is not None:
+                self.db.delete(mirror)
+            else:
+                logger.warning(
+                    "[INTERNAL_TRANSFER] Mirror %s for link %s already gone — "
+                    "link was pointing at a deleted transaction",
+                    link.mirror_txn_id,
+                    link.id,
+                )
+
+        # Flush deletion of the mirror BEFORE deleting the link so the
+        # transactions.internal_transfer_id -> internal_transfers.id FK
+        # (ON DELETE SET NULL) does not become ambiguous under some drivers.
+        self.db.flush()
+        self.db.delete(link)
+        self.db.commit()
+
+    def unlink_all_for_pocket(self, pocket_account_id: UUID) -> int:
+        """Remove all ``internal_transfers`` rows that point at the given pocket,
+        restoring each source transaction's analytics flag.
+
+        **IMPORTANT — call contract:** this is the pre-delete cleanup hook. The
+        caller MUST delete the pocket account itself immediately after a
+        successful return. Mirror transactions (the ones on the pocket side)
+        are NOT deleted here — they depend on the ``ON DELETE CASCADE`` from
+        ``transactions.account_id`` when the pocket row is removed. If you call
+        this method and do NOT delete the pocket, orphan mirror transactions
+        will remain on the pocket account with no linking ``internal_transfers``
+        row, and analytics will misreport the pocket's activity.
+
+        Returns the number of links removed.
+        """
+        links = (
+            self.db.query(InternalTransfer)
+            .filter(
+                InternalTransfer.pocket_account_id == pocket_account_id,
+                InternalTransfer.user_id == self.user_id,
+            )
+            .all()
+        )
+        count = 0
+        for link in links:
+            src = (
+                self.db.query(Transaction)
+                .filter(Transaction.id == link.source_txn_id)
+                .one_or_none()
+            )
+            if src is not None:
+                src.include_in_analytics = True
+                src.internal_transfer_id = None
+            self.db.delete(link)
+            count += 1
+
+        if count:
+            self.db.commit()
+        return count

--- a/backend/app/services/internal_transfer_service.py
+++ b/backend/app/services/internal_transfer_service.py
@@ -65,19 +65,26 @@ class InternalTransferService:
     # Public API
     # ------------------------------------------------------------------
 
-    def detect_for_transactions(self, transaction_ids: List[UUID]) -> int:
+    def detect_for_transactions(self, transaction_ids: List[UUID]) -> dict:
         """Inspect the given transactions and, for each whose counterparty IBAN
         matches one of the user's pocket accounts, create a mirror transaction
         on the pocket and an ``internal_transfers`` link row.
 
-        Returns the number of transfers detected (newly linked).
+        Returns ``{"detected": int, "pocket_account_ids": list[UUID]}``. The
+        ``pocket_account_ids`` set is what callers need to extend their balance
+        / timeseries recalculation scope to include touched pockets.
+
+        Only transactions that are currently ``include_in_analytics=True`` are
+        considered — user-hidden rows are preserved as-is, and restoring
+        ``include_in_analytics=True`` on unlink is then the correct inverse.
         """
+        empty_result = {"detected": 0, "pocket_account_ids": []}
         if not transaction_ids:
-            return 0
+            return empty_result
 
         pocket_map = self._load_pocket_map()
         if not pocket_map:
-            return 0
+            return empty_result
 
         # Eager-load the source account so we can build a descriptive mirror
         # description without extra queries per-source.
@@ -89,6 +96,10 @@ class InternalTransferService:
                 Transaction.user_id == self.user_id,
                 Transaction.counterparty_iban_hash.isnot(None),
                 Transaction.internal_transfer_id.is_(None),
+                # Preserve user-hidden rows. Only link transactions currently
+                # in analytics — detection sets them to False, and unlink
+                # restores them to True (the correct inverse).
+                Transaction.include_in_analytics.is_(True),
             )
             .all()
         )
@@ -101,6 +112,7 @@ class InternalTransferService:
                 self.user_id,
             )
         detected = 0
+        touched_pockets: set = set()
 
         for src in sources:
             pocket = pocket_map.get(src.counterparty_iban_hash)
@@ -156,6 +168,7 @@ class InternalTransferService:
             if transfer_category_id and src.category_id is None:
                 src.category_system_id = transfer_category_id
 
+            touched_pockets.add(pocket.id)
             detected += 1
 
         if detected:
@@ -166,7 +179,10 @@ class InternalTransferService:
             detected,
             self.user_id,
         )
-        return detected
+        return {
+            "detected": detected,
+            "pocket_account_ids": list(touched_pockets),
+        }
 
     def unlink(self, internal_transfer_id: UUID) -> None:
         """Reverse a single detection: restore the source, delete the mirror,

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -250,6 +250,12 @@ class SyncService:
                 existing_transaction.booked_at = transaction_data.booked_at
                 existing_transaction.transaction_type = transaction_data.transaction_type
                 existing_transaction.pending = transaction_data.pending
+                if transaction_data.counterparty_iban:
+                    existing_transaction.counterparty_iban_ciphertext = encrypt_value(transaction_data.counterparty_iban)
+                    existing_transaction.counterparty_iban_hash = blind_index(transaction_data.counterparty_iban)
+                else:
+                    existing_transaction.counterparty_iban_ciphertext = None
+                    existing_transaction.counterparty_iban_hash = None
                 if not existing_transaction.category_id and not existing_transaction.category_system_id and category:
                     existing_transaction.category_system_id = category.id
                 if not existing_transaction.recurring_transaction_id and matched_subscription:
@@ -274,6 +280,12 @@ class SyncService:
                     pending_match.merchant = merchant or transaction_data.merchant
                     pending_match.creditor = transaction_data.creditor
                     pending_match.debtor = transaction_data.debtor
+                    if transaction_data.counterparty_iban:
+                        pending_match.counterparty_iban_ciphertext = encrypt_value(transaction_data.counterparty_iban)
+                        pending_match.counterparty_iban_hash = blind_index(transaction_data.counterparty_iban)
+                    else:
+                        pending_match.counterparty_iban_ciphertext = None
+                        pending_match.counterparty_iban_hash = None
                     if not pending_match.category_id and not pending_match.category_system_id and category:
                         pending_match.category_system_id = category.id
                     if not pending_match.recurring_transaction_id and matched_subscription:
@@ -320,6 +332,8 @@ class SyncService:
                 pending=transaction_data.pending,
                 category_system_id=category.id if category else None,
                 recurring_transaction_id=matched_subscription.id if matched_subscription else None,
+                counterparty_iban_ciphertext=encrypt_value(transaction_data.counterparty_iban) if transaction_data.counterparty_iban else None,
+                counterparty_iban_hash=blind_index(transaction_data.counterparty_iban) if transaction_data.counterparty_iban else None,
             )
             self.db.add(new_transaction)
             self.db.flush()
@@ -417,7 +431,6 @@ class SyncService:
 
         # For Revolut, permanently delete old "Revolut default" accounts if they exist
         if provider == 'revolut':
-            from app.models import Transaction
             old_default_accounts = self.db.query(Account).filter(
                 Account.user_id == self.user_id,
                 Account.provider == 'revolut',
@@ -556,6 +569,12 @@ class SyncService:
             existing_transaction.booked_at = transaction_data.booked_at
             existing_transaction.transaction_type = transaction_data.transaction_type
             existing_transaction.pending = transaction_data.pending
+            if transaction_data.counterparty_iban:
+                existing_transaction.counterparty_iban_ciphertext = encrypt_value(transaction_data.counterparty_iban)
+                existing_transaction.counterparty_iban_hash = blind_index(transaction_data.counterparty_iban)
+            else:
+                existing_transaction.counterparty_iban_ciphertext = None
+                existing_transaction.counterparty_iban_hash = None
 
             # Only set category if neither user override nor AI category is already present.
             if not existing_transaction.category_id and not existing_transaction.category_system_id and category:
@@ -588,6 +607,8 @@ class SyncService:
                 pending=transaction_data.pending,
                 category_system_id=category.id if category else None,
                 recurring_transaction_id=matched_subscription.id if matched_subscription else None,
+                counterparty_iban_ciphertext=encrypt_value(transaction_data.counterparty_iban) if transaction_data.counterparty_iban else None,
+                counterparty_iban_hash=blind_index(transaction_data.counterparty_iban) if transaction_data.counterparty_iban else None,
             )
             self.db.add(new_transaction)
             self.db.commit()

--- a/backend/tasks/post_import_pipeline.py
+++ b/backend/tasks/post_import_pipeline.py
@@ -122,11 +122,16 @@ def _update_functional_amounts(db, user_id: str, transaction_ids: List[str]) -> 
     db.commit()
 
 
-def _detect_internal_transfers(db, user_id: str, transaction_ids: List[str]) -> int:
+def _detect_internal_transfers(db, user_id: str, transaction_ids: List[str]) -> dict:
     """Detect counterparty-IBAN matches against the user's manual pocket accounts
-    and create mirror transactions on the pocket side. Returns count detected."""
+    and create mirror transactions on the pocket side.
+
+    Returns ``{"detected": int, "pocket_account_ids": list[UUID]}``. Callers
+    should extend their balance/timeseries account scope with
+    ``pocket_account_ids`` so mirrored pockets get recalculated.
+    """
     if not transaction_ids:
-        return 0
+        return {"detected": 0, "pocket_account_ids": []}
     service = InternalTransferService(db, user_id=user_id)
     return service.detect_for_transactions(transaction_ids)
 
@@ -309,17 +314,28 @@ def _run_post_import_pipeline(
         _update_functional_amounts(db, user_id, transaction_ids)
 
         # Step 3: Internal transfer detection (must run before LLM categorization)
-        detected = _detect_internal_transfers(db, user_id, transaction_ids)
-        logger.info("[POST_IMPORT_PIPELINE] Internal transfers detected: %d", detected)
+        detection = _detect_internal_transfers(db, user_id, transaction_ids)
+        logger.info(
+            "[POST_IMPORT_PIPELINE] Internal transfers detected: %d (touched %d pocket(s))",
+            detection["detected"],
+            len(detection["pocket_account_ids"]),
+        )
+
+        # Mirror transactions created in step 3 live on the pocket account; if
+        # that pocket isn't in the sync's original account_ids scope, its
+        # balance and timeseries won't be refreshed. Extend the recalc set to
+        # include every pocket we just mirrored into.
+        touched_pocket_ids = [str(pid) for pid in detection["pocket_account_ids"]]
+        recalc_account_ids = list({*account_ids, *touched_pocket_ids})
 
         # Step 4: Batch AI categorization (overwrites wrong system categories; preserves user overrides)
         _batch_categorize_transactions(db, user_id, transaction_ids)
 
         # Step 5: Balance calculation
-        _calculate_balances(db, user_id, account_ids)
+        _calculate_balances(db, user_id, recalc_account_ids)
 
         # Step 6: Balance timeseries
-        _calculate_timeseries(db, user_id, account_ids)
+        _calculate_timeseries(db, user_id, recalc_account_ids)
 
         # Step 7: Subscription detection
         # For initial sync, pass None so the detector scans ALL user transactions

--- a/backend/tasks/post_import_pipeline.py
+++ b/backend/tasks/post_import_pipeline.py
@@ -1,13 +1,14 @@
 """
 Shared post-import pipeline Celery task.
 
-Runs 6 post-processing steps in order after any transaction import (CSV or Enable Banking):
+Runs 7 post-processing steps in order after any transaction import (CSV or Enable Banking):
   1. FX rate sync
   2. Functional amount calculation
-  3. Batch AI categorization (for transactions without a user-assigned category)
-  4. Balance calculation
-  5. Balance timeseries
-  6. Subscription detection
+  3. Internal transfer detection (create mirrors, flag both sides as non-analytics)
+  4. Batch AI categorization (for transactions without a user-assigned category)
+  5. Balance calculation
+  6. Balance timeseries
+  7. Subscription detection
 """
 import logging
 from datetime import datetime
@@ -24,6 +25,7 @@ from app.services.account_balance_service import AccountBalanceService
 from app.services.subscription_matcher import SubscriptionMatcher
 from app.services.subscription_detector import SubscriptionDetector
 from app.services.category_matcher import CategoryMatcher
+from app.services.internal_transfer_service import InternalTransferService
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +122,15 @@ def _update_functional_amounts(db, user_id: str, transaction_ids: List[str]) -> 
     db.commit()
 
 
+def _detect_internal_transfers(db, user_id: str, transaction_ids: List[str]) -> int:
+    """Detect counterparty-IBAN matches against the user's manual pocket accounts
+    and create mirror transactions on the pocket side. Returns count detected."""
+    if not transaction_ids:
+        return 0
+    service = InternalTransferService(db, user_id=user_id)
+    return service.detect_for_transactions(transaction_ids)
+
+
 def _batch_categorize_transactions(db, user_id: str, transaction_ids: List[str]) -> None:
     """Batch AI categorize touched transactions that have no user-assigned category.
 
@@ -136,6 +147,9 @@ def _batch_categorize_transactions(db, user_id: str, transaction_ids: List[str])
             Transaction.id.in_(transaction_ids),
             Transaction.user_id == user_id,
             Transaction.category_id.is_(None),  # Preserve user-assigned categories
+            # Skip transactions excluded from analytics — covers internal
+            # transfers (set by step 3) AND user-hidden rows (set via UI).
+            Transaction.include_in_analytics.is_(True),
         )
         .all()
     )
@@ -294,15 +308,20 @@ def _run_post_import_pipeline(
         # Step 2: Functional amount calculation
         _update_functional_amounts(db, user_id, transaction_ids)
 
-        # Step 3: Batch AI categorization (overwrites wrong system categories; preserves user overrides)
+        # Step 3: Internal transfer detection (must run before LLM categorization)
+        detected = _detect_internal_transfers(db, user_id, transaction_ids)
+        logger.info("[POST_IMPORT_PIPELINE] Internal transfers detected: %d", detected)
+
+        # Step 4: Batch AI categorization (overwrites wrong system categories; preserves user overrides)
         _batch_categorize_transactions(db, user_id, transaction_ids)
 
-        # Step 4: Balance calculation
+        # Step 5: Balance calculation
         _calculate_balances(db, user_id, account_ids)
 
-        # Step 5: Balance timeseries
+        # Step 6: Balance timeseries
         _calculate_timeseries(db, user_id, account_ids)
 
+        # Step 7: Subscription detection
         # For initial sync, pass None so the detector scans ALL user transactions
         effective_txn_ids = None if is_initial_sync else transaction_ids
         _detect_subscriptions(db, user_id, effective_txn_ids, account_ids)

--- a/backend/tests/test_account_sync_encryption.py
+++ b/backend/tests/test_account_sync_encryption.py
@@ -113,7 +113,128 @@ def test_account_sync_dedupes_on_encrypted_external_id() -> bool:
         db.close()
 
 
+class _IBANAdapter(BankAdapter):
+    """Minimal adapter that returns a single transaction with a counterparty IBAN."""
+
+    def __init__(self, account_external_id: str, iban: Optional[str] = "NL91ABNA0417164300") -> None:
+        self._account_external_id = account_external_id
+        self._iban = iban
+
+    def fetch_accounts(self) -> list[AccountData]:
+        return [
+            AccountData(
+                external_id=self._account_external_id,
+                name="IBAN Test Account",
+                account_type="checking",
+                institution="Test Bank",
+                currency="EUR",
+                balance_available=Decimal("0.00"),
+            )
+        ]
+
+    def fetch_transactions(
+        self,
+        account_external_id: str,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+    ) -> list[TransactionData]:
+        from datetime import timezone
+        return [
+            TransactionData(
+                external_id="ext-iban-1",
+                account_external_id=account_external_id,
+                amount=Decimal("-10.00"),
+                currency="EUR",
+                description="IBAN test transaction",
+                counterparty_iban=self._iban,
+                booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                transaction_type="debit",
+            )
+        ]
+
+    def normalize_transaction(self, raw: dict) -> TransactionData:
+        raise NotImplementedError
+
+
+def test_sync_service_persists_encrypted_counterparty_iban() -> bool:
+    _set_encryption_env()
+    Base.metadata.create_all(bind=engine)
+
+    from app.models import Transaction
+    from app.security.data_encryption import decrypt_value, blind_index
+
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        user = get_or_create_system_user(db)
+        user_id = str(user.id)
+
+        # Clean up any leftover rows from prior runs
+        provider = "iban-enc-test"
+        existing_accounts = db.query(Account).filter(
+            Account.user_id == user_id,
+            Account.provider == provider,
+        ).all()
+        for acc in existing_accounts:
+            db.query(Transaction).filter(Transaction.account_id == acc.id).delete()
+        db.query(Account).filter(
+            Account.user_id == user_id,
+            Account.provider == provider,
+        ).delete()
+        db.commit()
+
+        token = set_request_user_id(user_id)
+        service = SyncService(db, user_id=user_id, use_llm_categorization=False)
+        adapter = _IBANAdapter(account_external_id="iban-test-acct-001")
+
+        try:
+            service.sync_all(adapter, provider=provider)
+        finally:
+            clear_request_user_id(token)
+
+        row = db.query(Transaction).join(Account).filter(
+            Account.user_id == user_id,
+            Account.provider == provider,
+            Transaction.external_id == "ext-iban-1",
+        ).first()
+
+        assert row is not None, "Transaction row should have been created."
+        assert row.counterparty_iban_ciphertext is not None, (
+            f"counterparty_iban_ciphertext should not be None, got: {row.counterparty_iban_ciphertext!r}"
+        )
+        assert row.counterparty_iban_ciphertext.startswith("enc:v1:"), (
+            f"Unexpected ciphertext format: {row.counterparty_iban_ciphertext!r}"
+        )
+        assert decrypt_value(row.counterparty_iban_ciphertext) == "NL91ABNA0417164300", (
+            "Decrypted IBAN should match the original value."
+        )
+        assert row.counterparty_iban_hash == blind_index("NL91ABNA0417164300"), (
+            "Blind index should match expected HMAC."
+        )
+
+        print("✓ sync service persists encrypted counterparty IBAN + blind index")
+        return True
+    finally:
+        if user_id:
+            provider = "iban-enc-test"
+            existing_accounts = db.query(Account).filter(
+                Account.user_id == user_id,
+                Account.provider == provider,
+            ).all()
+            for acc in existing_accounts:
+                db.query(Transaction).filter(Transaction.account_id == acc.id).delete()
+            db.query(Account).filter(
+                Account.user_id == user_id,
+                Account.provider == provider,
+            ).delete()
+            db.commit()
+        db.close()
+        reset_encryption_config_cache()
+
+
 if __name__ == "__main__":
     success = test_account_sync_dedupes_on_encrypted_external_id()
-    print("All encrypted account sync tests passed." if success else "Encrypted account sync tests failed.")
-    sys.exit(0 if success else 1)
+    success2 = test_sync_service_persists_encrypted_counterparty_iban()
+    all_passed = success and success2
+    print("All encrypted account sync tests passed." if all_passed else "Encrypted account sync tests failed.")
+    sys.exit(0 if all_passed else 1)

--- a/backend/tests/test_enable_banking_adapter.py
+++ b/backend/tests/test_enable_banking_adapter.py
@@ -90,5 +90,92 @@ class TestMapAccountType(unittest.TestCase):
         self.assertEqual(self.adapter._map_account_type(None), "checking")
 
 
+class TestCounterpartyIban(unittest.TestCase):
+    def setUp(self):
+        self.adapter = EnableBankingAdapter.__new__(EnableBankingAdapter)
+
+    def test_normalize_extracts_counterparty_iban_from_creditor_account_iban(self):
+        raw = {
+            "transaction_id": "tx-1",
+            "account_id": "acc-1",
+            "transaction_amount": {"amount": "12.50", "currency": "EUR"},
+            "credit_debit_indicator": "DBIT",
+            "booking_date": "2026-04-01",
+            "creditor_account": {"iban": "NL91 ABNA 0417 1643 00"},
+            "debtor_account": {"iban": "NL02 RABO 0123 4567 89"},
+            "creditor": {"name": "Some Merchant"},
+        }
+        txn = self.adapter.normalize_transaction(raw)
+        # Outflow (DBIT) → counterparty is the creditor IBAN, stripped of spaces and upper-cased
+        self.assertEqual(txn.counterparty_iban, "NL91ABNA0417164300")
+
+    def test_normalize_extracts_counterparty_iban_from_nested_debtor(self):
+        raw = {
+            "transaction_id": "tx-2",
+            "account_id": "acc-1",
+            "transaction_amount": {"amount": "5.00", "currency": "EUR"},
+            "credit_debit_indicator": "CRDT",
+            "booking_date": "2026-04-01",
+            "creditor_account": None,
+            "debtor_account": None,
+            "debtor": {"name": "Friend", "iban": "BE68539007547034"},
+        }
+        txn = self.adapter.normalize_transaction(raw)
+        # Inflow (CRDT) → counterparty is the debtor IBAN
+        self.assertEqual(txn.counterparty_iban, "BE68539007547034")
+
+    def test_normalize_handles_missing_iban_gracefully(self):
+        raw = {
+            "transaction_id": "tx-3",
+            "account_id": "acc-1",
+            "transaction_amount": {"amount": "5.00", "currency": "EUR"},
+            "credit_debit_indicator": "DBIT",
+            "booking_date": "2026-04-01",
+        }
+        txn = self.adapter.normalize_transaction(raw)
+        self.assertIsNone(txn.counterparty_iban)
+
+    def test_normalize_ignores_non_iban_scheme(self):
+        """BBAN / SORT and other non-IBAN schemes must NOT be extracted."""
+        raw = {
+            "transaction_id": "tx-4",
+            "account_id": "acc-1",
+            "transaction_amount": {"amount": "5.00", "currency": "EUR"},
+            "credit_debit_indicator": "DBIT",
+            "booking_date": "2026-04-01",
+            "creditor_account": {"scheme_name": "BBAN", "identification": "12345678"},
+        }
+        txn = self.adapter.normalize_transaction(raw)
+        self.assertIsNone(txn.counterparty_iban)
+
+    def test_normalize_scheme_form_missing_identification(self):
+        """``scheme_name: IBAN`` without ``identification`` must return None, not raise."""
+        raw = {
+            "transaction_id": "tx-5",
+            "account_id": "acc-1",
+            "transaction_amount": {"amount": "5.00", "currency": "EUR"},
+            "credit_debit_indicator": "DBIT",
+            "booking_date": "2026-04-01",
+            "creditor_account": {"scheme_name": "IBAN"},
+        }
+        txn = self.adapter.normalize_transaction(raw)
+        self.assertIsNone(txn.counterparty_iban)
+
+    def test_normalize_creditor_account_takes_precedence_over_nested_creditor(self):
+        """When both ``creditor_account`` and ``creditor`` carry an IBAN, the account
+        object wins — it is authoritative."""
+        raw = {
+            "transaction_id": "tx-6",
+            "account_id": "acc-1",
+            "transaction_amount": {"amount": "5.00", "currency": "EUR"},
+            "credit_debit_indicator": "DBIT",
+            "booking_date": "2026-04-01",
+            "creditor_account": {"iban": "NL91ABNA0417164300"},
+            "creditor": {"name": "Some Merchant", "iban": "DE89370400440532013000"},
+        }
+        txn = self.adapter.normalize_transaction(raw)
+        self.assertEqual(txn.counterparty_iban, "NL91ABNA0417164300")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_internal_transfer_service.py
+++ b/backend/tests/test_internal_transfer_service.py
@@ -1,0 +1,633 @@
+"""
+Tests for InternalTransferService.
+
+Run with:
+    cd backend && pytest tests/test_internal_transfer_service.py -v
+or:
+    cd backend && python tests/test_internal_transfer_service.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+# Ensure backend/ is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.database import Base, SessionLocal, engine  # noqa: E402
+from app.models import (  # noqa: E402
+    Account,
+    Category,
+    InternalTransfer,
+    Transaction,
+    User,
+)
+from app.security.data_encryption import blind_index  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+POCKET_IBAN = "NL91ABNA0417164300"
+UNRELATED_IBAN = "DE89370400440532013000"
+
+
+def _ensure_schema() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def _make_user(db) -> User:
+    uid = f"itf-test-user-{uuid.uuid4().hex[:8]}"
+    user = User(
+        id=uid,
+        email=f"{uid}@example.com",
+        name="Internal Transfer Test User",
+        email_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_synced_account(db, user_id: str, name: str = "Checking") -> Account:
+    acc = Account(
+        user_id=user_id,
+        name=name,
+        account_type="checking",
+        institution="Test Bank",
+        currency="EUR",
+        provider="enable_banking",
+        external_id=f"ext-{uuid.uuid4().hex[:12]}",
+        is_active=True,
+        starting_balance=Decimal("0"),
+    )
+    db.add(acc)
+    db.commit()
+    db.refresh(acc)
+    return acc
+
+
+def _make_pocket_account(
+    db, user_id: str, iban: str, name: str = "Savings Pocket"
+) -> Account:
+    acc = Account(
+        user_id=user_id,
+        name=name,
+        account_type="savings",
+        institution="Manual",
+        currency="EUR",
+        provider="manual",
+        iban_hash=blind_index(iban),
+        is_active=True,
+        starting_balance=Decimal("0"),
+    )
+    db.add(acc)
+    db.commit()
+    db.refresh(acc)
+    return acc
+
+
+def _make_transfer_category(db, user_id: str) -> Category:
+    cat = Category(
+        user_id=user_id,
+        name="Transfer",
+        category_type="transfer",
+        is_system=True,
+    )
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+def _make_source_transaction(
+    db,
+    user_id: str,
+    account_id,
+    counterparty_iban: Optional[str],
+    amount: Decimal = Decimal("-150.00"),
+    currency: str = "EUR",
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        account_id=account_id,
+        external_id=f"src-{uuid.uuid4().hex[:12]}",
+        amount=amount,
+        currency=currency,
+        functional_amount=amount,
+        description="Source transfer",
+        merchant="Counterparty",
+        booked_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+        transaction_type="debit" if amount < 0 else "credit",
+        counterparty_iban_hash=blind_index(counterparty_iban) if counterparty_iban else None,
+        include_in_analytics=True,
+    )
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+    return tx
+
+
+def _cleanup_user(db, user_id: str) -> None:
+    # Delete in FK-safe order: transactions + internal_transfers must go before
+    # accounts, but transactions.internal_transfer_id -> internal_transfers uses
+    # ON DELETE SET NULL, and internal_transfers -> transactions uses CASCADE.
+    # Null-out the back-reference first so we can freely delete.
+    db.query(Transaction).filter(Transaction.user_id == user_id).update(
+        {Transaction.internal_transfer_id: None}, synchronize_session=False
+    )
+    db.query(InternalTransfer).filter(InternalTransfer.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Transaction).filter(Transaction.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Account).filter(Account.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Category).filter(Category.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(User).filter(User.id == user_id).delete(synchronize_session=False)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: detect creates mirror and marks source not in analytics
+# ---------------------------------------------------------------------------
+
+def test_detect_creates_mirror_and_marks_source_not_in_analytics() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        transfer_cat = _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id, name="Main Checking")
+        pocket = _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-200.00"),
+        )
+
+        service = InternalTransferService(db, user_id=user_id)
+        detected = service.detect_for_transactions([src.id])
+        assert detected == 1, f"Expected 1 detection, got {detected}"
+
+        db.refresh(src)
+        assert src.include_in_analytics is False
+        assert src.internal_transfer_id is not None
+
+        link = (
+            db.query(InternalTransfer)
+            .filter(InternalTransfer.id == src.internal_transfer_id)
+            .one()
+        )
+        assert link.source_txn_id == src.id
+        assert link.source_account_id == synced.id
+        assert link.pocket_account_id == pocket.id
+        assert Decimal(str(link.amount)) == Decimal("200.00")
+        assert link.currency == "EUR"
+
+        mirror = (
+            db.query(Transaction)
+            .filter(Transaction.id == link.mirror_txn_id)
+            .one()
+        )
+        assert mirror.account_id == pocket.id
+        assert Decimal(str(mirror.amount)) == Decimal("200.00")
+        assert mirror.currency == "EUR"
+        assert mirror.include_in_analytics is False
+        assert mirror.category_system_id == transfer_cat.id
+        assert mirror.external_id == f"mirror-{src.id}"
+        assert mirror.transaction_type == "credit"  # positive amount => credit
+        print("  PASS: test_detect_creates_mirror_and_marks_source_not_in_analytics")
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: detect is idempotent
+# ---------------------------------------------------------------------------
+
+def test_detect_is_idempotent() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id)
+        _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-50.00"),
+        )
+
+        service = InternalTransferService(db, user_id=user_id)
+        first = service.detect_for_transactions([src.id])
+        second = service.detect_for_transactions([src.id])
+
+        assert first == 1
+        assert second == 0, "Second detection should be a no-op"
+
+        mirrors = (
+            db.query(Transaction)
+            .filter(Transaction.external_id == f"mirror-{src.id}")
+            .all()
+        )
+        assert len(mirrors) == 1, f"Expected exactly one mirror, got {len(mirrors)}"
+
+        links = (
+            db.query(InternalTransfer)
+            .filter(InternalTransfer.source_txn_id == src.id)
+            .all()
+        )
+        assert len(links) == 1, f"Expected exactly one internal_transfer row, got {len(links)}"
+        print("  PASS: test_detect_is_idempotent")
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: detect skips when no matching pocket
+# ---------------------------------------------------------------------------
+
+def test_detect_skips_when_no_matching_pocket() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id)
+        # Pocket has a DIFFERENT IBAN
+        _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=UNRELATED_IBAN,  # no matching pocket
+            amount=Decimal("-75.00"),
+        )
+
+        service = InternalTransferService(db, user_id=user_id)
+        detected = service.detect_for_transactions([src.id])
+
+        assert detected == 0
+        db.refresh(src)
+        assert src.include_in_analytics is True
+        assert src.internal_transfer_id is None
+
+        links = db.query(InternalTransfer).filter(
+            InternalTransfer.user_id == user_id
+        ).count()
+        mirrors = db.query(Transaction).filter(
+            Transaction.external_id == f"mirror-{src.id}"
+        ).count()
+        assert links == 0
+        assert mirrors == 0
+        print("  PASS: test_detect_skips_when_no_matching_pocket")
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: unlink reverses detection
+# ---------------------------------------------------------------------------
+
+def test_unlink_reverses_detection() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id)
+        _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-120.00"),
+        )
+
+        service = InternalTransferService(db, user_id=user_id)
+        assert service.detect_for_transactions([src.id]) == 1
+
+        db.refresh(src)
+        transfer_id = src.internal_transfer_id
+        assert transfer_id is not None
+
+        service.unlink(transfer_id)
+
+        db.refresh(src)
+        assert src.include_in_analytics is True
+        assert src.internal_transfer_id is None
+
+        mirrors = (
+            db.query(Transaction)
+            .filter(Transaction.external_id == f"mirror-{src.id}")
+            .count()
+        )
+        assert mirrors == 0, "Mirror transaction should be deleted on unlink"
+
+        links = (
+            db.query(InternalTransfer)
+            .filter(InternalTransfer.id == transfer_id)
+            .count()
+        )
+        assert links == 0, "Internal transfer row should be deleted on unlink"
+        print("  PASS: test_unlink_reverses_detection")
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: unlink_all_for_pocket restores sources
+# ---------------------------------------------------------------------------
+
+def test_unlink_all_for_pocket_restores_sources() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id)
+        pocket = _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+
+        src_a = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-60.00"),
+        )
+        src_b = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-25.00"),
+        )
+
+        service = InternalTransferService(db, user_id=user_id)
+        assert service.detect_for_transactions([src_a.id, src_b.id]) == 2
+
+        unlinked = service.unlink_all_for_pocket(pocket.id)
+        assert unlinked == 2, f"Expected 2 unlinked, got {unlinked}"
+
+        db.refresh(src_a)
+        db.refresh(src_b)
+        assert src_a.include_in_analytics is True
+        assert src_a.internal_transfer_id is None
+        assert src_b.include_in_analytics is True
+        assert src_b.internal_transfer_id is None
+
+        remaining_links = (
+            db.query(InternalTransfer)
+            .filter(InternalTransfer.pocket_account_id == pocket.id)
+            .count()
+        )
+        assert remaining_links == 0
+        # NOTE: mirrors are NOT expected to be deleted here — cascade handles them
+        # when the pocket account itself is deleted. unlink_all_for_pocket's job
+        # is to detach the sources.
+        print("  PASS: test_unlink_all_for_pocket_restores_sources")
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: detection overwrites a stale LLM-assigned category_system_id
+# (authoritative overwrite; preserves only user-set category_id)
+# ---------------------------------------------------------------------------
+
+def test_detect_overwrites_stale_system_category() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        transfer_cat = _make_transfer_category(db, user_id)
+
+        # Seed an unrelated "Groceries" category that the LLM might have picked.
+        stale_cat = Category(
+            user_id=user_id,
+            name="Groceries",
+            category_type="expense",
+            is_system=True,
+        )
+        db.add(stale_cat)
+        db.commit()
+        db.refresh(stale_cat)
+
+        synced = _make_synced_account(db, user_id, name="Main Checking")
+        pocket = _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-75.00"),
+        )
+        # Simulate a prior LLM run: a stale system category is already set,
+        # and the user has NOT overridden (category_id is None).
+        src.category_system_id = stale_cat.id
+        db.commit()
+
+        service = InternalTransferService(db, user_id=user_id)
+        detected = service.detect_for_transactions([src.id])
+        assert detected == 1
+
+        db.refresh(src)
+        # Detection is authoritative — category_system_id flipped to Transfer.
+        assert src.category_system_id == transfer_cat.id, (
+            "Detection must overwrite a stale LLM system category with Transfer."
+        )
+        # User override untouched (still None).
+        assert src.category_id is None
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: detection preserves user category override
+# ---------------------------------------------------------------------------
+
+def test_detect_preserves_user_category_override() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        transfer_cat = _make_transfer_category(db, user_id)
+
+        user_cat = Category(
+            user_id=user_id,
+            name="My Custom",
+            category_type="expense",
+            is_system=False,
+        )
+        db.add(user_cat)
+        db.commit()
+        db.refresh(user_cat)
+
+        synced = _make_synced_account(db, user_id, name="Main Checking")
+        _ = _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-30.00"),
+        )
+        # User has explicitly chosen a category for this transaction.
+        src.category_id = user_cat.id
+        db.commit()
+
+        service = InternalTransferService(db, user_id=user_id)
+        assert service.detect_for_transactions([src.id]) == 1
+
+        db.refresh(src)
+        # Link was still created and analytics was flipped off,
+        # but the user's category_id MUST be preserved.
+        assert src.include_in_analytics is False
+        assert src.internal_transfer_id is not None
+        assert src.category_id == user_cat.id
+        # category_system_id is NOT overwritten when category_id is set.
+        # It may or may not be None depending on prior state — here we left it
+        # None, so it should stay None.
+        assert src.category_system_id is None
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: detection is strictly scoped to user — cross-user pockets never match
+# (security invariant; relies on the user_id filter in _load_pocket_map)
+# ---------------------------------------------------------------------------
+
+def test_detect_does_not_match_cross_user_pocket() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_a_id: Optional[str] = None
+    user_b_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user_a = _make_user(db)
+        user_a_id = user_a.id
+        user_b = _make_user(db)
+        user_b_id = user_b.id
+
+        # User B owns a pocket with the IBAN.
+        _make_transfer_category(db, user_b_id)
+        _ = _make_pocket_account(db, user_b_id, iban=POCKET_IBAN)
+
+        # User A has a transaction whose counterparty matches that IBAN.
+        _make_transfer_category(db, user_a_id)
+        synced_a = _make_synced_account(db, user_a_id, name="A's Checking")
+        src_a = _make_source_transaction(
+            db,
+            user_a_id,
+            synced_a.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-40.00"),
+        )
+
+        service_a = InternalTransferService(db, user_id=user_a_id)
+        assert service_a.detect_for_transactions([src_a.id]) == 0, (
+            "User A's detection must not link to User B's pocket, "
+            "even with a matching IBAN hash."
+        )
+        db.refresh(src_a)
+        assert src_a.include_in_analytics is True
+        assert src_a.internal_transfer_id is None
+        assert db.query(InternalTransfer).filter_by(user_id=user_a_id).count() == 0
+    finally:
+        if user_a_id:
+            _cleanup_user(db, user_a_id)
+        if user_b_id:
+            _cleanup_user(db, user_b_id)
+        db.close()
+
+
+if __name__ == "__main__":
+    tests = [
+        test_detect_creates_mirror_and_marks_source_not_in_analytics,
+        test_detect_is_idempotent,
+        test_detect_skips_when_no_matching_pocket,
+        test_unlink_reverses_detection,
+        test_unlink_all_for_pocket_restores_sources,
+        test_detect_overwrites_stale_system_category,
+        test_detect_preserves_user_category_override,
+        test_detect_does_not_match_cross_user_pocket,
+    ]
+    results = []
+    for fn in tests:
+        try:
+            fn()
+            results.append((fn.__name__, True, None))
+        except Exception:
+            import traceback
+            results.append((fn.__name__, False, traceback.format_exc()))
+
+    print("\n--- Results ---")
+    all_passed = True
+    for name, passed, err in results:
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
+        if err:
+            print(err)
+            all_passed = False
+
+    sys.exit(0 if all_passed else 1)

--- a/backend/tests/test_internal_transfer_service.py
+++ b/backend/tests/test_internal_transfer_service.py
@@ -8,6 +8,7 @@ or:
 """
 from __future__ import annotations
 
+import base64
 import os
 import sys
 import uuid
@@ -18,6 +19,25 @@ from typing import Optional
 # Ensure backend/ is importable
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+
+def _set_test_env() -> None:
+    """Make the encryption config deterministic before app modules are imported.
+
+    Without this, ``blind_index()`` returns ``None`` whenever
+    ``DATA_ENCRYPTION_KEY_CURRENT`` isn't set in the shell, which leaves the
+    pocket's ``iban_hash`` and the source transaction's
+    ``counterparty_iban_hash`` both NULL — and detection silently matches
+    nothing. Set a deterministic test key here so the tests always exercise
+    the encryption-enabled code path.
+    """
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-internal-transfer"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
 from app.database import Base, SessionLocal, engine  # noqa: E402
 from app.models import (  # noqa: E402
     Account,
@@ -26,7 +46,14 @@ from app.models import (  # noqa: E402
     Transaction,
     User,
 )
-from app.security.data_encryption import blind_index  # noqa: E402
+from app.security.data_encryption import (  # noqa: E402
+    blind_index,
+    reset_encryption_config_cache,
+)
+
+
+# Refresh the lru_cache so the encryption config picks up our env vars.
+reset_encryption_config_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -183,8 +210,11 @@ def test_detect_creates_mirror_and_marks_source_not_in_analytics() -> None:
         )
 
         service = InternalTransferService(db, user_id=user_id)
-        detected = service.detect_for_transactions([src.id])
-        assert detected == 1, f"Expected 1 detection, got {detected}"
+        result = service.detect_for_transactions([src.id])
+        assert result["detected"] == 1, f"Expected 1 detection, got {result}"
+        assert result["pocket_account_ids"] == [pocket.id], (
+            f"Expected pocket_account_ids=[{pocket.id}], got {result['pocket_account_ids']}"
+        )
 
         db.refresh(src)
         assert src.include_in_analytics is False
@@ -248,8 +278,9 @@ def test_detect_is_idempotent() -> None:
         first = service.detect_for_transactions([src.id])
         second = service.detect_for_transactions([src.id])
 
-        assert first == 1
-        assert second == 0, "Second detection should be a no-op"
+        assert first["detected"] == 1
+        assert second["detected"] == 0, "Second detection should be a no-op"
+        assert second["pocket_account_ids"] == []
 
         mirrors = (
             db.query(Transaction)
@@ -297,9 +328,10 @@ def test_detect_skips_when_no_matching_pocket() -> None:
         )
 
         service = InternalTransferService(db, user_id=user_id)
-        detected = service.detect_for_transactions([src.id])
+        result = service.detect_for_transactions([src.id])
 
-        assert detected == 0
+        assert result["detected"] == 0
+        assert result["pocket_account_ids"] == []
         db.refresh(src)
         assert src.include_in_analytics is True
         assert src.internal_transfer_id is None
@@ -344,7 +376,7 @@ def test_unlink_reverses_detection() -> None:
         )
 
         service = InternalTransferService(db, user_id=user_id)
-        assert service.detect_for_transactions([src.id]) == 1
+        assert service.detect_for_transactions([src.id])['detected'] == 1
 
         db.refresh(src)
         transfer_id = src.internal_transfer_id
@@ -409,7 +441,7 @@ def test_unlink_all_for_pocket_restores_sources() -> None:
         )
 
         service = InternalTransferService(db, user_id=user_id)
-        assert service.detect_for_transactions([src_a.id, src_b.id]) == 2
+        assert service.detect_for_transactions([src_a.id, src_b.id])['detected'] == 2
 
         unlinked = service.unlink_all_for_pocket(pocket.id)
         assert unlinked == 2, f"Expected 2 unlinked, got {unlinked}"
@@ -480,7 +512,7 @@ def test_detect_overwrites_stale_system_category() -> None:
 
         service = InternalTransferService(db, user_id=user_id)
         detected = service.detect_for_transactions([src.id])
-        assert detected == 1
+        assert detected["detected"] == 1
 
         db.refresh(src)
         # Detection is authoritative — category_system_id flipped to Transfer.
@@ -534,7 +566,7 @@ def test_detect_preserves_user_category_override() -> None:
         db.commit()
 
         service = InternalTransferService(db, user_id=user_id)
-        assert service.detect_for_transactions([src.id]) == 1
+        assert service.detect_for_transactions([src.id])['detected'] == 1
 
         db.refresh(src)
         # Link was still created and analytics was flipped off,
@@ -586,7 +618,7 @@ def test_detect_does_not_match_cross_user_pocket() -> None:
         )
 
         service_a = InternalTransferService(db, user_id=user_a_id)
-        assert service_a.detect_for_transactions([src_a.id]) == 0, (
+        assert service_a.detect_for_transactions([src_a.id])['detected'] == 0, (
             "User A's detection must not link to User B's pocket, "
             "even with a matching IBAN hash."
         )

--- a/backend/tests/test_pocket_account_routes.py
+++ b/backend/tests/test_pocket_account_routes.py
@@ -430,7 +430,11 @@ def test_unlink_internal_transfer_restores_source() -> None:
             amount=Decimal("-9.00"),
         )
         # Trigger detection so there's a link to unlink
-        assert InternalTransferService(db, user_id=user_id).detect_for_transactions([src.id]) == 1
+        assert (
+            InternalTransferService(db, user_id=user_id)
+            .detect_for_transactions([src.id])["detected"]
+            == 1
+        )
         link = db.query(InternalTransfer).filter_by(user_id=user_id).one()
 
         client = _client()
@@ -521,7 +525,7 @@ def test_delete_pocket_account_returns_404_for_other_user() -> None:
         )
         assert (
             InternalTransferService(db, user_id=user_b_id)
-            .detect_for_transactions([b_src.id])
+            .detect_for_transactions([b_src.id])["detected"]
             == 1
         )
         b_link_count_before = db.query(InternalTransfer).filter_by(user_id=user_b_id).count()

--- a/backend/tests/test_pocket_account_routes.py
+++ b/backend/tests/test_pocket_account_routes.py
@@ -1,0 +1,408 @@
+"""Tests for POST /api/accounts/pocket — pocket account registration with backfill.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_pocket_account_routes.py -v
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+# Ensure backend/ is importable
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    """Configure encryption and internal-auth secrets before importing app."""
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-pocket"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+    os.environ.setdefault("INTERNAL_AUTH_SECRET", "test-internal-secret")
+
+
+_set_test_env()
+
+from app.database import Base, SessionLocal, engine  # noqa: E402
+from app.models import (  # noqa: E402
+    Account,
+    Category,
+    InternalTransfer,
+    Transaction,
+    User,
+)
+from app.security.data_encryption import (  # noqa: E402
+    blind_index,
+    reset_encryption_config_cache,
+)
+from tests.internal_auth import build_internal_auth_headers  # noqa: E402
+
+
+# Refresh the lru_cache so the encryption config picks up our env vars.
+reset_encryption_config_cache()
+
+
+POCKET_IBAN = "NL91ABNA0417164300"
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers (mirror the style used in test_internal_transfer_service.py)
+# ---------------------------------------------------------------------------
+
+
+def _ensure_schema() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def _make_user(db) -> User:
+    uid = f"pocket-route-user-{uuid.uuid4().hex[:8]}"
+    user = User(
+        id=uid,
+        email=f"{uid}@example.com",
+        name="Pocket Route Test User",
+        email_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_synced_account(db, user_id: str, name: str = "Checking") -> Account:
+    acc = Account(
+        user_id=user_id,
+        name=name,
+        account_type="checking",
+        institution="Test Bank",
+        currency="EUR",
+        provider="enable_banking",
+        external_id=f"ext-{uuid.uuid4().hex[:12]}",
+        is_active=True,
+        starting_balance=Decimal("0"),
+    )
+    db.add(acc)
+    db.commit()
+    db.refresh(acc)
+    return acc
+
+
+def _make_transfer_category(db, user_id: str) -> Category:
+    cat = Category(
+        user_id=user_id,
+        name="Transfer",
+        category_type="transfer",
+        is_system=True,
+    )
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+def _make_source_transaction(
+    db,
+    user_id: str,
+    account_id,
+    counterparty_iban: Optional[str],
+    amount: Decimal = Decimal("-150.00"),
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        account_id=account_id,
+        external_id=f"src-{uuid.uuid4().hex[:12]}",
+        amount=amount,
+        currency="EUR",
+        functional_amount=amount,
+        description="Source transfer",
+        merchant="Counterparty",
+        booked_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+        transaction_type="debit" if amount < 0 else "credit",
+        counterparty_iban_hash=blind_index(counterparty_iban) if counterparty_iban else None,
+        include_in_analytics=True,
+    )
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+    return tx
+
+
+def _cleanup_user(db, user_id: str) -> None:
+    """FK-safe cleanup identical to test_internal_transfer_service._cleanup_user."""
+    db.query(Transaction).filter(Transaction.user_id == user_id).update(
+        {Transaction.internal_transfer_id: None}, synchronize_session=False
+    )
+    db.query(InternalTransfer).filter(InternalTransfer.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Transaction).filter(Transaction.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Account).filter(Account.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Category).filter(Category.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(User).filter(User.id == user_id).delete(synchronize_session=False)
+    db.commit()
+
+
+def _client():
+    """Return a fresh TestClient, importing main lazily so env vars are set first."""
+    from fastapi.testclient import TestClient
+    from app.main import app
+
+    return TestClient(app)
+
+
+def _signed_post(client, user_id: str, path: str, body: dict):
+    """POST to an internal-auth-protected endpoint with properly signed headers."""
+    headers = build_internal_auth_headers("POST", path, user_id)
+    return client.post(path, headers=headers, json=body)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: happy path — encrypts IBAN, creates pocket, backfills existing txns
+# ---------------------------------------------------------------------------
+
+
+def test_create_pocket_account_encrypts_iban_and_backfills() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        user = _make_user(db)
+        user_id = user.id
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id, name="Main Checking")
+        src_tx = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-200.00"),
+        )
+
+        client = _client()
+        path = "/api/accounts/pocket"
+        body = {
+            "name": "My Pocket",
+            "account_type": "savings",
+            "currency": "EUR",
+            "starting_balance": "0",
+            "iban": POCKET_IBAN,
+        }
+        response = _signed_post(client, user_id, path, body)
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+        payload = response.json()
+        assert "account_id" in payload
+        assert payload["backfilled_count"] == 1, (
+            f"Expected 1 backfilled transaction, got {payload.get('backfilled_count')}"
+        )
+
+        # New account row has encrypted IBAN + hash + manual provider
+        account = (
+            db.query(Account)
+            .filter(Account.id == payload["account_id"])
+            .one()
+        )
+        assert account.user_id == user_id
+        assert account.provider == "manual"
+        assert account.iban_hash == blind_index(POCKET_IBAN)
+        assert account.iban_ciphertext is not None
+        assert account.iban_ciphertext.startswith("enc:v1:"), (
+            f"Expected enc:v1: envelope, got {account.iban_ciphertext[:20]!r}"
+        )
+
+        # Pre-existing transaction is now linked + excluded from analytics
+        db.expire_all()
+        refreshed = db.query(Transaction).filter(Transaction.id == src_tx.id).one()
+        assert refreshed.include_in_analytics is False
+        assert refreshed.internal_transfer_id is not None
+
+        # Exactly one InternalTransfer row for this user
+        links = (
+            db.query(InternalTransfer)
+            .filter(InternalTransfer.user_id == user_id)
+            .all()
+        )
+        assert len(links) == 1
+        assert links[0].pocket_account_id == account.id
+        assert links[0].source_txn_id == src_tx.id
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: duplicate IBAN for the same user => 400
+# ---------------------------------------------------------------------------
+
+
+def test_create_pocket_account_rejects_duplicate_iban() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        user = _make_user(db)
+        user_id = user.id
+
+        # Seed an existing manual account with the same iban_hash
+        existing = Account(
+            user_id=user_id,
+            name="Existing Pocket",
+            account_type="savings",
+            currency="EUR",
+            provider="manual",
+            iban_hash=blind_index(POCKET_IBAN),
+            is_active=True,
+            starting_balance=Decimal("0"),
+        )
+        db.add(existing)
+        db.commit()
+
+        client = _client()
+        path = "/api/accounts/pocket"
+        body = {
+            "name": "Another Pocket",
+            "account_type": "savings",
+            "currency": "EUR",
+            "starting_balance": "0",
+            "iban": POCKET_IBAN,
+        }
+        response = _signed_post(client, user_id, path, body)
+
+        assert response.status_code == 400, (
+            f"Expected 400 on duplicate IBAN, got {response.status_code}: {response.text}"
+        )
+        detail = response.json().get("detail", "")
+        assert "already" in detail.lower(), (
+            f"Expected 'already' in error detail, got: {detail!r}"
+        )
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: duplicate scope is manual-only — synced accounts with the same
+# hash do NOT collide. (Defense in depth: synced accounts don't populate
+# iban_hash today, but the scoping check should still enforce it.)
+# ---------------------------------------------------------------------------
+
+
+def test_create_pocket_account_duplicate_check_ignores_non_manual_providers() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        user = _make_user(db)
+        user_id = user.id
+
+        # Seed a non-manual account sharing the same iban_hash — must NOT
+        # block the pocket registration.
+        synced_sharing_hash = Account(
+            user_id=user_id,
+            name="Synced ABN Account",
+            account_type="checking",
+            currency="EUR",
+            provider="enable_banking",
+            external_id=f"ext-{uuid.uuid4().hex[:12]}",
+            iban_hash=blind_index(POCKET_IBAN),
+            is_active=True,
+            starting_balance=Decimal("0"),
+        )
+        db.add(synced_sharing_hash)
+        db.commit()
+
+        client = _client()
+        path = "/api/accounts/pocket"
+        body = {
+            "name": "Pocket With Same IBAN",
+            "account_type": "savings",
+            "currency": "EUR",
+            "starting_balance": "0",
+            "iban": POCKET_IBAN,
+        }
+        response = _signed_post(client, user_id, path, body)
+
+        assert response.status_code == 200, (
+            f"Expected 200 (synced account with same hash must not block), "
+            f"got {response.status_code}: {response.text}"
+        )
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: malformed IBAN => validation failure (400 or 422)
+# ---------------------------------------------------------------------------
+
+
+def test_create_pocket_account_rejects_invalid_iban() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        user = _make_user(db)
+        user_id = user.id
+
+        client = _client()
+        path = "/api/accounts/pocket"
+        body = {
+            "name": "Bad IBAN Pocket",
+            "account_type": "savings",
+            "currency": "EUR",
+            "starting_balance": "0",
+            "iban": "not-an-iban",
+        }
+        response = _signed_post(client, user_id, path, body)
+
+        # Pydantic validator raises ValueError => FastAPI returns 422 by default.
+        # Accept either 400 (explicit check) or 422 (pydantic validation).
+        assert response.status_code in (400, 422), (
+            f"Expected 400 or 422, got {response.status_code}: {response.text}"
+        )
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+if __name__ == "__main__":
+    tests = [
+        test_create_pocket_account_encrypts_iban_and_backfills,
+        test_create_pocket_account_rejects_duplicate_iban,
+        test_create_pocket_account_duplicate_check_ignores_non_manual_providers,
+        test_create_pocket_account_rejects_invalid_iban,
+    ]
+    results = []
+    for fn in tests:
+        try:
+            fn()
+            results.append((fn.__name__, True, None))
+        except Exception:
+            import traceback
+            results.append((fn.__name__, False, traceback.format_exc()))
+
+    print("\n--- Results ---")
+    all_passed = True
+    for name, passed, err in results:
+        print(f"  [{'PASS' if passed else 'FAIL'}] {name}")
+        if err:
+            print(err)
+            all_passed = False
+
+    sys.exit(0 if all_passed else 1)

--- a/backend/tests/test_pocket_account_routes.py
+++ b/backend/tests/test_pocket_account_routes.py
@@ -166,6 +166,12 @@ def _signed_post(client, user_id: str, path: str, body: dict):
     return client.post(path, headers=headers, json=body)
 
 
+def _signed_delete(client, user_id: str, path: str):
+    """DELETE to an internal-auth-protected endpoint with properly signed headers."""
+    headers = build_internal_auth_headers("DELETE", path, user_id)
+    return client.delete(path, headers=headers)
+
+
 # ---------------------------------------------------------------------------
 # Test 1: happy path — encrypts IBAN, creates pocket, backfills existing txns
 # ---------------------------------------------------------------------------
@@ -381,12 +387,181 @@ def test_create_pocket_account_rejects_invalid_iban() -> None:
         db.close()
 
 
+# ---------------------------------------------------------------------------
+# Task 9: DELETE /api/accounts/internal-transfers/{transfer_id}
+# ---------------------------------------------------------------------------
+
+
+def _make_pocket_account(db, user_id: str, iban: str) -> Account:
+    """Create a manual pocket account with encrypted IBAN + hash."""
+    from app.security.data_encryption import encrypt_value
+
+    acc = Account(
+        user_id=user_id,
+        name="Pocket",
+        account_type="savings",
+        currency="EUR",
+        provider="manual",
+        iban_ciphertext=encrypt_value(iban),
+        iban_hash=blind_index(iban),
+        is_active=True,
+        starting_balance=Decimal("0"),
+    )
+    db.add(acc)
+    db.commit()
+    db.refresh(acc)
+    return acc
+
+
+def test_unlink_internal_transfer_restores_source() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id, name="Main")
+        pocket = _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db, user_id, synced.id, counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-9.00"),
+        )
+        # Trigger detection so there's a link to unlink
+        assert InternalTransferService(db, user_id=user_id).detect_for_transactions([src.id]) == 1
+        link = db.query(InternalTransfer).filter_by(user_id=user_id).one()
+
+        client = _client()
+        path = f"/api/accounts/internal-transfers/{link.id}"
+        response = _signed_delete(client, user_id, path)
+        assert response.status_code == 204, f"Expected 204, got {response.status_code}: {response.text}"
+
+        db.refresh(src)
+        assert src.include_in_analytics is True
+        assert src.internal_transfer_id is None
+        # Link is gone
+        assert db.query(InternalTransfer).filter_by(id=link.id).first() is None
+        # Mirror transaction was deleted too
+        assert db.query(Transaction).filter_by(account_id=pocket.id).count() == 0
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Task 10: DELETE /api/accounts/{account_id} with pre-delete cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_delete_pocket_account_restores_linked_sources() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user = _make_user(db)
+        user_id = user.id
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id, name="Main")
+        pocket = _make_pocket_account(db, user_id, iban=POCKET_IBAN)
+        src = _make_source_transaction(
+            db, user_id, synced.id, counterparty_iban=POCKET_IBAN,
+            amount=Decimal("-4.00"),
+        )
+        InternalTransferService(db, user_id=user_id).detect_for_transactions([src.id])
+        pocket_id = pocket.id
+        assert db.query(InternalTransfer).filter_by(pocket_account_id=pocket_id).count() == 1
+
+        client = _client()
+        path = f"/api/accounts/{pocket_id}"
+        response = _signed_delete(client, user_id, path)
+        assert response.status_code == 204, f"Expected 204, got {response.status_code}: {response.text}"
+
+        # Pocket gone
+        assert db.query(Account).filter_by(id=pocket_id).count() == 0
+        # Source restored
+        db.refresh(src)
+        assert src.include_in_analytics is True
+        assert src.internal_transfer_id is None
+        # Links gone
+        assert db.query(InternalTransfer).filter_by(user_id=user_id).count() == 0
+    finally:
+        if user_id:
+            _cleanup_user(db, user_id)
+        db.close()
+
+
+def test_delete_pocket_account_returns_404_for_other_user() -> None:
+    _ensure_schema()
+    db = SessionLocal()
+    user_a_id: Optional[str] = None
+    user_b_id: Optional[str] = None
+    try:
+        from app.services.internal_transfer_service import InternalTransferService
+
+        user_a = _make_user(db)
+        user_b = _make_user(db)
+        user_a_id = user_a.id
+        user_b_id = user_b.id
+
+        # User B has a pocket with a detected internal transfer — we want to
+        # prove that a cross-user delete attempt CANNOT trigger any mutation
+        # of B's data (ownership check must short-circuit before the service
+        # call).
+        _make_transfer_category(db, user_b_id)
+        b_synced = _make_synced_account(db, user_b_id, name="B's Main")
+        b_pocket = _make_pocket_account(db, user_b_id, iban=POCKET_IBAN)
+        b_src = _make_source_transaction(
+            db, user_b_id, b_synced.id,
+            counterparty_iban=POCKET_IBAN, amount=Decimal("-50.00"),
+        )
+        assert (
+            InternalTransferService(db, user_id=user_b_id)
+            .detect_for_transactions([b_src.id])
+            == 1
+        )
+        b_link_count_before = db.query(InternalTransfer).filter_by(user_id=user_b_id).count()
+        assert b_link_count_before == 1
+
+        client = _client()
+        path = f"/api/accounts/{b_pocket.id}"
+        response = _signed_delete(client, user_a_id, path)
+        assert response.status_code == 404, (
+            f"Expected 404, got {response.status_code}: {response.text}"
+        )
+
+        # Account still exists (owned by user B)
+        assert db.query(Account).filter_by(id=b_pocket.id).count() == 1
+        # B's link was NOT torn down by the cross-user attempt
+        assert (
+            db.query(InternalTransfer).filter_by(user_id=user_b_id).count()
+            == b_link_count_before
+        )
+        # B's source transaction is still in its detected state
+        db.refresh(b_src)
+        assert b_src.include_in_analytics is False
+        assert b_src.internal_transfer_id is not None
+    finally:
+        if user_a_id:
+            _cleanup_user(db, user_a_id)
+        if user_b_id:
+            _cleanup_user(db, user_b_id)
+        db.close()
+
+
 if __name__ == "__main__":
     tests = [
         test_create_pocket_account_encrypts_iban_and_backfills,
         test_create_pocket_account_rejects_duplicate_iban,
         test_create_pocket_account_duplicate_check_ignores_non_manual_providers,
         test_create_pocket_account_rejects_invalid_iban,
+        test_unlink_internal_transfer_restores_source,
+        test_delete_pocket_account_restores_linked_sources,
+        test_delete_pocket_account_returns_404_for_other_user,
     ]
     results = []
     for fn in tests:

--- a/backend/tests/test_post_import_pipeline.py
+++ b/backend/tests/test_post_import_pipeline.py
@@ -4,6 +4,7 @@ Tests for the post_import_pipeline Celery task.
 Run with:
     cd backend && python tests/test_post_import_pipeline.py
 """
+import base64
 import sys
 import os
 import uuid
@@ -15,9 +16,29 @@ from unittest.mock import MagicMock, patch, call
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+
+def _set_test_env() -> None:
+    """Set a deterministic encryption key before app modules are imported.
+
+    Otherwise ``blind_index()`` returns ``None`` whenever the shell lacks
+    ``DATA_ENCRYPTION_KEY_CURRENT``, which silently NULLs out the IBAN
+    hashes our integration test relies on for transfer-matching.
+    """
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-pipeline"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
 from app.database import Base, SessionLocal, engine
 from app.models import Account, Category, InternalTransfer, Transaction, User
-from app.security.data_encryption import blind_index
+from app.security.data_encryption import blind_index, reset_encryption_config_cache
+
+
+# Refresh the lru_cache so the encryption config picks up our env vars.
+reset_encryption_config_cache()
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +183,7 @@ def test_pipeline_calls_all_steps_in_order():
         mock_session_local.return_value = mock_db
         mock_token = "test-token"
         mock_set_user.return_value = mock_token
-        mock_it.return_value = 0
+        mock_it.return_value = {"detected": 0, "pocket_account_ids": []}
 
         from tasks.post_import_pipeline import _run_post_import_pipeline
 
@@ -214,7 +235,7 @@ def test_pipeline_initial_sync_passes_none_to_subscription_detector():
         mock_db = MagicMock()
         mock_session_local.return_value = mock_db
         mock_set_user.return_value = "token"
-        mock_it.return_value = 0
+        mock_it.return_value = {"detected": 0, "pocket_account_ids": []}
 
         from tasks.post_import_pipeline import _run_post_import_pipeline
 

--- a/backend/tests/test_post_import_pipeline.py
+++ b/backend/tests/test_post_import_pipeline.py
@@ -6,14 +6,145 @@ Run with:
 """
 import sys
 import os
+import uuid
+from decimal import Decimal
+from datetime import datetime, timezone
+from typing import Optional
 from unittest.mock import MagicMock, patch, call
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from app.database import Base, SessionLocal, engine
+from app.models import Account, Category, InternalTransfer, Transaction, User
+from app.security.data_encryption import blind_index
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture helpers (integration tests only)
+# ---------------------------------------------------------------------------
+
+PIPELINE_TEST_IBAN = "NL91ABNA0417164300"
+
+
+def _ensure_schema() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def _make_user(db) -> User:
+    uid = f"pip-test-user-{uuid.uuid4().hex[:8]}"
+    user = User(
+        id=uid,
+        email=f"{uid}@example.com",
+        name="Pipeline Test User",
+        email_verified=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_synced_account(db, user_id: str, name: str = "Checking") -> Account:
+    acc = Account(
+        user_id=user_id,
+        name=name,
+        account_type="checking",
+        institution="Test Bank",
+        currency="EUR",
+        provider="enable_banking",
+        external_id=f"ext-{uuid.uuid4().hex[:12]}",
+        is_active=True,
+        starting_balance=Decimal("0"),
+    )
+    db.add(acc)
+    db.commit()
+    db.refresh(acc)
+    return acc
+
+
+def _make_pocket_account(db, user_id: str, iban: str, name: str = "Savings Pocket") -> Account:
+    acc = Account(
+        user_id=user_id,
+        name=name,
+        account_type="savings",
+        institution="Manual",
+        currency="EUR",
+        provider="manual",
+        iban_hash=blind_index(iban),
+        is_active=True,
+        starting_balance=Decimal("0"),
+    )
+    db.add(acc)
+    db.commit()
+    db.refresh(acc)
+    return acc
+
+
+def _make_transfer_category(db, user_id: str) -> Category:
+    cat = Category(
+        user_id=user_id,
+        name="Transfer",
+        category_type="transfer",
+        is_system=True,
+    )
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+def _make_source_transaction(
+    db,
+    user_id: str,
+    account_id,
+    counterparty_iban: Optional[str],
+    amount: Decimal = Decimal("-150.00"),
+    currency: str = "EUR",
+) -> Transaction:
+    tx = Transaction(
+        user_id=user_id,
+        account_id=account_id,
+        external_id=f"src-{uuid.uuid4().hex[:12]}",
+        amount=amount,
+        currency=currency,
+        functional_amount=amount,  # pre-set so transfer detection can use it
+        description="Source transfer",
+        merchant="Counterparty",
+        booked_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+        transaction_type="debit" if amount < 0 else "credit",
+        counterparty_iban_hash=blind_index(counterparty_iban) if counterparty_iban else None,
+        include_in_analytics=True,
+    )
+    db.add(tx)
+    db.commit()
+    db.refresh(tx)
+    return tx
+
+
+def _cleanup_user_data(db, user_id: str) -> None:
+    """Remove all rows for a test user in FK-safe order."""
+    db.query(Transaction).filter(Transaction.user_id == user_id).update(
+        {Transaction.internal_transfer_id: None}, synchronize_session=False
+    )
+    db.query(InternalTransfer).filter(InternalTransfer.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Transaction).filter(Transaction.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Account).filter(Account.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(Category).filter(Category.user_id == user_id).delete(
+        synchronize_session=False
+    )
+    db.query(User).filter(User.id == user_id).delete(synchronize_session=False)
+    db.commit()
+
 
 def test_pipeline_calls_all_steps_in_order():
-    """Verify that _run_post_import_pipeline calls all 5 helper functions in the right order."""
+    """Verify that _run_post_import_pipeline calls all 7 step helpers in the right order."""
     print("Running test_pipeline_calls_all_steps_in_order...")
 
     with patch("tasks.post_import_pipeline.SessionLocal") as mock_session_local, \
@@ -21,6 +152,8 @@ def test_pipeline_calls_all_steps_in_order():
          patch("tasks.post_import_pipeline.clear_request_user_id") as mock_clear_user, \
          patch("tasks.post_import_pipeline._sync_exchange_rates") as mock_fx, \
          patch("tasks.post_import_pipeline._update_functional_amounts") as mock_fa, \
+         patch("tasks.post_import_pipeline._detect_internal_transfers") as mock_it, \
+         patch("tasks.post_import_pipeline._batch_categorize_transactions") as mock_cat, \
          patch("tasks.post_import_pipeline._calculate_balances") as mock_balances, \
          patch("tasks.post_import_pipeline._calculate_timeseries") as mock_timeseries, \
          patch("tasks.post_import_pipeline._detect_subscriptions") as mock_subs:
@@ -29,6 +162,7 @@ def test_pipeline_calls_all_steps_in_order():
         mock_session_local.return_value = mock_db
         mock_token = "test-token"
         mock_set_user.return_value = mock_token
+        mock_it.return_value = 0
 
         from tasks.post_import_pipeline import _run_post_import_pipeline
 
@@ -46,9 +180,11 @@ def test_pipeline_calls_all_steps_in_order():
         # Verify session setup
         mock_set_user.assert_called_once_with(user_id)
 
-        # Verify all 5 steps called
+        # Verify all 7 steps called with the right arguments.
         mock_fx.assert_called_once_with(mock_db, user_id, transaction_ids)
         mock_fa.assert_called_once_with(mock_db, user_id, transaction_ids)
+        mock_it.assert_called_once_with(mock_db, user_id, transaction_ids)
+        mock_cat.assert_called_once_with(mock_db, user_id, transaction_ids)
         mock_balances.assert_called_once_with(mock_db, user_id, account_ids)
         mock_timeseries.assert_called_once_with(mock_db, user_id, account_ids)
         mock_subs.assert_called_once_with(mock_db, user_id, transaction_ids, account_ids)
@@ -57,7 +193,7 @@ def test_pipeline_calls_all_steps_in_order():
         mock_clear_user.assert_called_once_with(mock_token)
         mock_db.close.assert_called_once()
 
-    print("  PASS: All 5 steps called in order with correct arguments")
+    print("  PASS: All 7 steps called in order with correct arguments")
 
 
 def test_pipeline_initial_sync_passes_none_to_subscription_detector():
@@ -69,6 +205,8 @@ def test_pipeline_initial_sync_passes_none_to_subscription_detector():
          patch("tasks.post_import_pipeline.clear_request_user_id"), \
          patch("tasks.post_import_pipeline._sync_exchange_rates"), \
          patch("tasks.post_import_pipeline._update_functional_amounts"), \
+         patch("tasks.post_import_pipeline._detect_internal_transfers") as mock_it, \
+         patch("tasks.post_import_pipeline._batch_categorize_transactions"), \
          patch("tasks.post_import_pipeline._calculate_balances"), \
          patch("tasks.post_import_pipeline._calculate_timeseries"), \
          patch("tasks.post_import_pipeline._detect_subscriptions") as mock_subs:
@@ -76,6 +214,7 @@ def test_pipeline_initial_sync_passes_none_to_subscription_detector():
         mock_db = MagicMock()
         mock_session_local.return_value = mock_db
         mock_set_user.return_value = "token"
+        mock_it.return_value = 0
 
         from tasks.post_import_pipeline import _run_post_import_pipeline
 
@@ -105,6 +244,8 @@ def test_pipeline_cleans_up_on_error():
          patch("tasks.post_import_pipeline.clear_request_user_id") as mock_clear_user, \
          patch("tasks.post_import_pipeline._sync_exchange_rates") as mock_fx, \
          patch("tasks.post_import_pipeline._update_functional_amounts"), \
+         patch("tasks.post_import_pipeline._detect_internal_transfers"), \
+         patch("tasks.post_import_pipeline._batch_categorize_transactions"), \
          patch("tasks.post_import_pipeline._calculate_balances"), \
          patch("tasks.post_import_pipeline._calculate_timeseries"), \
          patch("tasks.post_import_pipeline._detect_subscriptions"):
@@ -139,6 +280,107 @@ def test_pipeline_cleans_up_on_error():
     print("  PASS: Cleanup happens even when a step raises an exception")
 
 
+# ---------------------------------------------------------------------------
+# Integration test: internal transfer detection runs before LLM categorization
+# ---------------------------------------------------------------------------
+
+def test_pipeline_runs_internal_transfer_detection_before_llm() -> None:
+    """Detection must create a mirror, flip the source's include_in_analytics,
+    and the LLM batch must skip internal-transfer transactions."""
+    _ensure_schema()
+    db = SessionLocal()
+    user_id: Optional[str] = None
+    try:
+        user = _make_user(db)
+        user_id = user.id
+
+        _make_transfer_category(db, user_id)
+        synced = _make_synced_account(db, user_id, name="Main Checking")
+        pocket = _make_pocket_account(db, user_id, iban=PIPELINE_TEST_IBAN)
+        src = _make_source_transaction(
+            db,
+            user_id,
+            synced.id,
+            counterparty_iban=PIPELINE_TEST_IBAN,
+            amount=Decimal("-300.00"),
+        )
+        # Capture IDs as plain values before closing the setup session
+        synced_id = str(synced.id)
+        pocket_id = str(pocket.id)
+        src_id = str(src.id)
+        db.close()
+
+        # Track which transaction_ids the LLM batch actually receives
+        captured_batch_inputs = []
+
+        def fake_llm_batch(batch_input):
+            captured_batch_inputs.extend(batch_input)
+            return {}, 0, 0.0
+
+        from tasks.post_import_pipeline import _run_post_import_pipeline
+
+        with patch("app.services.category_matcher.CategoryMatcher.match_categories_batch_llm",
+                   side_effect=fake_llm_batch), \
+             patch("tasks.post_import_pipeline._sync_exchange_rates"), \
+             patch("tasks.post_import_pipeline._update_functional_amounts"), \
+             patch("tasks.post_import_pipeline._calculate_balances"), \
+             patch("tasks.post_import_pipeline._calculate_timeseries"), \
+             patch("tasks.post_import_pipeline._detect_subscriptions"):
+            _run_post_import_pipeline(
+                user_id=user_id,
+                account_ids=[synced_id, pocket_id],
+                transaction_ids=[src_id],
+                is_initial_sync=False,
+            )
+
+        # Open a fresh session to verify DB state
+        db2 = SessionLocal()
+        try:
+            refreshed_src = db2.query(Transaction).filter(Transaction.id == src_id).one()
+
+            # 1. Source must be flagged as internal transfer (not in analytics)
+            assert refreshed_src.include_in_analytics is False, (
+                "Source transaction include_in_analytics must be False after detection"
+            )
+
+            # 2. An InternalTransfer link row must exist
+            links = (
+                db2.query(InternalTransfer)
+                .filter(InternalTransfer.source_txn_id == src_id)
+                .all()
+            )
+            assert len(links) == 1, f"Expected 1 InternalTransfer link, got {len(links)}"
+
+            # 3. A mirror transaction must exist on the pocket account
+            link = links[0]
+            mirror = (
+                db2.query(Transaction)
+                .filter(Transaction.id == link.mirror_txn_id)
+                .one()
+            )
+            assert str(mirror.account_id) == pocket_id, "Mirror must be on the pocket account"
+
+            # 4. The LLM was NOT called with the internal-transfer source transaction
+            # The source is the only uncategorized transaction in this run — after
+            # detection sets include_in_analytics=False on it, the LLM filter
+            # (category_id IS NULL AND include_in_analytics IS TRUE) should yield
+            # zero rows, so the LLM batch receives an empty list and never fires.
+            assert len(captured_batch_inputs) == 0, (
+                f"LLM batch must not receive internal-transfer transactions, "
+                f"but got {len(captured_batch_inputs)} item(s): {captured_batch_inputs}"
+            )
+        finally:
+            db2.close()
+
+    finally:
+        if user_id:
+            db3 = SessionLocal()
+            try:
+                _cleanup_user_data(db3, user_id)
+            finally:
+                db3.close()
+
+
 if __name__ == "__main__":
     results = []
 
@@ -146,6 +388,7 @@ if __name__ == "__main__":
         test_pipeline_calls_all_steps_in_order,
         test_pipeline_initial_sync_passes_none_to_subscription_detector,
         test_pipeline_cleans_up_on_error,
+        test_pipeline_runs_internal_transfer_detection_before_llm,
     ]
 
     for test_fn in tests:

--- a/docs/superpowers/plans/2026-04-19-pocket-accounts.md
+++ b/docs/superpowers/plans/2026-04-19-pocket-accounts.md
@@ -1,0 +1,2065 @@
+# Pocket Account Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users register unsyncable savings accounts ("pockets") by IBAN, then auto-detect internal transfers from the synced parent, create mirror transactions so balances derive naturally, and exclude transfers from analytics.
+
+**Architecture:** Three schema additions (IBAN fields on `accounts`, counterparty IBAN on `transactions`, a new `internal_transfers` table). The Enable Banking adapter extracts counterparty IBAN, the sync service encrypts and hashes it on persist, and a new `InternalTransferService` runs detection as a step in the post-import pipeline. A new backend endpoint creates pocket accounts with IBAN, backfilling matches. Frontend gets an IBAN input, a "pocket" badge, an internal-transfer chip on transactions, and an unlink action.
+
+**Tech Stack:** Drizzle (schema source of truth) + SQLAlchemy (backend mirror), Next.js server actions, FastAPI + Celery, AES-GCM + HMAC-SHA256 blind index via existing `data_encryption` module, pytest + vitest.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-pocket-accounts-design.md`
+
+**Scope note — IBAN editing:** this plan implements IBAN assignment at pocket creation only. Editing an existing pocket account's IBAN is out of scope; users can delete and recreate. This keeps the surface area small for v1 and avoids the edge case of "partially migrated" internal transfer links.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `frontend/lib/db/schema.ts` | Drizzle schema — source of truth |
+| `backend/app/models.py` | SQLAlchemy mirror |
+| `frontend/lib/db/migrations/NNNN_*.sql` | Generated migration |
+| `backend/app/integrations/base.py` | Add `counterparty_iban` to `TransactionData` |
+| `backend/app/integrations/enable_banking_adapter.py` | Extract IBAN from EB raw payload |
+| `backend/app/services/sync_service.py` | Encrypt + hash IBAN on persist |
+| `backend/app/services/internal_transfer_service.py` | NEW — detect/unlink internal transfers |
+| `backend/tasks/post_import_pipeline.py` | Add detection step; filter LLM by `include_in_analytics` |
+| `backend/app/routes/accounts.py` | NEW endpoints — create pocket, update iban, delete cleanup |
+| `frontend/lib/actions/accounts.ts` | Route IBAN ops through backend; new `unlinkInternalTransfer` |
+| `frontend/components/accounts/account-form.tsx` | IBAN input + validation |
+| `frontend/components/transactions/transaction-row-details.tsx` | Internal-transfer chip |
+| `frontend/components/accounts/account-header.tsx` | "Pocket" badge |
+
+---
+
+## Task 1: Add IBAN fields to `accounts` schema
+
+**Files:**
+- Modify: `frontend/lib/db/schema.ts`
+- Modify: `backend/app/models.py`
+- Create: `frontend/lib/db/migrations/<next>_add_pocket_account_fields.sql` (auto-generated)
+
+- [ ] **Step 1: Add Drizzle columns**
+
+In `frontend/lib/db/schema.ts`, inside the `accounts` pgTable block, add after `externalIdHash`:
+
+```typescript
+    ibanCiphertext: text("iban_ciphertext"),
+    ibanHash: varchar("iban_hash", { length: 64 }),
+```
+
+And in the table options block, add an index:
+
+```typescript
+    index("idx_accounts_user_iban_hash").on(table.userId, table.ibanHash),
+```
+
+- [ ] **Step 2: Add SQLAlchemy columns**
+
+In `backend/app/models.py`, locate the `Account` model and add inside the columns (after `external_id_hash`):
+
+```python
+    iban_ciphertext = Column(Text, nullable=True)
+    iban_hash = Column(String(64), nullable=True, index=False)  # composite index defined in __table_args__
+```
+
+Then update `__table_args__` to include:
+
+```python
+    Index("idx_accounts_user_iban_hash", "user_id", "iban_hash"),
+```
+
+- [ ] **Step 3: Generate migration**
+
+```bash
+cd frontend && pnpm db:generate
+```
+
+Expected: new `NNNN_*.sql` file created adding the two columns and index. Inspect the generated SQL to confirm.
+
+- [ ] **Step 4: Apply migration locally**
+
+```bash
+cd frontend && pnpm db:push
+```
+
+Expected: migration applies cleanly, no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/db/schema.ts backend/app/models.py frontend/lib/db/migrations/
+git commit -m "feat(db): add iban_ciphertext and iban_hash to accounts"
+```
+
+---
+
+## Task 2: Add counterparty IBAN fields to `transactions` schema
+
+**Files:**
+- Modify: `frontend/lib/db/schema.ts`
+- Modify: `backend/app/models.py`
+
+- [ ] **Step 1: Add Drizzle columns**
+
+In `frontend/lib/db/schema.ts`, inside the `transactions` pgTable block, add after `debtor`:
+
+```typescript
+    counterpartyIbanCiphertext: text("counterparty_iban_ciphertext"),
+    counterpartyIbanHash: varchar("counterparty_iban_hash", { length: 64 }),
+    internalTransferId: uuid("internal_transfer_id"),  // FK added in Task 3
+```
+
+Add an index in the options block:
+
+```typescript
+    index("idx_transactions_user_counterparty_iban").on(table.userId, table.counterpartyIbanHash),
+```
+
+- [ ] **Step 2: Add SQLAlchemy columns**
+
+In `backend/app/models.py`, inside `Transaction`:
+
+```python
+    counterparty_iban_ciphertext = Column(Text, nullable=True)
+    counterparty_iban_hash = Column(String(64), nullable=True)
+    internal_transfer_id = Column(UUID(as_uuid=True), nullable=True)  # FK constraint added via __table_args__ after Task 3
+```
+
+Add to `__table_args__`:
+
+```python
+    Index("idx_transactions_user_counterparty_iban", "user_id", "counterparty_iban_hash"),
+```
+
+- [ ] **Step 3: Generate and apply migration**
+
+```bash
+cd frontend && pnpm db:generate && pnpm db:push
+```
+
+Expected: new columns + index present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/lib/db/schema.ts backend/app/models.py frontend/lib/db/migrations/
+git commit -m "feat(db): add counterparty IBAN fields to transactions"
+```
+
+---
+
+## Task 3: Add `internal_transfers` table
+
+**Files:**
+- Modify: `frontend/lib/db/schema.ts`
+- Modify: `backend/app/models.py`
+
+- [ ] **Step 1: Add Drizzle table**
+
+In `frontend/lib/db/schema.ts`, after `transactions` block and before `accountBalances`, add:
+
+```typescript
+export const internalTransfers = pgTable(
+  "internal_transfers",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    sourceTxnId: uuid("source_txn_id")
+      .references(() => transactions.id, { onDelete: "cascade" })
+      .notNull()
+      .unique(),
+    mirrorTxnId: uuid("mirror_txn_id")
+      .references(() => transactions.id, { onDelete: "set null" })
+      .unique(),
+    sourceAccountId: uuid("source_account_id")
+      .references(() => accounts.id, { onDelete: "cascade" })
+      .notNull(),
+    pocketAccountId: uuid("pocket_account_id")
+      .references(() => accounts.id, { onDelete: "cascade" })
+      .notNull(),
+    amount: decimal("amount", { precision: 15, scale: 2 }).notNull(),
+    currency: char("currency", { length: 3 }).notNull(),
+    detectedAt: timestamp("detected_at").defaultNow(),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (table) => [
+    index("idx_internal_transfers_user").on(table.userId),
+    index("idx_internal_transfers_pocket").on(table.pocketAccountId),
+  ]
+);
+```
+
+Then wire the FK on `transactions.internalTransferId` — change the column added in Task 2 to:
+
+```typescript
+    internalTransferId: uuid("internal_transfer_id").references(() => internalTransfers.id, { onDelete: "set null" }),
+```
+
+- [ ] **Step 2: Add SQLAlchemy model**
+
+In `backend/app/models.py`, add a new class `InternalTransfer`:
+
+```python
+class InternalTransfer(Base):
+    __tablename__ = "internal_transfers"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=sa_text("gen_random_uuid()"))
+    user_id = Column(Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    source_txn_id = Column(UUID(as_uuid=True), ForeignKey("transactions.id", ondelete="CASCADE"), nullable=False, unique=True)
+    mirror_txn_id = Column(UUID(as_uuid=True), ForeignKey("transactions.id", ondelete="SET NULL"), unique=True, nullable=True)
+    source_account_id = Column(UUID(as_uuid=True), ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
+    pocket_account_id = Column(UUID(as_uuid=True), ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
+    amount = Column(Numeric(15, 2), nullable=False)
+    currency = Column(String(3), nullable=False)
+    detected_at = Column(DateTime, server_default=sa_func.now())
+    created_at = Column(DateTime, server_default=sa_func.now())
+
+    __table_args__ = (
+        Index("idx_internal_transfers_user", "user_id"),
+        Index("idx_internal_transfers_pocket", "pocket_account_id"),
+    )
+```
+
+Update `Transaction.__table_args__` / column FK: the `internal_transfer_id` column now has a real FK to `internal_transfers.id`:
+
+```python
+    internal_transfer_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("internal_transfers.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+```
+
+- [ ] **Step 3: Generate and apply migration**
+
+```bash
+cd frontend && pnpm db:generate && pnpm db:push
+```
+
+Expected: `internal_transfers` table created with FKs and indexes; `transactions.internal_transfer_id` FK added.
+
+- [ ] **Step 4: Verify schema**
+
+```bash
+cd frontend && pnpm db:studio
+```
+
+Open studio, confirm the new table exists with correct columns and FKs. (Manual visual check — no automated test yet; service tests come in Task 6.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/lib/db/schema.ts backend/app/models.py frontend/lib/db/migrations/
+git commit -m "feat(db): add internal_transfers table"
+```
+
+---
+
+## Task 4: Extract counterparty IBAN in Enable Banking adapter
+
+**Files:**
+- Modify: `backend/app/integrations/base.py` (add field to `TransactionData`)
+- Modify: `backend/app/integrations/enable_banking_adapter.py`
+- Test: `backend/tests/test_enable_banking_adapter.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/test_enable_banking_adapter.py`:
+
+```python
+def test_normalize_extracts_counterparty_iban_from_creditor_account_iban():
+    adapter = EnableBankingAdapter(token="tok", base_url="https://example.com")
+    raw = {
+        "transaction_id": "tx-1",
+        "account_id": "acc-1",
+        "transaction_amount": {"amount": "12.50", "currency": "EUR"},
+        "credit_debit_indicator": "DBIT",
+        "booking_date": "2026-04-01",
+        "creditor_account": {"iban": "NL91 ABNA 0417 1643 00"},
+        "debtor_account": {"iban": "NL02 RABO 0123 4567 89"},
+        "creditor": {"name": "Some Merchant"},
+    }
+    txn = adapter.normalize_transaction(raw)
+    # Outflow (DBIT) → counterparty is the creditor IBAN, stripped of spaces and upper-cased
+    assert txn.counterparty_iban == "NL91ABNA0417164300"
+
+
+def test_normalize_extracts_counterparty_iban_from_nested_creditor():
+    adapter = EnableBankingAdapter(token="tok", base_url="https://example.com")
+    raw = {
+        "transaction_id": "tx-2",
+        "account_id": "acc-1",
+        "transaction_amount": {"amount": "5.00", "currency": "EUR"},
+        "credit_debit_indicator": "CRDT",
+        "booking_date": "2026-04-01",
+        "creditor_account": None,
+        "debtor_account": None,
+        "debtor": {"name": "Friend", "iban": "BE68539007547034"},
+    }
+    txn = adapter.normalize_transaction(raw)
+    # Inflow (CRDT) → counterparty is the debtor IBAN
+    assert txn.counterparty_iban == "BE68539007547034"
+
+
+def test_normalize_handles_missing_iban_gracefully():
+    adapter = EnableBankingAdapter(token="tok", base_url="https://example.com")
+    raw = {
+        "transaction_id": "tx-3",
+        "account_id": "acc-1",
+        "transaction_amount": {"amount": "5.00", "currency": "EUR"},
+        "credit_debit_indicator": "DBIT",
+        "booking_date": "2026-04-01",
+    }
+    txn = adapter.normalize_transaction(raw)
+    assert txn.counterparty_iban is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && pytest tests/test_enable_banking_adapter.py -v -k counterparty_iban
+```
+
+Expected: FAIL with `AttributeError: 'TransactionData' object has no attribute 'counterparty_iban'`.
+
+- [ ] **Step 3: Add field to `TransactionData`**
+
+In `backend/app/integrations/base.py`, inside `class TransactionData`, add after `debtor`:
+
+```python
+    counterparty_iban: Optional[str] = None  # IBAN of the other party (stripped, upper-cased)
+```
+
+- [ ] **Step 4: Extract IBAN in the adapter**
+
+In `backend/app/integrations/enable_banking_adapter.py`, add a module-level helper above the class:
+
+```python
+def _extract_iban(account_obj) -> Optional[str]:
+    if not isinstance(account_obj, dict):
+        return None
+    iban = account_obj.get("iban")
+    if iban:
+        return iban.replace(" ", "").upper()
+    if (account_obj.get("scheme_name") or "").upper() == "IBAN":
+        ident = account_obj.get("identification")
+        if ident:
+            return ident.replace(" ", "").upper()
+    return None
+```
+
+Then inside `normalize_transaction`, after the existing `credit_debit = ...` line and before the sign-flip logic, compute the counterparty IBAN:
+
+```python
+        creditor_iban = (
+            _extract_iban(raw.get("creditor_account"))
+            or _extract_iban(raw.get("creditor"))
+        )
+        debtor_iban = (
+            _extract_iban(raw.get("debtor_account"))
+            or _extract_iban(raw.get("debtor"))
+        )
+        counterparty_iban = creditor_iban if credit_debit == "DBIT" else debtor_iban
+```
+
+And pass it through in the `TransactionData(...)` return:
+
+```python
+        return TransactionData(
+            # ... existing fields ...
+            counterparty_iban=counterparty_iban,
+            metadata={"raw": raw},
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/test_enable_banking_adapter.py -v
+```
+
+Expected: all counterparty_iban tests PASS; all previously-passing tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/integrations/base.py backend/app/integrations/enable_banking_adapter.py backend/tests/test_enable_banking_adapter.py
+git commit -m "feat(eb): extract counterparty IBAN from Enable Banking payload"
+```
+
+---
+
+## Task 5: Persist encrypted counterparty IBAN during sync
+
+**Files:**
+- Modify: `backend/app/services/sync_service.py`
+- Test: `backend/tests/test_account_sync_encryption.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/test_account_sync_encryption.py`:
+
+```python
+def test_sync_service_persists_encrypted_counterparty_iban(db_session, user_with_manual_account, monkeypatch):
+    # Force encryption on for this test
+    monkeypatch.setenv("DATA_ENCRYPTION_KEY_CURRENT", "0" * 64)  # 32-byte hex zero key for deterministic test
+    from backend.app.security.data_encryption import reset_encryption_config_cache
+    reset_encryption_config_cache()
+
+    from backend.app.services.sync_service import SyncService
+    from backend.app.integrations.base import TransactionData
+    from decimal import Decimal
+    from datetime import datetime, timezone
+
+    user = user_with_manual_account["user"]
+    account = user_with_manual_account["account"]
+    service = SyncService(db_session, user_id=user.id, use_llm_categorization=False)
+
+    td = TransactionData(
+        external_id="ext-1",
+        account_external_id=account.external_id,
+        amount=Decimal("-10.00"),
+        currency="EUR",
+        description="Test",
+        counterparty_iban="NL91ABNA0417164300",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        transaction_type="debit",
+    )
+
+    service.upsert_transactions(account, [td])
+    db_session.commit()
+
+    from backend.app.models import Transaction
+    from backend.app.security.data_encryption import decrypt_value, blind_index
+
+    row = db_session.query(Transaction).filter_by(external_id="ext-1").one()
+    assert row.counterparty_iban_ciphertext is not None
+    assert row.counterparty_iban_ciphertext.startswith("enc:v1:")
+    assert decrypt_value(row.counterparty_iban_ciphertext) == "NL91ABNA0417164300"
+    assert row.counterparty_iban_hash == blind_index("NL91ABNA0417164300")
+```
+
+(If `user_with_manual_account` fixture does not yet exist, add it to `conftest.py` creating a user plus one account with `provider="manual"`, `external_id="acc-ext"`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && pytest tests/test_account_sync_encryption.py::test_sync_service_persists_encrypted_counterparty_iban -v
+```
+
+Expected: FAIL — the sync service currently ignores `counterparty_iban`.
+
+- [ ] **Step 3: Implement**
+
+In `backend/app/services/sync_service.py`, locate the section where a `Transaction` is built from `TransactionData` (search for `Transaction(` within `upsert_transactions` or equivalent). Add:
+
+```python
+from app.security.data_encryption import encrypt_value, blind_index
+
+# ... inside the mapping where fields are set on a new/updated Transaction row ...
+if td.counterparty_iban:
+    txn.counterparty_iban_ciphertext = encrypt_value(td.counterparty_iban)
+    txn.counterparty_iban_hash = blind_index(td.counterparty_iban)
+else:
+    txn.counterparty_iban_ciphertext = None
+    txn.counterparty_iban_hash = None
+```
+
+Apply this for both the insert branch and the update branch so re-synced transactions pick up IBAN on subsequent runs.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/test_account_sync_encryption.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/sync_service.py backend/tests/test_account_sync_encryption.py
+git commit -m "feat(sync): persist encrypted counterparty IBAN + blind index"
+```
+
+---
+
+## Task 6: `InternalTransferService` — detect, unlink, unlink_all_for_pocket
+
+**Files:**
+- Create: `backend/app/services/internal_transfer_service.py`
+- Create: `backend/tests/test_internal_transfer_service.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `backend/tests/test_internal_transfer_service.py`:
+
+```python
+import pytest
+from decimal import Decimal
+from datetime import datetime, timezone
+from uuid import UUID
+
+from app.models import Account, Transaction, InternalTransfer, Category
+from app.services.internal_transfer_service import InternalTransferService
+from app.security.data_encryption import encrypt_value, blind_index, reset_encryption_config_cache
+
+
+@pytest.fixture(autouse=True)
+def _enable_encryption(monkeypatch):
+    monkeypatch.setenv("DATA_ENCRYPTION_KEY_CURRENT", "0" * 64)
+    reset_encryption_config_cache()
+    yield
+    reset_encryption_config_cache()
+
+
+@pytest.fixture
+def user_with_synced_and_pocket(db_session):
+    """User with one synced main account and one manual pocket account with IBAN."""
+    from tests.helpers import create_user  # expected existing test helper
+    user = create_user(db_session)
+
+    pocket_iban = "NL91ABNA0417164300"
+    synced = Account(
+        user_id=user.id, name="Main", account_type="checking",
+        provider="gocardless", external_id="acc-synced", currency="EUR",
+        starting_balance=Decimal("0"),
+    )
+    pocket = Account(
+        user_id=user.id, name="Savings Pocket", account_type="savings",
+        provider="manual", currency="EUR", starting_balance=Decimal("0"),
+        iban_ciphertext=encrypt_value(pocket_iban),
+        iban_hash=blind_index(pocket_iban),
+    )
+    # Transfer category
+    transfer_cat = Category(
+        user_id=user.id, name="Transfer", category_type="transfer", is_system=True,
+    )
+    db_session.add_all([synced, pocket, transfer_cat])
+    db_session.commit()
+    return {"user": user, "synced": synced, "pocket": pocket, "transfer_cat": transfer_cat, "pocket_iban": pocket_iban}
+
+
+def test_detect_creates_mirror_and_marks_source_not_in_analytics(db_session, user_with_synced_and_pocket):
+    ctx = user_with_synced_and_pocket
+    src = Transaction(
+        user_id=ctx["user"].id,
+        account_id=ctx["synced"].id,
+        external_id="ext-1",
+        amount=Decimal("-50.00"),
+        currency="EUR",
+        description="To savings",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(ctx["pocket_iban"]),
+        counterparty_iban_hash=blind_index(ctx["pocket_iban"]),
+        include_in_analytics=True,
+    )
+    db_session.add(src)
+    db_session.commit()
+
+    service = InternalTransferService(db_session, user_id=ctx["user"].id)
+    count = service.detect_for_transactions([src.id])
+
+    assert count == 1
+
+    # Source flipped
+    db_session.refresh(src)
+    assert src.include_in_analytics is False
+    assert src.internal_transfer_id is not None
+
+    # Mirror exists on pocket
+    mirror = db_session.query(Transaction).filter_by(account_id=ctx["pocket"].id).one()
+    assert mirror.amount == Decimal("50.00")  # sign flipped
+    assert mirror.currency == "EUR"
+    assert mirror.include_in_analytics is False
+    assert mirror.category_system_id == ctx["transfer_cat"].id
+    assert mirror.external_id == f"mirror-{src.id}"
+    assert mirror.transaction_type == "credit"
+
+    # InternalTransfer row
+    it = db_session.query(InternalTransfer).filter_by(source_txn_id=src.id).one()
+    assert it.mirror_txn_id == mirror.id
+    assert it.amount == Decimal("50.00")
+    assert it.currency == "EUR"
+    assert it.source_account_id == ctx["synced"].id
+    assert it.pocket_account_id == ctx["pocket"].id
+
+
+def test_detect_is_idempotent(db_session, user_with_synced_and_pocket):
+    ctx = user_with_synced_and_pocket
+    src = Transaction(
+        user_id=ctx["user"].id, account_id=ctx["synced"].id, external_id="ext-2",
+        amount=Decimal("-5.00"), currency="EUR", description="x",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(ctx["pocket_iban"]),
+        counterparty_iban_hash=blind_index(ctx["pocket_iban"]),
+        include_in_analytics=True,
+    )
+    db_session.add(src); db_session.commit()
+
+    service = InternalTransferService(db_session, user_id=ctx["user"].id)
+    assert service.detect_for_transactions([src.id]) == 1
+    # Second call: no new mirrors
+    assert service.detect_for_transactions([src.id]) == 0
+    assert db_session.query(Transaction).filter_by(account_id=ctx["pocket"].id).count() == 1
+
+
+def test_detect_skips_when_no_matching_pocket(db_session, user_with_synced_and_pocket):
+    ctx = user_with_synced_and_pocket
+    src = Transaction(
+        user_id=ctx["user"].id, account_id=ctx["synced"].id, external_id="ext-3",
+        amount=Decimal("-5.00"), currency="EUR", description="x",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value("NL99OTHER0000000000"),
+        counterparty_iban_hash=blind_index("NL99OTHER0000000000"),
+        include_in_analytics=True,
+    )
+    db_session.add(src); db_session.commit()
+
+    service = InternalTransferService(db_session, user_id=ctx["user"].id)
+    assert service.detect_for_transactions([src.id]) == 0
+    db_session.refresh(src)
+    assert src.include_in_analytics is True
+    assert src.internal_transfer_id is None
+
+
+def test_unlink_reverses_detection(db_session, user_with_synced_and_pocket):
+    ctx = user_with_synced_and_pocket
+    src = Transaction(
+        user_id=ctx["user"].id, account_id=ctx["synced"].id, external_id="ext-4",
+        amount=Decimal("-7.00"), currency="EUR", description="x",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(ctx["pocket_iban"]),
+        counterparty_iban_hash=blind_index(ctx["pocket_iban"]),
+        include_in_analytics=True,
+    )
+    db_session.add(src); db_session.commit()
+
+    service = InternalTransferService(db_session, user_id=ctx["user"].id)
+    service.detect_for_transactions([src.id])
+    it = db_session.query(InternalTransfer).one()
+
+    service.unlink(it.id)
+    db_session.commit()
+
+    db_session.refresh(src)
+    assert src.include_in_analytics is True
+    assert src.internal_transfer_id is None
+    assert db_session.query(InternalTransfer).count() == 0
+    assert db_session.query(Transaction).filter_by(account_id=ctx["pocket"].id).count() == 0
+
+
+def test_unlink_all_for_pocket_restores_sources(db_session, user_with_synced_and_pocket):
+    ctx = user_with_synced_and_pocket
+    src1 = Transaction(
+        user_id=ctx["user"].id, account_id=ctx["synced"].id, external_id="ext-5",
+        amount=Decimal("-1.00"), currency="EUR", description="a",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(ctx["pocket_iban"]),
+        counterparty_iban_hash=blind_index(ctx["pocket_iban"]),
+        include_in_analytics=True,
+    )
+    src2 = Transaction(
+        user_id=ctx["user"].id, account_id=ctx["synced"].id, external_id="ext-6",
+        amount=Decimal("-2.00"), currency="EUR", description="b",
+        booked_at=datetime(2026, 4, 2, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(ctx["pocket_iban"]),
+        counterparty_iban_hash=blind_index(ctx["pocket_iban"]),
+        include_in_analytics=True,
+    )
+    db_session.add_all([src1, src2]); db_session.commit()
+
+    service = InternalTransferService(db_session, user_id=ctx["user"].id)
+    service.detect_for_transactions([src1.id, src2.id])
+    assert service.unlink_all_for_pocket(ctx["pocket"].id) == 2
+
+    db_session.refresh(src1); db_session.refresh(src2)
+    assert src1.include_in_analytics is True and src1.internal_transfer_id is None
+    assert src2.include_in_analytics is True and src2.internal_transfer_id is None
+    assert db_session.query(InternalTransfer).count() == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd backend && pytest tests/test_internal_transfer_service.py -v
+```
+
+Expected: FAIL with `ImportError` (service module doesn't exist).
+
+- [ ] **Step 3: Implement the service**
+
+Create `backend/app/services/internal_transfer_service.py`:
+
+```python
+"""Detect and manage internal transfers between the user's synced accounts
+and their manually-registered pocket accounts.
+
+Matching is done by counterparty IBAN blind index: transactions whose
+counterparty_iban_hash matches a manual account's iban_hash are linked to
+that pocket, and a mirror transaction is created on the pocket side.
+"""
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import List
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models import Account, Category, InternalTransfer, Transaction
+
+logger = logging.getLogger(__name__)
+
+
+class InternalTransferService:
+    def __init__(self, db: Session, user_id: str):
+        self.db = db
+        self.user_id = user_id
+
+    def _load_pocket_map(self) -> dict[str, Account]:
+        """Return {iban_hash: pocket_account} for this user's manual accounts with an IBAN."""
+        pockets = (
+            self.db.query(Account)
+            .filter(
+                Account.user_id == self.user_id,
+                Account.provider == "manual",
+                Account.iban_hash.isnot(None),
+                Account.is_active.is_(True),
+            )
+            .all()
+        )
+        return {p.iban_hash: p for p in pockets}
+
+    def _resolve_transfer_category_id(self):
+        cat = (
+            self.db.query(Category)
+            .filter(
+                Category.user_id == self.user_id,
+                Category.category_type == "transfer",
+            )
+            .order_by(Category.is_system.desc(), Category.created_at.asc())
+            .first()
+        )
+        return cat.id if cat else None
+
+    def detect_for_transactions(self, transaction_ids: List[UUID]) -> int:
+        if not transaction_ids:
+            return 0
+
+        pocket_map = self._load_pocket_map()
+        if not pocket_map:
+            return 0
+
+        sources = (
+            self.db.query(Transaction)
+            .filter(
+                Transaction.id.in_(transaction_ids),
+                Transaction.user_id == self.user_id,
+                Transaction.counterparty_iban_hash.isnot(None),
+                Transaction.internal_transfer_id.is_(None),
+            )
+            .all()
+        )
+
+        transfer_category_id = self._resolve_transfer_category_id()
+        detected = 0
+
+        for src in sources:
+            pocket = pocket_map.get(src.counterparty_iban_hash)
+            if pocket is None or pocket.id == src.account_id:
+                continue
+
+            mirror_amount = -src.amount
+            mirror = Transaction(
+                user_id=self.user_id,
+                account_id=pocket.id,
+                external_id=f"mirror-{src.id}",
+                amount=mirror_amount,
+                currency=src.currency,
+                functional_amount=(-src.functional_amount) if src.functional_amount is not None else None,
+                description=f"Transfer from {src.account.name}" if mirror_amount > 0 else f"Transfer to {src.account.name}",
+                merchant=src.account.name,
+                booked_at=src.booked_at,
+                transaction_type="credit" if mirror_amount > 0 else "debit",
+                category_system_id=transfer_category_id,
+                include_in_analytics=False,
+            )
+            self.db.add(mirror)
+            self.db.flush()  # assigns mirror.id
+
+            link = InternalTransfer(
+                user_id=self.user_id,
+                source_txn_id=src.id,
+                mirror_txn_id=mirror.id,
+                source_account_id=src.account_id,
+                pocket_account_id=pocket.id,
+                amount=abs(src.amount),
+                currency=src.currency,
+            )
+            self.db.add(link)
+            self.db.flush()
+
+            src.include_in_analytics = False
+            src.internal_transfer_id = link.id
+            # Also label source with Transfer system category for consistency
+            if transfer_category_id and src.category_id is None:
+                src.category_system_id = transfer_category_id
+
+            detected += 1
+
+        if detected:
+            self.db.commit()
+        logger.info("[INTERNAL_TRANSFER] Detected %d transfer(s) for user %s", detected, self.user_id)
+        return detected
+
+    def unlink(self, internal_transfer_id: UUID) -> None:
+        link = (
+            self.db.query(InternalTransfer)
+            .filter(
+                InternalTransfer.id == internal_transfer_id,
+                InternalTransfer.user_id == self.user_id,
+            )
+            .one_or_none()
+        )
+        if link is None:
+            return
+
+        src = self.db.query(Transaction).filter(Transaction.id == link.source_txn_id).one_or_none()
+        if src is not None:
+            src.include_in_analytics = True
+            src.internal_transfer_id = None
+
+        if link.mirror_txn_id is not None:
+            mirror = self.db.query(Transaction).filter(Transaction.id == link.mirror_txn_id).one_or_none()
+            if mirror is not None:
+                self.db.delete(mirror)
+
+        self.db.delete(link)
+        self.db.commit()
+
+    def unlink_all_for_pocket(self, pocket_account_id: UUID) -> int:
+        links = (
+            self.db.query(InternalTransfer)
+            .filter(
+                InternalTransfer.pocket_account_id == pocket_account_id,
+                InternalTransfer.user_id == self.user_id,
+            )
+            .all()
+        )
+        count = 0
+        for link in links:
+            src = self.db.query(Transaction).filter(Transaction.id == link.source_txn_id).one_or_none()
+            if src is not None:
+                src.include_in_analytics = True
+                src.internal_transfer_id = None
+            # Mirror transactions will be removed by cascade when the pocket account is deleted
+            self.db.delete(link)
+            count += 1
+        if count:
+            self.db.commit()
+        return count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/test_internal_transfer_service.py -v
+```
+
+Expected: all five tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/internal_transfer_service.py backend/tests/test_internal_transfer_service.py
+git commit -m "feat(service): InternalTransferService — detect, unlink, unlink_all_for_pocket"
+```
+
+---
+
+## Task 7: Wire detection into the post-import pipeline
+
+**Files:**
+- Modify: `backend/tasks/post_import_pipeline.py`
+- Test: `backend/tests/test_post_import_pipeline.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/test_post_import_pipeline.py`:
+
+```python
+def test_pipeline_runs_internal_transfer_detection_before_llm(db_session, monkeypatch):
+    """Detection step must run between functional_amounts and batch LLM categorization."""
+    from backend.tasks.post_import_pipeline import _run_pipeline
+    from backend.app.models import Transaction, Account, InternalTransfer, Category
+    from backend.app.security.data_encryption import encrypt_value, blind_index, reset_encryption_config_cache
+    from tests.helpers import create_user
+    from decimal import Decimal
+    from datetime import datetime, timezone
+
+    monkeypatch.setenv("DATA_ENCRYPTION_KEY_CURRENT", "0" * 64)
+    reset_encryption_config_cache()
+
+    user = create_user(db_session)
+    pocket_iban = "NL91ABNA0417164300"
+    synced = Account(
+        user_id=user.id, name="Main", account_type="checking",
+        provider="gocardless", currency="EUR", starting_balance=Decimal("0"),
+    )
+    pocket = Account(
+        user_id=user.id, name="Pocket", account_type="savings",
+        provider="manual", currency="EUR", starting_balance=Decimal("0"),
+        iban_ciphertext=encrypt_value(pocket_iban),
+        iban_hash=blind_index(pocket_iban),
+    )
+    cat = Category(user_id=user.id, name="Transfer", category_type="transfer", is_system=True)
+    db_session.add_all([synced, pocket, cat]); db_session.commit()
+
+    src = Transaction(
+        user_id=user.id, account_id=synced.id, external_id="ext-pipe",
+        amount=Decimal("-20.00"), currency="EUR", description="to pocket",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(pocket_iban),
+        counterparty_iban_hash=blind_index(pocket_iban),
+    )
+    db_session.add(src); db_session.commit()
+
+    # Patch the LLM call to capture what it was given
+    calls = {"llm_txn_ids": []}
+    from backend.app.services.category_matcher import CategoryMatcher
+    def fake_batch(self, inp):
+        calls["llm_txn_ids"] = [d["index"] for d in inp]
+        return {}, 0, 0.0
+    monkeypatch.setattr(CategoryMatcher, "match_categories_batch_llm", fake_batch)
+
+    _run_pipeline(db_session, user_id=user.id, transaction_ids=[src.id], account_ids=[synced.id, pocket.id])
+
+    # Mirror was created
+    mirror_count = db_session.query(Transaction).filter_by(account_id=pocket.id).count()
+    assert mirror_count == 1
+    # Link exists
+    assert db_session.query(InternalTransfer).count() == 1
+    # LLM did NOT see internal transfers (filtered out by include_in_analytics=False)
+    assert len(calls["llm_txn_ids"]) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && pytest tests/test_post_import_pipeline.py::test_pipeline_runs_internal_transfer_detection_before_llm -v
+```
+
+Expected: FAIL — pipeline currently doesn't invoke the service, and LLM sees all transactions.
+
+- [ ] **Step 3: Add detection step + LLM filter**
+
+In `backend/tasks/post_import_pipeline.py`:
+
+First, update the module docstring to list 7 steps (was 6):
+
+```python
+"""
+Shared post-import pipeline Celery task.
+
+Runs 7 post-processing steps in order after any transaction import (CSV or Enable Banking):
+  1. FX rate sync
+  2. Functional amount calculation
+  3. Internal transfer detection (create mirrors, flag both sides as non-analytics)
+  4. Batch AI categorization (for transactions without a user-assigned category)
+  5. Balance calculation
+  6. Balance timeseries
+  7. Subscription detection
+"""
+```
+
+Add the import:
+
+```python
+from app.services.internal_transfer_service import InternalTransferService
+```
+
+Add the helper before `_batch_categorize_transactions`:
+
+```python
+def _detect_internal_transfers(db, user_id: str, transaction_ids: List[str]) -> int:
+    service = InternalTransferService(db, user_id=user_id)
+    return service.detect_for_transactions(transaction_ids)
+```
+
+Update `_batch_categorize_transactions`'s query to also filter out non-analytics transactions (mirrors and detected sources):
+
+```python
+    transactions = (
+        db.query(Transaction)
+        .filter(
+            Transaction.id.in_(transaction_ids),
+            Transaction.user_id == user_id,
+            Transaction.category_id.is_(None),   # Preserve user-assigned categories
+            Transaction.include_in_analytics.is_(True),  # Skip internal transfers
+        )
+        .all()
+    )
+```
+
+Then inside the main pipeline function (search for where `_update_functional_amounts(...)` is called — that's step 2), insert the new step 3 call immediately after:
+
+```python
+    _update_functional_amounts(db, user_id, transaction_ids)
+
+    # Step 3: Internal transfer detection (must run before LLM categorization)
+    detected = _detect_internal_transfers(db, user_id, transaction_ids)
+    logger.info("[POST_IMPORT_PIPELINE] Internal transfers detected: %d", detected)
+
+    # Step 4: Batch AI categorization
+    _batch_categorize_transactions(db, user_id, transaction_ids)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/test_post_import_pipeline.py -v
+```
+
+Expected: new test PASSes; previously-passing tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/tasks/post_import_pipeline.py backend/tests/test_post_import_pipeline.py
+git commit -m "feat(pipeline): detect internal transfers before LLM categorization"
+```
+
+---
+
+## Task 8: Backend endpoint — create pocket account with IBAN
+
+**Files:**
+- Modify: `backend/app/routes/accounts.py` (create the file if it does not yet exist; otherwise add a new router entry)
+- Test: `backend/tests/test_pocket_account_routes.py` (new)
+
+- [ ] **Step 1: Check whether `accounts.py` routes file exists**
+
+```bash
+ls backend/app/routes/ | grep -i account
+```
+
+If it exists, add the new endpoint to it. If not, create `backend/app/routes/accounts.py` and register the router in `backend/app/main.py` with `app.include_router(accounts_router, prefix="/api/accounts", tags=["accounts"])`.
+
+- [ ] **Step 2: Write failing test**
+
+Create `backend/tests/test_pocket_account_routes.py`:
+
+```python
+import pytest
+from decimal import Decimal
+from fastapi.testclient import TestClient
+from datetime import datetime, timezone
+
+from backend.app.main import app
+from backend.app.models import Account, Transaction, InternalTransfer, Category
+from backend.app.security.data_encryption import encrypt_value, blind_index, reset_encryption_config_cache
+from tests.helpers import create_user, make_internal_auth_headers  # existing helper used in other EB tests
+
+
+@pytest.fixture(autouse=True)
+def _keys(monkeypatch):
+    monkeypatch.setenv("DATA_ENCRYPTION_KEY_CURRENT", "0" * 64)
+    reset_encryption_config_cache()
+    yield
+    reset_encryption_config_cache()
+
+
+def test_create_pocket_account_encrypts_iban_and_backfills(db_session):
+    user = create_user(db_session)
+    # Pre-seed a synced account + one transaction with counterparty IBAN matching the to-be-registered pocket
+    synced = Account(
+        user_id=user.id, name="Main", account_type="checking",
+        provider="gocardless", currency="EUR", starting_balance=Decimal("0"),
+    )
+    cat = Category(user_id=user.id, name="Transfer", category_type="transfer", is_system=True)
+    db_session.add_all([synced, cat]); db_session.commit()
+
+    iban = "NL91ABNA0417164300"
+    src = Transaction(
+        user_id=user.id, account_id=synced.id, external_id="ext-pre",
+        amount=Decimal("-30.00"), currency="EUR", description="pre-existing",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(iban),
+        counterparty_iban_hash=blind_index(iban),
+    )
+    db_session.add(src); db_session.commit()
+
+    client = TestClient(app)
+    path = "/api/accounts/pocket"
+    resp = client.post(
+        path,
+        json={
+            "name": "My Pocket",
+            "account_type": "savings",
+            "currency": "EUR",
+            "starting_balance": "0",
+            "iban": iban,
+        },
+        headers=make_internal_auth_headers("POST", path, user.id),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["account_id"]
+    assert body["backfilled_count"] == 1
+
+    pocket = db_session.query(Account).filter_by(id=body["account_id"]).one()
+    assert pocket.provider == "manual"
+    assert pocket.iban_ciphertext.startswith("enc:v1:")
+    assert pocket.iban_hash == blind_index(iban)
+
+    # Backfill linked the pre-existing transaction
+    db_session.refresh(src)
+    assert src.include_in_analytics is False
+    assert src.internal_transfer_id is not None
+    assert db_session.query(InternalTransfer).count() == 1
+
+
+def test_create_pocket_account_rejects_duplicate_iban(db_session):
+    user = create_user(db_session)
+    iban = "NL91ABNA0417164300"
+    existing = Account(
+        user_id=user.id, name="Existing", account_type="savings",
+        provider="manual", currency="EUR", starting_balance=Decimal("0"),
+        iban_ciphertext=encrypt_value(iban), iban_hash=blind_index(iban),
+    )
+    db_session.add(existing); db_session.commit()
+
+    client = TestClient(app)
+    path = "/api/accounts/pocket"
+    resp = client.post(
+        path,
+        json={"name": "Dup", "account_type": "savings", "currency": "EUR", "starting_balance": "0", "iban": iban},
+        headers=make_internal_auth_headers("POST", path, user.id),
+    )
+    assert resp.status_code == 400
+    assert "already" in resp.json()["detail"].lower()
+
+
+def test_create_pocket_account_rejects_invalid_iban(db_session):
+    user = create_user(db_session)
+    client = TestClient(app)
+    path = "/api/accounts/pocket"
+    resp = client.post(
+        path,
+        json={"name": "Bad", "account_type": "savings", "currency": "EUR", "starting_balance": "0", "iban": "not-an-iban"},
+        headers=make_internal_auth_headers("POST", path, user.id),
+    )
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd backend && pytest tests/test_pocket_account_routes.py -v
+```
+
+Expected: FAIL — endpoint doesn't exist.
+
+- [ ] **Step 4: Implement the endpoint**
+
+Add to `backend/app/routes/accounts.py`:
+
+```python
+import re
+from decimal import Decimal
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.dependencies import get_user_id   # existing internal-auth dependency
+from app.models import Account, Transaction
+from app.security.data_encryption import encrypt_value, blind_index
+from app.services.internal_transfer_service import InternalTransferService
+
+router = APIRouter()
+
+_IBAN_RE = re.compile(r"^[A-Z]{2}\d{2}[A-Z0-9]{10,30}$")
+
+
+class CreatePocketRequest(BaseModel):
+    name: str
+    account_type: str = "savings"
+    currency: str = "EUR"
+    starting_balance: Decimal = Decimal("0")
+    iban: str
+
+    @field_validator("iban")
+    @classmethod
+    def _normalize_iban(cls, v: str) -> str:
+        norm = v.replace(" ", "").upper()
+        if not (15 <= len(norm) <= 34) or not _IBAN_RE.match(norm):
+            raise ValueError("Invalid IBAN format")
+        return norm
+
+
+class CreatePocketResponse(BaseModel):
+    account_id: UUID
+    backfilled_count: int
+
+
+@router.post("/pocket", response_model=CreatePocketResponse)
+def create_pocket_account(
+    payload: CreatePocketRequest,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    iban_hash = blind_index(payload.iban)
+    if iban_hash is None:
+        raise HTTPException(status_code=500, detail="Encryption not configured")
+
+    existing = (
+        db.query(Account)
+        .filter(Account.user_id == user_id, Account.iban_hash == iban_hash)
+        .first()
+    )
+    if existing is not None:
+        raise HTTPException(status_code=400, detail="An account with this IBAN is already registered")
+
+    account = Account(
+        user_id=user_id,
+        name=payload.name,
+        account_type=payload.account_type,
+        currency=payload.currency,
+        provider="manual",
+        starting_balance=payload.starting_balance,
+        functional_balance=payload.starting_balance,
+        iban_ciphertext=encrypt_value(payload.iban),
+        iban_hash=iban_hash,
+        is_active=True,
+    )
+    db.add(account)
+    db.flush()
+
+    # Backfill: find existing transactions whose counterparty matches this IBAN
+    candidate_ids = [
+        row[0]
+        for row in db.query(Transaction.id)
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.counterparty_iban_hash == iban_hash,
+            Transaction.internal_transfer_id.is_(None),
+        )
+        .all()
+    ]
+    service = InternalTransferService(db, user_id=user_id)
+    backfilled = service.detect_for_transactions(candidate_ids)
+    db.commit()
+
+    return CreatePocketResponse(account_id=account.id, backfilled_count=backfilled)
+```
+
+Also register the router — in `backend/app/main.py`, add:
+
+```python
+from app.routes import accounts as accounts_router
+app.include_router(accounts_router.router, prefix="/api/accounts", tags=["accounts"])
+```
+
+(If a router is already defined, add the new endpoint to the existing one instead.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/test_pocket_account_routes.py -v
+```
+
+Expected: all three tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/routes/accounts.py backend/app/main.py backend/tests/test_pocket_account_routes.py
+git commit -m "feat(api): POST /api/accounts/pocket — create pocket with IBAN + backfill"
+```
+
+---
+
+## Task 9: Backend endpoint — unlink internal transfer
+
+**Files:**
+- Modify: `backend/app/routes/accounts.py`
+- Test: `backend/tests/test_pocket_account_routes.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/test_pocket_account_routes.py`:
+
+```python
+def test_unlink_internal_transfer_restores_source(db_session):
+    user = create_user(db_session)
+    iban = "NL91ABNA0417164300"
+    synced = Account(user_id=user.id, name="Main", account_type="checking", provider="gocardless", currency="EUR", starting_balance=Decimal("0"))
+    pocket = Account(
+        user_id=user.id, name="Pocket", account_type="savings",
+        provider="manual", currency="EUR", starting_balance=Decimal("0"),
+        iban_ciphertext=encrypt_value(iban), iban_hash=blind_index(iban),
+    )
+    cat = Category(user_id=user.id, name="Transfer", category_type="transfer", is_system=True)
+    db_session.add_all([synced, pocket, cat]); db_session.commit()
+
+    src = Transaction(
+        user_id=user.id, account_id=synced.id, external_id="ext-u",
+        amount=Decimal("-9.00"), currency="EUR", description="x",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(iban),
+        counterparty_iban_hash=blind_index(iban),
+    )
+    db_session.add(src); db_session.commit()
+
+    from backend.app.services.internal_transfer_service import InternalTransferService
+    InternalTransferService(db_session, user_id=user.id).detect_for_transactions([src.id])
+    link = db_session.query(InternalTransfer).one()
+
+    client = TestClient(app)
+    path = f"/api/accounts/internal-transfers/{link.id}"
+    resp = client.delete(path, headers=make_internal_auth_headers("DELETE", path, user.id))
+    assert resp.status_code == 204
+
+    db_session.refresh(src)
+    assert src.include_in_analytics is True
+    assert db_session.query(InternalTransfer).count() == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd backend && pytest tests/test_pocket_account_routes.py::test_unlink_internal_transfer_restores_source -v
+```
+
+Expected: FAIL (404 — endpoint missing).
+
+- [ ] **Step 3: Implement the endpoint**
+
+Add to `backend/app/routes/accounts.py`:
+
+```python
+from fastapi import status
+
+@router.delete("/internal-transfers/{transfer_id}", status_code=status.HTTP_204_NO_CONTENT)
+def unlink_internal_transfer(
+    transfer_id: UUID,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    service = InternalTransferService(db, user_id=user_id)
+    service.unlink(transfer_id)
+    return None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/test_pocket_account_routes.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/routes/accounts.py backend/tests/test_pocket_account_routes.py
+git commit -m "feat(api): DELETE /api/accounts/internal-transfers/:id — unlink detected transfer"
+```
+
+---
+
+## Task 10: Backend endpoint — account delete cleans up internal transfers
+
+**Files:**
+- Modify: `backend/app/routes/accounts.py` (or wherever DELETE /api/accounts/:id lives today)
+- Test: `backend/tests/test_pocket_account_routes.py`
+
+- [ ] **Step 1: Locate the existing delete endpoint**
+
+```bash
+grep -rn "accounts/\{account_id\}" backend/app/routes/ || grep -rn "DELETE.*account" backend/app/routes/
+```
+
+If a DELETE endpoint already exists, modify it. If not, add one in `backend/app/routes/accounts.py`.
+
+- [ ] **Step 2: Write failing test**
+
+Append to `backend/tests/test_pocket_account_routes.py`:
+
+```python
+def test_delete_pocket_account_restores_linked_sources(db_session):
+    user = create_user(db_session)
+    iban = "NL91ABNA0417164300"
+    synced = Account(user_id=user.id, name="Main", account_type="checking", provider="gocardless", currency="EUR", starting_balance=Decimal("0"))
+    pocket = Account(
+        user_id=user.id, name="Pocket", account_type="savings",
+        provider="manual", currency="EUR", starting_balance=Decimal("0"),
+        iban_ciphertext=encrypt_value(iban), iban_hash=blind_index(iban),
+    )
+    cat = Category(user_id=user.id, name="Transfer", category_type="transfer", is_system=True)
+    db_session.add_all([synced, pocket, cat]); db_session.commit()
+
+    src = Transaction(
+        user_id=user.id, account_id=synced.id, external_id="ext-d",
+        amount=Decimal("-4.00"), currency="EUR", description="x",
+        booked_at=datetime(2026, 4, 1, tzinfo=timezone.utc), transaction_type="debit",
+        counterparty_iban_ciphertext=encrypt_value(iban),
+        counterparty_iban_hash=blind_index(iban),
+    )
+    db_session.add(src); db_session.commit()
+
+    from backend.app.services.internal_transfer_service import InternalTransferService
+    InternalTransferService(db_session, user_id=user.id).detect_for_transactions([src.id])
+    pocket_id = pocket.id
+
+    client = TestClient(app)
+    path = f"/api/accounts/{pocket_id}"
+    resp = client.delete(path, headers=make_internal_auth_headers("DELETE", path, user.id))
+    assert resp.status_code == 204
+
+    # Pocket gone
+    assert db_session.query(Account).filter_by(id=pocket_id).count() == 0
+    # Source restored
+    db_session.refresh(src)
+    assert src.include_in_analytics is True
+    assert src.internal_transfer_id is None
+    # Links gone
+    assert db_session.query(InternalTransfer).count() == 0
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+cd backend && pytest tests/test_pocket_account_routes.py::test_delete_pocket_account_restores_linked_sources -v
+```
+
+Expected: depending on whether a delete endpoint exists, either FAIL (404) or PASS-but-not-restored.
+
+- [ ] **Step 4: Implement / update the delete endpoint**
+
+In `backend/app/routes/accounts.py`:
+
+```python
+@router.delete("/{account_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_account(
+    account_id: UUID,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    account = (
+        db.query(Account)
+        .filter(Account.id == account_id, Account.user_id == user_id)
+        .one_or_none()
+    )
+    if account is None:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    # Pocket accounts may have linked internal transfers — restore the sources before cascade
+    InternalTransferService(db, user_id=user_id).unlink_all_for_pocket(account_id)
+
+    db.delete(account)
+    db.commit()
+    return None
+```
+
+If there is already a delete endpoint elsewhere (e.g. in the frontend server action using Drizzle), add the `unlink_all_for_pocket` call in that code path instead, before the delete runs.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd backend && pytest tests/test_pocket_account_routes.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/routes/accounts.py backend/tests/test_pocket_account_routes.py
+git commit -m "feat(api): DELETE /api/accounts/:id unlinks internal transfers before cascade"
+```
+
+---
+
+## Task 11: Frontend server actions — pocket account + unlink
+
+**Files:**
+- Modify: `frontend/lib/actions/accounts.ts`
+
+- [ ] **Step 1: Add the `createPocketAccount` action**
+
+In `frontend/lib/actions/accounts.ts`, add at the bottom of the file:
+
+```typescript
+import { getBackendBaseUrl } from "@/lib/backend-url";
+import { createInternalAuthHeaders } from "@/lib/internal-auth";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { isDemoRestrictedUserEmail, DEMO_RESTRICTED_ACTION_ERROR } from "@/lib/demo-access";
+
+export type CreatePocketAccountInput = {
+  name: string;
+  accountType?: string;           // defaults to "savings"
+  currency?: string;              // defaults to "EUR"
+  startingBalance?: number;
+  iban: string;
+};
+
+export async function createPocketAccount(
+  input: CreatePocketAccountInput,
+): Promise<{ success: boolean; error?: string; accountId?: string; backfilledCount?: number }> {
+  const session = await getAuthenticatedSession();
+  const userId = session?.user?.id;
+  if (!userId) return { success: false, error: "Not authenticated" };
+  if (isDemoRestrictedUserEmail(session.user.email)) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
+  }
+
+  try {
+    const path = "/api/accounts/pocket";
+    const url = `${getBackendBaseUrl().replace(/\/+$/, "")}${path}`;
+    const headers = createInternalAuthHeaders({ method: "POST", pathWithQuery: path, userId });
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({
+        name: input.name,
+        account_type: input.accountType ?? "savings",
+        currency: input.currency ?? "EUR",
+        starting_balance: String(input.startingBalance ?? 0),
+        iban: input.iban,
+      }),
+    });
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({ detail: "Failed to create pocket account" }));
+      return { success: false, error: data.detail ?? "Failed to create pocket account" };
+    }
+    const data = await resp.json();
+    revalidatePath("/settings");
+    revalidatePath("/transactions/import");
+    return { success: true, accountId: data.account_id, backfilledCount: data.backfilled_count };
+  } catch {
+    return { success: false, error: "Failed to create pocket account" };
+  }
+}
+
+export async function unlinkInternalTransfer(
+  transferId: string,
+): Promise<{ success: boolean; error?: string }> {
+  const session = await getAuthenticatedSession();
+  const userId = session?.user?.id;
+  if (!userId) return { success: false, error: "Not authenticated" };
+
+  try {
+    const path = `/api/accounts/internal-transfers/${transferId}`;
+    const url = `${getBackendBaseUrl().replace(/\/+$/, "")}${path}`;
+    const headers = createInternalAuthHeaders({ method: "DELETE", pathWithQuery: path, userId });
+    const resp = await fetch(url, { method: "DELETE", headers });
+    if (!resp.ok && resp.status !== 204) {
+      return { success: false, error: "Failed to unlink" };
+    }
+    revalidatePath("/transactions");
+    return { success: true };
+  } catch {
+    return { success: false, error: "Failed to unlink" };
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd frontend && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/lib/actions/accounts.ts
+git commit -m "feat(actions): createPocketAccount + unlinkInternalTransfer"
+```
+
+---
+
+## Task 12: Frontend — IBAN input in AccountForm
+
+**Files:**
+- Modify: `frontend/components/accounts/account-form.tsx`
+
+- [ ] **Step 1: Add IBAN state and validation regex**
+
+Replace the body of `frontend/components/accounts/account-form.tsx` with this version (keeps existing behavior for regular accounts and adds an optional "Register as Pocket" toggle that reveals the IBAN field):
+
+```typescript
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CURRENCIES, ACCOUNT_TYPES } from "@/lib/constants";
+import { createAccount, createPocketAccount } from "@/lib/actions/accounts";
+
+const IBAN_RE = /^[A-Z]{2}\d{2}[A-Z0-9]{10,30}$/;
+
+interface AccountFormProps {
+  onSuccess?: () => void;
+  onCancel?: () => void;
+  submitLabel?: string;
+  cancelLabel?: string;
+  showCancel?: boolean;
+  successMessage?: string;
+}
+
+export function AccountForm({
+  onSuccess,
+  onCancel,
+  submitLabel = "Create Account",
+  cancelLabel = "Cancel",
+  showCancel = true,
+  successMessage = "Account created successfully",
+}: AccountFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [name, setName] = useState("");
+  const [accountType, setAccountType] = useState("");
+  const [institution, setInstitution] = useState("");
+  const [currency, setCurrency] = useState("EUR");
+  const [initialBalance, setInitialBalance] = useState("");
+  const [isPocket, setIsPocket] = useState(false);
+  const [iban, setIban] = useState("");
+
+  const resetForm = () => {
+    setName("");
+    setAccountType("");
+    setInstitution("");
+    setCurrency("EUR");
+    setInitialBalance("");
+    setIsPocket(false);
+    setIban("");
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!name.trim()) {
+      toast.error("Please enter an account name");
+      return;
+    }
+    if (!accountType) {
+      toast.error("Please select an account type");
+      return;
+    }
+    if (!currency) {
+      toast.error("Please select a currency");
+      return;
+    }
+
+    const normalizedIban = iban.replace(/\s+/g, "").toUpperCase();
+    if (isPocket) {
+      if (!normalizedIban) {
+        toast.error("Please enter an IBAN for the pocket account");
+        return;
+      }
+      if (!IBAN_RE.test(normalizedIban) || normalizedIban.length < 15 || normalizedIban.length > 34) {
+        toast.error("Please enter a valid IBAN");
+        return;
+      }
+    }
+
+    setIsLoading(true);
+
+    try {
+      const balance = initialBalance ? parseFloat(initialBalance) : 0;
+      if (initialBalance && isNaN(balance)) {
+        toast.error("Please enter a valid initial balance");
+        setIsLoading(false);
+        return;
+      }
+
+      const result = isPocket
+        ? await createPocketAccount({
+            name: name.trim(),
+            accountType,
+            currency,
+            startingBalance: balance,
+            iban: normalizedIban,
+          })
+        : await createAccount({
+            name: name.trim(),
+            accountType,
+            institution: institution.trim() || undefined,
+            currency,
+            startingBalance: balance,
+          });
+
+      if (result.success) {
+        const message = isPocket && result.backfilledCount
+          ? `${successMessage} — ${result.backfilledCount} existing transfer(s) linked`
+          : successMessage;
+        toast.success(message);
+        resetForm();
+        onSuccess?.();
+      } else {
+        toast.error(result.error || "Failed to create account");
+      }
+    } catch {
+      toast.error("An error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    resetForm();
+    onCancel?.();
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="grid gap-4 py-4">
+        <div className="space-y-2">
+          <Label htmlFor="account-name">Account Name</Label>
+          <Input
+            id="account-name"
+            placeholder="e.g., Main Checking"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="account-type">Account Type</Label>
+          <Select value={accountType} onValueChange={(v) => v && setAccountType(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select account type" />
+            </SelectTrigger>
+            <SelectContent>
+              {ACCOUNT_TYPES.map((type) => (
+                <SelectItem key={type.value} value={type.value}>
+                  {type.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {!isPocket && (
+          <div className="space-y-2">
+            <Label htmlFor="account-institution">Institution (optional)</Label>
+            <Input
+              id="account-institution"
+              placeholder="e.g., Bank of America"
+              value={institution}
+              onChange={(e) => setInstitution(e.target.value)}
+            />
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="account-currency">Currency</Label>
+          <Select value={currency} onValueChange={(v) => v && setCurrency(v)}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select currency" />
+            </SelectTrigger>
+            <SelectContent>
+              {CURRENCIES.map((curr) => (
+                <SelectItem key={curr.code} value={curr.code}>
+                  {curr.code} - {curr.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="account-balance">Initial Balance (optional)</Label>
+          <Input
+            id="account-balance"
+            type="number"
+            step="0.01"
+            placeholder="0.00"
+            value={initialBalance}
+            onChange={(e) => setInitialBalance(e.target.value)}
+          />
+        </div>
+
+        <div className="flex items-center justify-between rounded border p-3">
+          <div>
+            <Label htmlFor="is-pocket" className="cursor-pointer">Register as pocket account</Label>
+            <p className="text-xs text-muted-foreground">
+              Tracks a savings pocket by IBAN. Transfers from your main account will be auto-detected.
+            </p>
+          </div>
+          <Switch id="is-pocket" checked={isPocket} onCheckedChange={setIsPocket} />
+        </div>
+
+        {isPocket && (
+          <div className="space-y-2">
+            <Label htmlFor="account-iban">IBAN</Label>
+            <Input
+              id="account-iban"
+              placeholder="NL91 ABNA 0417 1643 00"
+              value={iban}
+              onChange={(e) => setIban(e.target.value)}
+              autoComplete="off"
+              autoCapitalize="characters"
+            />
+          </div>
+        )}
+      </div>
+      <div className="flex justify-end gap-2">
+        {showCancel && (
+          <Button type="button" variant="outline" onClick={handleCancel} disabled={isLoading}>
+            {cancelLabel}
+          </Button>
+        )}
+        <Button type="submit" disabled={isLoading}>
+          {isLoading ? "Creating..." : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 2: Verify the `Switch` component is available**
+
+```bash
+ls frontend/components/ui/switch.tsx
+```
+
+If missing, add it via shadcn MCP. Command:
+
+```bash
+cd frontend && pnpm dlx shadcn@latest add switch
+```
+
+- [ ] **Step 3: Typecheck and build**
+
+```bash
+cd frontend && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/accounts/account-form.tsx frontend/components/ui/switch.tsx
+git commit -m "feat(ui): AccountForm — register-as-pocket toggle + IBAN input"
+```
+
+---
+
+## Task 13: Frontend — internal transfer chip on transaction detail
+
+**Files:**
+- Find: the transaction detail component (likely `frontend/components/transactions/transaction-row-details.tsx` or similar)
+- Modify: that component
+
+- [ ] **Step 1: Locate the component**
+
+```bash
+grep -rln "transaction" frontend/components/transactions/ | head
+```
+
+Find the component that renders transaction detail (expanded row, side panel, or dialog). Note its path.
+
+- [ ] **Step 2: Surface `internalTransferId` + pocket info in the query**
+
+In the Drizzle query that fetches a single transaction (search in `frontend/lib/actions/transactions.ts` or equivalent), add a left join to `internal_transfers` and `accounts` so the result includes `internalTransferId`, `pocketAccountId`, `pocketAccountName`. Example snippet (adapt to existing query shape):
+
+```typescript
+import { internalTransfers, accounts as accountsTable } from "@/lib/db/schema";
+
+// In the select:
+const rows = await db
+  .select({
+    // ... existing fields ...
+    internalTransferId: transactions.internalTransferId,
+    pocketAccountName: accountsTable.name,
+    pocketAccountId: accountsTable.id,
+  })
+  .from(transactions)
+  .leftJoin(internalTransfers, eq(internalTransfers.id, transactions.internalTransferId))
+  .leftJoin(accountsTable, eq(accountsTable.id, internalTransfers.pocketAccountId))
+  .where(/* existing */);
+```
+
+- [ ] **Step 3: Render the chip**
+
+In the transaction detail component, add near the top of the detail block:
+
+```tsx
+{transaction.internalTransferId && transaction.pocketAccountName && (
+  <div className="flex items-center gap-2 rounded border bg-muted/40 p-2 text-xs">
+    <RiExchangeLine className="h-4 w-4" />
+    <span className="flex-1">
+      Internal transfer — {transaction.pocketAccountName}
+    </span>
+    <button
+      type="button"
+      className="text-muted-foreground underline hover:text-foreground"
+      onClick={async () => {
+        const res = await unlinkInternalTransfer(transaction.internalTransferId!);
+        if (res.success) {
+          toast.success("Transfer unlinked");
+        } else {
+          toast.error(res.error ?? "Failed to unlink");
+        }
+      }}
+    >
+      Unlink
+    </button>
+  </div>
+)}
+```
+
+Add imports at the top of the file:
+
+```tsx
+import { RiExchangeLine } from "@remixicon/react";
+import { unlinkInternalTransfer } from "@/lib/actions/accounts";
+import { toast } from "sonner";
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+cd frontend && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/transactions/ frontend/lib/actions/transactions.ts
+git commit -m "feat(ui): internal-transfer chip + unlink button on transaction detail"
+```
+
+---
+
+## Task 14: Frontend — "Pocket" badge on account card
+
+**Files:**
+- Find: the account list or account card component (likely `frontend/components/accounts/account-header.tsx` or a list page)
+- Modify: that component
+
+- [ ] **Step 1: Locate the component**
+
+```bash
+grep -rln "provider.*manual\|Manual\b" frontend/components/accounts/ | head
+```
+
+If there is already logic branching on `provider`, extend it. Otherwise, open `frontend/components/accounts/account-header.tsx` and the account list at `frontend/app/(dashboard)/settings/accounts/page.tsx` (or similar) and add the badge where account metadata is rendered.
+
+- [ ] **Step 2: Add the badge**
+
+Where the account's name/type is rendered, add:
+
+```tsx
+{account.provider === "manual" && account.ibanHash ? (
+  <Badge variant="secondary">Pocket</Badge>
+) : null}
+```
+
+The Drizzle query that loads the account must include `ibanHash` — check `frontend/lib/actions/accounts.ts` and add `ibanHash: accounts.ibanHash` to the select if missing.
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+cd frontend && pnpm tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Visual check**
+
+Run `cd frontend && pnpm dev`, create a pocket account via the form, and confirm:
+- The "Pocket" badge appears on the account card
+- Internal transfer chip appears on a transaction whose counterparty IBAN matches the pocket
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/components/accounts/ frontend/lib/actions/accounts.ts
+git commit -m "feat(ui): Pocket badge on account header + include ibanHash in query"
+```
+
+---
+
+## Task 15: Deploy
+
+- [ ] **Step 1: Open PR**
+
+```bash
+gh pr create --title "feat: pocket account tracking (IBAN-based internal transfer detection)" --body "$(cat <<'EOF'
+## Summary
+- Adds manual "pocket" accounts registered by IBAN
+- Enable Banking adapter extracts counterparty IBAN
+- Post-import pipeline detects internal transfers, creates mirror transactions on pocket accounts, flags both sides as `include_in_analytics=false`
+- Frontend: IBAN input, "Pocket" badge, internal-transfer chip with unlink action
+- Spec: `docs/superpowers/specs/2026-04-19-pocket-accounts-design.md`
+
+## Test plan
+- [ ] Run `pytest backend/tests/ -v` — all green
+- [ ] Create a pocket account with an IBAN that matches existing transactions → backfill creates mirrors
+- [ ] Trigger a bank sync → new transfers auto-linked
+- [ ] Unlink a mistaken match via the chip → source restored to analytics
+- [ ] Delete the pocket account → all sources restored
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Merge the PR and redeploy Railway services**
+
+After merge:
+
+```bash
+RAILWAY_ENVIRONMENT=production railway redeploy --service backend --yes
+RAILWAY_ENVIRONMENT=production railway redeploy --service worker --yes
+```
+
+(Frontend redeploy is automatic via Railway's GitHub integration.)
+
+- [ ] **Step 3: Post-deploy smoke check**
+
+On the deployed app:
+1. Go to Settings → Accounts → Add Account
+2. Toggle "Register as pocket account"
+3. Enter an IBAN matching one of your existing counterparties
+4. Submit → verify backfill count in the success toast
+5. Open a linked transaction → confirm chip appears
+
+---
+
+## Completion criteria
+
+- All 15 tasks checked off
+- All tests passing: `cd backend && pytest tests/ -v` and `cd frontend && pnpm tsc --noEmit`
+- PR merged and deployed
+- Manual smoke check passed

--- a/docs/superpowers/plans/2026-04-19-pocket-accounts.md
+++ b/docs/superpowers/plans/2026-04-19-pocket-accounts.md
@@ -26,7 +26,7 @@
 | `backend/app/services/sync_service.py` | Encrypt + hash IBAN on persist |
 | `backend/app/services/internal_transfer_service.py` | NEW — detect/unlink internal transfers |
 | `backend/tasks/post_import_pipeline.py` | Add detection step; filter LLM by `include_in_analytics` |
-| `backend/app/routes/accounts.py` | NEW endpoints — create pocket, update iban, delete cleanup |
+| `backend/app/routes/accounts.py` | NEW endpoints — create pocket, unlink internal transfer, delete cleanup |
 | `frontend/lib/actions/accounts.ts` | Route IBAN ops through backend; new `unlinkInternalTransfer` |
 | `frontend/components/accounts/account-form.tsx` | IBAN input + validation |
 | `frontend/components/transactions/transaction-row-details.tsx` | Internal-transfer chip |

--- a/docs/superpowers/specs/2026-04-19-pocket-accounts-design.md
+++ b/docs/superpowers/specs/2026-04-19-pocket-accounts-design.md
@@ -1,0 +1,348 @@
+# IBAN-Based Pocket Account Tracking
+
+**Date:** 2026-04-19
+**Status:** Approved
+
+## Background
+
+Some savings accounts (notably ABN AMRO "pockets") cannot be synced via Open Banking. However, every transfer between the user's main synced account and a pocket shows up in the main account's transaction feed, complete with a counterparty IBAN.
+
+This feature lets users manually register a pocket account by IBAN, and then the system:
+1. Auto-detects transfers between the synced parent and the pocket by matching counterparty IBAN
+2. Creates a mirror transaction on the pocket account so its balance derives naturally
+3. Flags both sides as `include_in_analytics = false` so transfers don't pollute spending/income analytics
+
+---
+
+## Goals
+
+1. Extract counterparty IBAN from Enable Banking transactions during sync
+2. Let users register pocket accounts (manual provider) with a canonical IBAN + starting balance
+3. Auto-detect and link internal transfers by matching `counterparty_iban_hash`
+4. Derive pocket balances from mirror transactions (consistent with the existing `starting_balance + sum(transactions)` model)
+5. Exclude detected transfers from analytics on both sides
+6. Let users unlink a mistaken match, reverting `include_in_analytics` and deleting the mirror
+
+## Non-Goals
+
+- Pockets that share an IBAN with the synced parent (ABN pockets have distinct IBANs)
+- Detecting transfers between two synced user-owned accounts (separate concern — can reuse the same machinery later)
+- IBAN validation beyond basic format (country code + length); full mod-97 is YAGNI
+- Predictive/fuzzy counterparty matching — the whole point is IBAN is an explicit identifier
+
+---
+
+## Approach
+
+Add IBAN fields to `accounts` and `transactions`. Add a new `internal_transfers` table that links the source transaction (on the synced account) to its mirror transaction (on the pocket account). Detection runs as a new step in the post-import pipeline, and a backfill runs on pocket account creation.
+
+No new service abstraction for counterparty extraction — the Enable Banking adapter gains a few lines to extract IBAN from the nested `creditor`/`debtor` objects it already parses.
+
+---
+
+## Changes
+
+### 1. Add IBAN fields to `accounts`
+
+**Files:** `frontend/lib/db/schema.ts`, `backend/app/models.py`, migration
+
+Two new nullable columns on `accounts`:
+- `iban_ciphertext` (text) — AES-encrypted IBAN, using the existing `data_encryption` util
+- `iban_hash` (varchar 64) — HMAC-SHA256 blind index for lookup without decrypting
+
+No partial unique constraint — users can legitimately share an IBAN across households (e.g., spouse's pocket), and the lookup is always scoped by `user_id`. A composite index `(user_id, iban_hash)` is added instead.
+
+### 2. Add counterparty IBAN fields to `transactions`
+
+**Files:** `frontend/lib/db/schema.ts`, `backend/app/models.py`, migration
+
+Three new nullable columns on `transactions`:
+- `counterparty_iban_ciphertext` (text) — encrypted raw IBAN
+- `counterparty_iban_hash` (varchar 64) — blind index for matching
+- `internal_transfer_id` (uuid, FK to `internal_transfers.id`, `ON DELETE SET NULL`)
+
+Index: `(user_id, counterparty_iban_hash)` for the detection query.
+
+### 3. Add `internal_transfers` table
+
+**Files:** `frontend/lib/db/schema.ts`, `backend/app/models.py`, migration
+
+```sql
+CREATE TABLE internal_transfers (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  source_txn_id    UUID NOT NULL UNIQUE REFERENCES transactions(id) ON DELETE CASCADE,
+  mirror_txn_id    UUID UNIQUE REFERENCES transactions(id) ON DELETE SET NULL,
+  source_account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  pocket_account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  amount           DECIMAL(15,2) NOT NULL,
+  currency         CHAR(3) NOT NULL,
+  detected_at      TIMESTAMP DEFAULT NOW(),
+  created_at       TIMESTAMP DEFAULT NOW()
+);
+CREATE INDEX idx_internal_transfers_user ON internal_transfers(user_id);
+CREATE INDEX idx_internal_transfers_pocket ON internal_transfers(pocket_account_id);
+```
+
+`source_txn_id` is unique — a transaction can only be part of one internal transfer. `mirror_txn_id` is nullable to allow "detected but not yet mirrored" states (and simplifies unlink → we can null it out then delete the mirror).
+
+### 4. Extract counterparty IBAN in the Enable Banking adapter
+
+**File:** `backend/app/integrations/enable_banking_adapter.py` — `normalize_transaction()`
+
+Enable Banking returns counterparty account objects as `creditor_account` / `debtor_account` (or nested under `creditor` / `debtor`), typically shaped like `{"iban": "NL91ABNA0417164300"}` or `{"identification": "...", "scheme_name": "IBAN"}`.
+
+**Logic** (appended to existing creditor/debtor name extraction):
+
+```python
+def _extract_iban(account_obj):
+    if not isinstance(account_obj, dict):
+        return None
+    # Most common field
+    iban = account_obj.get("iban")
+    if iban:
+        return iban.replace(" ", "").upper()
+    # Fallback: scheme_name + identification
+    if account_obj.get("scheme_name", "").upper() == "IBAN":
+        ident = account_obj.get("identification")
+        if ident:
+            return ident.replace(" ", "").upper()
+    return None
+
+creditor_iban = _extract_iban(raw.get("creditor_account")) or _extract_iban(raw.get("creditor"))
+debtor_iban   = _extract_iban(raw.get("debtor_account"))   or _extract_iban(raw.get("debtor"))
+
+# Counterparty depends on direction: for outflows (DBIT), counterparty is creditor; for inflows, debtor
+counterparty_iban = creditor_iban if credit_debit == "DBIT" else debtor_iban
+```
+
+Two new fields on `TransactionData` (the adapter DTO): `counterparty_iban: str | None`. Hashing happens at persist time in the sync service (where the encryption keys live), not in the adapter.
+
+### 5. Persist counterparty IBAN during sync
+
+**File:** `backend/app/services/sync_service.py` (or wherever `TransactionData` → `Transaction` mapping lives)
+
+On insert/update of a transaction, if `TransactionData.counterparty_iban` is set:
+- `transaction.counterparty_iban_ciphertext = encrypt(iban)`
+- `transaction.counterparty_iban_hash = blind_index(iban)`
+
+Uses the existing `encrypt()` / `blind_index()` helpers from `backend/app/security/data_encryption.py`.
+
+### 6. Internal transfer detection service
+
+**File:** `backend/app/services/internal_transfer_service.py` (new)
+
+One class, `InternalTransferService`, with two public methods:
+
+```python
+class InternalTransferService:
+    def __init__(self, db: Session, user_id: str): ...
+
+    def detect_for_transactions(self, transaction_ids: list[UUID]) -> int:
+        """
+        For each transaction in the list that has a counterparty_iban_hash,
+        check if it matches a manual account's iban_hash. If so, create the
+        internal_transfer + mirror transaction and mark both include_in_analytics=False.
+        Returns number of transfers detected.
+        Idempotent: skips transactions that already have internal_transfer_id set.
+        """
+
+    def unlink(self, internal_transfer_id: UUID) -> None:
+        """
+        Delete the mirror transaction, clear internal_transfer_id on the source,
+        set include_in_analytics=True on the source, delete the internal_transfers row.
+        """
+
+    def unlink_all_for_pocket(self, pocket_account_id: UUID) -> int:
+        """
+        Called by the delete-account endpoint before cascading delete.
+        Restores include_in_analytics=True on all source transactions linked to
+        this pocket; deletes internal_transfers rows. Mirror transactions are
+        left to the cascade. Returns count unlinked.
+        """
+```
+
+**Detection logic:**
+
+1. Load source transactions where `id IN (:ids) AND counterparty_iban_hash IS NOT NULL AND internal_transfer_id IS NULL`
+2. Build a dict of the user's manual account IBAN hashes: `{iban_hash: account}` for `user_id == self.user_id AND provider == 'manual' AND iban_hash IS NOT NULL`
+3. For each source transaction where `counterparty_iban_hash in manual_accounts`:
+   - Skip if source account == matched pocket (shouldn't happen but defensive)
+   - Create a mirror `Transaction`:
+     - `account_id` = pocket's id
+     - `amount` = `-source.amount` (sign flipped)
+     - `currency` = `source.currency`
+     - `booked_at` = `source.booked_at`
+     - `description` = `f"Transfer from/to {source_account.name}"`
+     - `merchant` = `source_account.name`
+     - `external_id` = `f"mirror-{source.id}"` (avoids dedup collision, scopes to this account)
+     - `category_system_id` = the user's "Transfer" category (resolved once per detection batch); `category_id` left NULL so the user can still override
+     - `include_in_analytics` = `False`
+     - `transaction_type` = `"credit"` if new amount > 0 else `"debit"`
+     - Pass the source account's IBAN as the mirror's `counterparty_iban` (if the synced account has one stored, otherwise leave null)
+   - Create `InternalTransfer` row linking source + mirror
+   - Update source: `include_in_analytics = False`, `internal_transfer_id = <new row id>`
+4. Return count
+
+### 7. Wire detection into the post-import pipeline
+
+**File:** `backend/tasks/post_import_pipeline.py`
+
+Add a new step between "functional amounts" and "batch AI categorization":
+
+```python
+# Step 2.5: Internal transfer detection
+transfer_service = InternalTransferService(db, user_id=user_id)
+detected = transfer_service.detect_for_transactions(touched_transaction_ids)
+logger.info("[PIPELINE] Internal transfers detected: %s", detected)
+```
+
+Must run **after** functional amounts (so mirrors inherit correct FX-converted values) and **before** batch AI categorization. Full order: fx rates → functional amounts → **internal transfer detection** → batch LLM categorization → balance calculation → balance timeseries → subscription detection.
+
+**Mirror functional amount**: computed at insert time by reusing the same `compute_functional_amount()` helper the pipeline step uses for new transactions.
+
+**LLM skip**: the batch categorization step must filter out transactions where `include_in_analytics = False` (which now includes all mirrors and detected source transactions). If that filter is not already present in `CategoryMatcher`, it is added as part of this work.
+
+### 8. Backfill on pocket account creation
+
+**Files:** `backend/app/routes/accounts.py` (or the existing create/update account endpoint)
+
+When a user creates a manual account with an IBAN, or updates an existing manual account to add/change an IBAN:
+
+1. Compute `iban_hash` and persist to the account
+2. Fetch all transactions for the user where `counterparty_iban_hash == iban_hash` AND `internal_transfer_id IS NULL`
+3. Call `InternalTransferService.detect_for_transactions(those_ids)`
+4. Recalculate balance timeseries for the pocket account and the source accounts involved (reuse existing `recalculate_balance_timeseries` task)
+
+This is a synchronous operation wrapped in a single DB transaction. Expected volume is low (≤ a few hundred transactions per pocket).
+
+### 9. Frontend: account form with IBAN input
+
+**File:** `frontend/components/accounts/account-form.tsx`
+
+Add an optional `iban` text input, only shown when the form is creating/editing a manual account. Client-side validation:
+- Trimmed, uppercased
+- Matches `/^[A-Z]{2}\d{2}[A-Z0-9]{10,30}$/` (2 letter country code + 2 check digits + 10-30 alphanumeric)
+- Length 15-34 characters
+
+Server action accepts `iban`, passes through to the backend.
+
+### 10. Frontend: server action + backend update
+
+**File:** `frontend/lib/actions/accounts.ts`
+
+Existing `createAccount` / `updateAccount` actions gain an `iban?: string` field. When present, the action posts it to the backend, which handles encryption + hashing + backfill.
+
+### 11. Frontend: internal transfer chip on transaction detail
+
+**Files:** Transaction detail component (locate during implementation)
+
+When a transaction has `internal_transfer_id`:
+- Show a subtle chip: "Internal transfer — {pocket account name}"
+- Clicking the chip navigates to the pocket account
+- An "Unlink" button (in the chip's context menu) calls a new server action `unlinkInternalTransfer(transferId)` → backend deletes mirror + clears flags
+
+### 12. Frontend: pocket account indicators
+
+**File:** Account list / card component
+
+- Accounts with `provider == "manual"` AND `iban IS NOT NULL` get a "Pocket" badge
+- Balance displays normally (derived from `starting_balance + sum(transactions)`, which now includes mirror transactions)
+
+---
+
+## Data Flow
+
+### New transaction arrives via sync
+
+```
+EB adapter normalizes txn
+  → TransactionData.counterparty_iban = "NL91..."
+  → SyncService persists txn with encrypted iban + iban_hash
+  → post_import_pipeline runs
+      → functional amounts
+      → InternalTransferService.detect_for_transactions([new_txn_ids])
+          → matches counterparty_iban_hash against user's manual accounts
+          → match found → creates mirror txn + internal_transfers row
+          → source.include_in_analytics = False
+      → batch LLM categorization (skips transactions already in Transfer category)
+      → balance timeseries recalc (pocket's balance now reflects mirror)
+```
+
+### User creates a pocket account with IBAN
+
+```
+POST /accounts {name, type: "savings", provider: "manual", iban, startingBalance}
+  → backend validates IBAN format
+  → encrypts IBAN, computes blind_index
+  → inserts account
+  → queries transactions where counterparty_iban_hash matches → N results
+  → InternalTransferService.detect_for_transactions([N ids])
+  → recalculates balance timeseries
+  → returns account with derived balance
+```
+
+### User unlinks a mistaken match
+
+```
+Click "Unlink" on transaction detail
+  → unlinkInternalTransfer(transferId) server action
+  → backend InternalTransferService.unlink(transferId)
+      → delete mirror transaction
+      → source: include_in_analytics=True, internal_transfer_id=NULL
+      → delete internal_transfers row
+  → balance timeseries recalc for affected accounts
+```
+
+---
+
+## What Does Not Change
+
+- Existing balance computation (`starting_balance + sum(transactions)`) — mirrors are just transactions ✅
+- Existing FX conversion / functional amount pipeline — mirrors use the same helpers ✅
+- Existing dedup via `(account_id, external_id)` unique constraint — mirrors use `mirror-{source_id}` as external_id, scoped to pocket account ✅
+- LLM categorization — mirrors arrive pre-categorized as Transfer, skipped ✅
+- Analytics queries — they already filter on `include_in_analytics = True` ✅
+
+---
+
+## Error Handling
+
+- **Duplicate detection**: `internal_transfer_id IS NULL` check makes detection idempotent — re-running the pipeline is a no-op for already-linked transactions.
+- **Cross-currency transfer**: mirror uses the same raw currency as the source. Balance timeseries + functional_amount handle FX conversion as usual.
+- **Pocket account deletion**: the delete-account endpoint must, before performing the delete, call `InternalTransferService.unlink_all_for_pocket(pocket_account_id)` which:
+  1. Loads every `internal_transfers` row where `pocket_account_id = target`
+  2. For each: sets source `include_in_analytics = True`, clears `internal_transfer_id`
+  3. Deletes the `internal_transfers` rows (mirror transactions are deleted by cascade when the pocket account is deleted)
+  Only after that does the account delete proceed. This keeps analytics consistent without relying on post-hoc cleanup.
+- **IBAN collision** (two pocket accounts with the same IBAN): disallowed at app level — reject on create with 400 "IBAN already registered for another account."
+
+---
+
+## Testing
+
+- Unit: `InternalTransferService.detect_for_transactions` matches, creates mirror, flips analytics flag
+- Unit: `InternalTransferService.unlink` reverses the above
+- Unit: EB adapter extracts IBAN from both `creditor_account.iban` and nested `creditor.iban` shapes
+- Integration: full sync → pipeline → pocket with pre-existing IBAN → mirror created, balance correct
+- Integration: create pocket account with existing matching transactions → backfill runs → mirrors created
+- Integration: delete pocket account → source transactions restored to `include_in_analytics=True`
+
+---
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `frontend/lib/db/schema.ts` | Add iban fields to accounts; counterparty_iban fields to transactions; new internal_transfers table |
+| `backend/app/models.py` | Mirror above |
+| `frontend/lib/db/migrations/` | One migration for all three schema changes |
+| `backend/app/integrations/enable_banking_adapter.py` | Extract counterparty IBAN |
+| `backend/app/services/sync_service.py` | Persist encrypted IBAN + hash when inserting transactions |
+| `backend/app/services/internal_transfer_service.py` | NEW — detect + unlink |
+| `backend/tasks/post_import_pipeline.py` | Wire detection step |
+| `backend/app/routes/accounts.py` | Accept IBAN; trigger backfill on create/update |
+| `frontend/components/accounts/account-form.tsx` | IBAN input, validation |
+| `frontend/lib/actions/accounts.ts` | Pass IBAN through; new `unlinkInternalTransfer` action |
+| Transaction detail component | Internal transfer chip + unlink button |
+| Account list / card component | "Pocket" badge |

--- a/frontend/components/accounts/account-form.tsx
+++ b/frontend/components/accounts/account-form.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -13,7 +14,9 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { CURRENCIES, ACCOUNT_TYPES } from "@/lib/constants";
-import { createAccount } from "@/lib/actions/accounts";
+import { createAccount, createPocketAccount } from "@/lib/actions/accounts";
+
+const IBAN_RE = /^[A-Z]{2}\d{2}[A-Z0-9]{10,30}$/;
 
 interface AccountFormProps {
   onSuccess?: () => void;
@@ -39,6 +42,8 @@ export function AccountForm({
   const [institution, setInstitution] = useState("");
   const [currency, setCurrency] = useState("EUR");
   const [initialBalance, setInitialBalance] = useState("");
+  const [isPocket, setIsPocket] = useState(false);
+  const [iban, setIban] = useState("");
 
   const resetForm = () => {
     setName("");
@@ -46,6 +51,8 @@ export function AccountForm({
     setInstitution("");
     setCurrency("EUR");
     setInitialBalance("");
+    setIsPocket(false);
+    setIban("");
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -55,15 +62,29 @@ export function AccountForm({
       toast.error("Please enter an account name");
       return;
     }
-
     if (!accountType) {
       toast.error("Please select an account type");
       return;
     }
-
     if (!currency) {
       toast.error("Please select a currency");
       return;
+    }
+
+    const normalizedIban = iban.replace(/\s+/g, "").toUpperCase();
+    if (isPocket) {
+      if (!normalizedIban) {
+        toast.error("Please enter an IBAN for the pocket account");
+        return;
+      }
+      if (
+        !IBAN_RE.test(normalizedIban)
+        || normalizedIban.length < 15
+        || normalizedIban.length > 34
+      ) {
+        toast.error("Please enter a valid IBAN");
+        return;
+      }
     }
 
     setIsLoading(true);
@@ -76,16 +97,31 @@ export function AccountForm({
         return;
       }
 
-      const result = await createAccount({
-        name: name.trim(),
-        accountType,
-        institution: institution.trim() || undefined,
-        currency,
-        startingBalance: balance,
-      });
+      const result = isPocket
+        ? await createPocketAccount({
+            name: name.trim(),
+            accountType,
+            currency,
+            startingBalance: balance,
+            iban: normalizedIban,
+          })
+        : await createAccount({
+            name: name.trim(),
+            accountType,
+            institution: institution.trim() || undefined,
+            currency,
+            startingBalance: balance,
+          });
 
       if (result.success) {
-        toast.success(successMessage);
+        const backfilled =
+          isPocket && "backfilledCount" in result && typeof result.backfilledCount === "number"
+            ? result.backfilledCount
+            : 0;
+        const message = backfilled > 0
+          ? `${successMessage} — ${backfilled} existing transfer${backfilled === 1 ? "" : "s"} linked`
+          : successMessage;
+        toast.success(message);
         resetForm();
         onSuccess?.();
       } else {
@@ -132,15 +168,17 @@ export function AccountForm({
           </Select>
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="account-institution">Institution (optional)</Label>
-          <Input
-            id="account-institution"
-            placeholder="e.g., Bank of America"
-            value={institution}
-            onChange={(e) => setInstitution(e.target.value)}
-          />
-        </div>
+        {!isPocket && (
+          <div className="space-y-2">
+            <Label htmlFor="account-institution">Institution (optional)</Label>
+            <Input
+              id="account-institution"
+              placeholder="e.g., Bank of America"
+              value={institution}
+              onChange={(e) => setInstitution(e.target.value)}
+            />
+          </div>
+        )}
 
         <div className="space-y-2">
           <Label htmlFor="account-currency">Currency</Label>
@@ -169,6 +207,41 @@ export function AccountForm({
             onChange={(e) => setInitialBalance(e.target.value)}
           />
         </div>
+
+        <div className="flex items-center justify-between rounded border p-3">
+          <div className="space-y-0.5">
+            <Label htmlFor="is-pocket" className="cursor-pointer">
+              Register as pocket account
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              Track a savings pocket by IBAN. Transfers from your synced accounts
+              will be auto-detected and linked.
+            </p>
+          </div>
+          <Switch
+            id="is-pocket"
+            checked={isPocket}
+            onCheckedChange={setIsPocket}
+          />
+        </div>
+
+        {isPocket && (
+          <div className="space-y-2">
+            <Label htmlFor="account-iban">IBAN</Label>
+            <Input
+              id="account-iban"
+              placeholder="NL91 ABNA 0417 1643 00"
+              value={iban}
+              onChange={(e) => setIban(e.target.value)}
+              autoComplete="off"
+              autoCapitalize="characters"
+            />
+            <p className="text-xs text-muted-foreground">
+              Spaces are ignored. The IBAN is encrypted at rest and only used to
+              match transfers from your synced accounts.
+            </p>
+          </div>
+        )}
       </div>
       <div className="flex justify-end gap-2">
         {showCancel && (

--- a/frontend/components/settings/account-list.tsx
+++ b/frontend/components/settings/account-list.tsx
@@ -16,6 +16,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -224,7 +225,12 @@ export function AccountList({ accounts, onAccountUpdated }: AccountListProps) {
                     className="!size-10"
                   />
                   <div>
-                    <p className="font-medium">{account.name}</p>
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium">{account.name}</p>
+                      {account.provider === "manual" && account.ibanHash ? (
+                        <Badge variant="secondary">Pocket</Badge>
+                      ) : null}
+                    </div>
                     <p className="text-sm text-muted-foreground">
                       {getAccountTypeLabel(account.accountType)}
                       {account.institution && ` • ${account.institution}`}

--- a/frontend/components/transactions/transaction-sheet.tsx
+++ b/frontend/components/transactions/transaction-sheet.tsx
@@ -34,10 +34,11 @@ import { Separator } from "@/components/ui/separator";
 import { cn, formatDate, formatAmount } from "@/lib/utils";
 import type { TransactionWithRelations } from "@/lib/actions/transactions";
 import { updateTransactionCategory, updateTransactionIncludeInAnalytics, deleteBalancingTransaction } from "@/lib/actions/transactions";
+import { unlinkInternalTransfer } from "@/lib/actions/accounts";
 import { Switch } from "@/components/ui/switch";
 import type { CategoryDisplay } from "@/types";
 import { filterSelectableCategories } from "@/lib/utils/category-utils";
-import { RiDeleteBinLine, RiLoopRightLine } from "@remixicon/react";
+import { RiDeleteBinLine, RiExchangeLine, RiLoopRightLine } from "@remixicon/react";
 import { toast } from "sonner";
 import { SubscriptionDetectionDialog } from "./subscription-detection-dialog";
 import { SubscriptionLinkedDialog } from "./subscription-linked-dialog";
@@ -79,13 +80,35 @@ export function TransactionSheet({
   const [showLinkedSubscriptionDialog, setShowLinkedSubscriptionDialog] = useState(false);
   const [showLinkReimbursementsDialog, setShowLinkReimbursementsDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [isUnlinkingTransfer, setIsUnlinkingTransfer] = useState(false);
 
   const isBalancingTransfer = transaction?.category?.name === "Balancing Transfer";
   const isExpense = transaction?.transactionType === "debit";
   const hasLinkedSubscription = !!transaction?.recurringTransactionId;
+  const pocketAccountName = transaction?.internalTransfer?.pocketAccount?.name ?? null;
+  const internalTransferId = transaction?.internalTransferId ?? null;
 
   // Track previous transaction ID to only reset state when a different transaction is opened
   const prevTransactionIdRef = useRef<string | null>(null);
+
+  const handleUnlinkInternalTransfer = async () => {
+    if (!internalTransferId) return;
+
+    setIsUnlinkingTransfer(true);
+    try {
+      const result = await unlinkInternalTransfer(internalTransferId);
+      if (result.success) {
+        toast.success("Transfer unlinked");
+        router.refresh();
+      } else {
+        toast.error(result.error || "Failed to unlink");
+      }
+    } catch {
+      toast.error("Failed to unlink");
+    } finally {
+      setIsUnlinkingTransfer(false);
+    }
+  };
 
   const handleRevertBalancingTransfer = async () => {
     if (!transaction) return;
@@ -225,6 +248,24 @@ export function TransactionSheet({
 
         {/* Scrollable Content */}
         <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0 space-y-6 pr-1">
+          {/* Internal Transfer Chip */}
+          {internalTransferId && pocketAccountName && (
+            <div className="flex items-center gap-2 rounded border bg-muted/40 p-2 text-xs">
+              <RiExchangeLine className="h-4 w-4 shrink-0" />
+              <span className="flex-1 truncate">
+                Internal transfer — {pocketAccountName}
+              </span>
+              <button
+                type="button"
+                className="text-muted-foreground underline hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={handleUnlinkInternalTransfer}
+                disabled={isUnlinkingTransfer}
+              >
+                {isUnlinkingTransfer ? "Unlinking..." : "Unlink"}
+              </button>
+            </div>
+          )}
+
           {/* Category Section */}
           <div className="space-y-3">
             <Label htmlFor="category">Category</Label>

--- a/frontend/lib/actions/accounts.ts
+++ b/frontend/lib/actions/accounts.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from "next/cache";
 import { eq, and, lte, gte, lt, desc, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, accountBalances, transactions, recurringTransactions, subscriptionSuggestions, type NewAccount } from "@/lib/db/schema";
-import { requireAuth } from "@/lib/auth-helpers";
+import { requireAuth, getAuthenticatedSession } from "@/lib/auth-helpers";
+import { isDemoRestrictedUserEmail, DEMO_RESTRICTED_ACTION_ERROR } from "@/lib/demo-access";
 import { getBackendBaseUrl } from "@/lib/backend-url";
 import { createInternalAuthHeaders } from "@/lib/internal-auth";
 import {
@@ -629,5 +630,96 @@ export async function recalculateAccountTimeseries(
   } catch (error) {
     console.error("Failed to recalculate timeseries:", error);
     return { success: false, error: "Failed to recalculate timeseries" };
+  }
+}
+
+export type CreatePocketAccountInput = {
+  name: string;
+  accountType?: string;
+  currency?: string;
+  startingBalance?: number;
+  iban: string;
+};
+
+export async function createPocketAccount(
+  input: CreatePocketAccountInput,
+): Promise<{ success: boolean; error?: string; accountId?: string; backfilledCount?: number }> {
+  const session = await getAuthenticatedSession();
+  const userId = session?.user?.id;
+  if (!userId) return { success: false, error: "Not authenticated" };
+  if (isDemoRestrictedUserEmail(session.user.email)) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
+  }
+
+  try {
+    const path = "/api/accounts/pocket";
+    const url = `${getBackendBaseUrl().replace(/\/+$/, "")}${path}`;
+    const headers = createInternalAuthHeaders({ method: "POST", pathWithQuery: path, userId });
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({
+        name: input.name,
+        account_type: input.accountType ?? "savings",
+        currency: input.currency ?? "EUR",
+        starting_balance: String(input.startingBalance ?? 0),
+        iban: input.iban,
+      }),
+    });
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({ detail: "Failed to create pocket account" }));
+      const detail =
+        typeof data.detail === "string"
+          ? data.detail
+          : Array.isArray(data.detail) && data.detail[0]?.msg
+            ? data.detail[0].msg
+            : "Failed to create pocket account";
+      return { success: false, error: detail };
+    }
+    const data = await resp.json();
+    revalidatePath("/settings");
+    revalidatePath("/assets");
+    revalidatePath("/transactions/import");
+    return { success: true, accountId: data.account_id, backfilledCount: data.backfilled_count };
+  } catch {
+    return { success: false, error: "Failed to create pocket account" };
+  }
+}
+
+export async function unlinkInternalTransfer(
+  transferId: string,
+): Promise<{ success: boolean; error?: string }> {
+  const session = await getAuthenticatedSession();
+  const userId = session?.user?.id;
+  if (!userId) return { success: false, error: "Not authenticated" };
+  if (isDemoRestrictedUserEmail(session.user.email)) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
+  }
+
+  try {
+    // URL-encode transferId so a malformed id (e.g. one with a slash) can't
+    // produce a mismatch between the signed pathWithQuery and the actual
+    // request path. UUIDs don't need it in practice, but be defensive.
+    const path = `/api/accounts/internal-transfers/${encodeURIComponent(transferId)}`;
+    const url = `${getBackendBaseUrl().replace(/\/+$/, "")}${path}`;
+    const headers = createInternalAuthHeaders({ method: "DELETE", pathWithQuery: path, userId });
+    const resp = await fetch(url, { method: "DELETE", headers });
+    if (!resp.ok) {
+      const data = await resp
+        .json()
+        .catch(() => ({ detail: "Failed to unlink internal transfer" }));
+      return {
+        success: false,
+        error:
+          typeof data.detail === "string"
+            ? data.detail
+            : "Failed to unlink internal transfer",
+      };
+    }
+    revalidatePath("/transactions");
+    revalidatePath("/assets");
+    return { success: true };
+  } catch {
+    return { success: false, error: "Failed to unlink internal transfer" };
   }
 }

--- a/frontend/lib/actions/category-spending.ts
+++ b/frontend/lib/actions/category-spending.ts
@@ -123,6 +123,7 @@ interface CategorySpendingTransactionRowWithRelations {
   categoryId: string | null;
   categorySystemId: string | null;
   recurringTransactionId: string | null;
+  internalTransferId: string | null;
   bookedAt: Date;
   pending: boolean | null;
   transactionType: string | null;
@@ -160,6 +161,13 @@ interface CategorySpendingTransactionRowWithRelations {
   transactionLink: {
     groupId: string;
     linkRole: string;
+  } | null;
+  internalTransfer: {
+    id: string;
+    pocketAccount: {
+      id: string;
+      name: string;
+    } | null;
   } | null;
 }
 
@@ -465,6 +473,18 @@ function mapCategorySpendingTransactionRowsForUi(
               linkRole: tx.transactionLink.linkRole,
             }
           : null,
+        internalTransferId: tx.internalTransferId,
+        internalTransfer: tx.internalTransfer
+          ? {
+              id: tx.internalTransfer.id,
+              pocketAccount: tx.internalTransfer.pocketAccount
+                ? {
+                    id: tx.internalTransfer.pocketAccount.id,
+                    name: tx.internalTransfer.pocketAccount.name,
+                  }
+                : null,
+            }
+          : null,
         bookedAt: tx.bookedAt,
         pending: tx.pending,
         transactionType: tx.transactionType,
@@ -740,6 +760,16 @@ export async function getCategorySpendingTransactionsPage(
         categorySystem: true,
         recurringTransaction: true,
         transactionLink: true,
+        internalTransfer: {
+          with: {
+            pocketAccount: {
+              columns: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
       },
     }),
   ]);

--- a/frontend/lib/actions/transactions.ts
+++ b/frontend/lib/actions/transactions.ts
@@ -380,6 +380,14 @@ export interface TransactionWithRelations {
     groupId: string;
     linkRole: string;
   } | null;
+  internalTransferId: string | null;
+  internalTransfer: {
+    id: string;
+    pocketAccount: {
+      id: string;
+      name: string;
+    } | null;
+  } | null;
   bookedAt: Date;
   pending: boolean | null;
   transactionType: string | null;
@@ -487,6 +495,14 @@ interface TransactionRowWithRelations {
     groupId: string;
     linkRole: string;
   } | null;
+  internalTransferId: string | null;
+  internalTransfer: {
+    id: string;
+    pocketAccount: {
+      id: string;
+      name: string;
+    } | null;
+  } | null;
 }
 
 function mapTransactionRowsForUi(
@@ -556,6 +572,18 @@ function mapTransactionRowsForUi(
           ? {
               groupId: tx.transactionLink.groupId,
               linkRole: tx.transactionLink.linkRole,
+            }
+          : null,
+        internalTransferId: tx.internalTransferId,
+        internalTransfer: tx.internalTransfer
+          ? {
+              id: tx.internalTransfer.id,
+              pocketAccount: tx.internalTransfer.pocketAccount
+                ? {
+                    id: tx.internalTransfer.pocketAccount.id,
+                    name: tx.internalTransfer.pocketAccount.name,
+                  }
+                : null,
             }
           : null,
         bookedAt: tx.bookedAt,
@@ -812,6 +840,16 @@ export async function getTransactionsPage(
         categorySystem: true,
         recurringTransaction: true,
         transactionLink: true,
+        internalTransfer: {
+          with: {
+            pocketAccount: {
+              columns: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
       },
     }),
     shouldComputeFilteredTotals
@@ -884,6 +922,16 @@ export async function getTransactions(): Promise<TransactionWithRelations[]> {
         categorySystem: true,
         recurringTransaction: true,
         transactionLink: true,
+        internalTransfer: {
+          with: {
+            pocketAccount: {
+              columns: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
       },
     });
     const hydratedRows = await hydrateTransactionRowsWithResolvedAccountLogos(result);
@@ -952,6 +1000,16 @@ export async function getTransactionsForAccount(
         categorySystem: true,
         recurringTransaction: true,
         transactionLink: true,
+        internalTransfer: {
+          with: {
+            pocketAccount: {
+              columns: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
       },
     });
     const hydratedRows = await hydrateTransactionRowsWithResolvedAccountLogos(result);

--- a/frontend/lib/db/migrations/0015_add_pocket_account_fields.manual.sql
+++ b/frontend/lib/db/migrations/0015_add_pocket_account_fields.manual.sql
@@ -8,3 +8,12 @@ ALTER TABLE "accounts"
 
 CREATE INDEX IF NOT EXISTS "idx_accounts_user_iban_hash"
 	ON "accounts" USING btree ("user_id", "iban_hash");
+--> statement-breakpoint
+
+-- Prevent two concurrent create-pocket requests from racing and inserting
+-- duplicate manual IBANs for the same user. The partial unique index is
+-- scoped to manual-provider rows with a non-null hash so it never blocks a
+-- pocket from coexisting with a synced-bank account that has the same IBAN.
+CREATE UNIQUE INDEX IF NOT EXISTS "accounts_user_iban_hash_manual_uq"
+	ON "accounts" USING btree ("user_id", "iban_hash")
+	WHERE "provider" = 'manual' AND "iban_hash" IS NOT NULL;

--- a/frontend/lib/db/migrations/0015_add_pocket_account_fields.manual.sql
+++ b/frontend/lib/db/migrations/0015_add_pocket_account_fields.manual.sql
@@ -1,0 +1,10 @@
+-- Pocket account IBAN fields (hand-authored; applied via `pnpm db:push`).
+-- Idempotent guards match the 0009 precedent so re-application is safe.
+
+ALTER TABLE "accounts"
+	ADD COLUMN IF NOT EXISTS "iban_ciphertext" text,
+	ADD COLUMN IF NOT EXISTS "iban_hash" varchar(64);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_accounts_user_iban_hash"
+	ON "accounts" USING btree ("user_id", "iban_hash");

--- a/frontend/lib/db/migrations/0016_add_counterparty_iban.manual.sql
+++ b/frontend/lib/db/migrations/0016_add_counterparty_iban.manual.sql
@@ -1,0 +1,12 @@
+-- Counterparty IBAN fields + internal_transfer_id placeholder on transactions
+-- (hand-authored; applied via `pnpm db:push`). FK on internal_transfer_id
+-- is added in migration 0017 once `internal_transfers` table exists.
+
+ALTER TABLE "transactions"
+	ADD COLUMN IF NOT EXISTS "counterparty_iban_ciphertext" text,
+	ADD COLUMN IF NOT EXISTS "counterparty_iban_hash" varchar(64),
+	ADD COLUMN IF NOT EXISTS "internal_transfer_id" uuid;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_transactions_user_counterparty_iban"
+	ON "transactions" USING btree ("user_id", "counterparty_iban_hash");

--- a/frontend/lib/db/migrations/0017_internal_transfers.manual.sql
+++ b/frontend/lib/db/migrations/0017_internal_transfers.manual.sql
@@ -1,0 +1,40 @@
+-- Internal transfers table (hand-authored; applied via `pnpm db:push`).
+-- Links a source transaction on a synced account to a mirror transaction
+-- on a manually-registered pocket account, matched by counterparty IBAN.
+
+CREATE TABLE IF NOT EXISTS "internal_transfers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+	"user_id" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+	"source_txn_id" uuid NOT NULL UNIQUE REFERENCES "transactions"("id") ON DELETE CASCADE,
+	"mirror_txn_id" uuid UNIQUE REFERENCES "transactions"("id") ON DELETE SET NULL,
+	"source_account_id" uuid NOT NULL REFERENCES "accounts"("id") ON DELETE CASCADE,
+	"pocket_account_id" uuid NOT NULL REFERENCES "accounts"("id") ON DELETE CASCADE,
+	"amount" numeric(15, 2) NOT NULL,
+	"currency" char(3) NOT NULL,
+	"detected_at" timestamp DEFAULT now(),
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_internal_transfers_user"
+	ON "internal_transfers" USING btree ("user_id");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_internal_transfers_pocket"
+	ON "internal_transfers" USING btree ("pocket_account_id");
+--> statement-breakpoint
+
+-- Now that internal_transfers exists, wire the FK on transactions.internal_transfer_id
+-- (column was added as a bare uuid in 0016).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'transactions_internal_transfer_id_internal_transfers_id_fk'
+  ) THEN
+    ALTER TABLE "transactions"
+      ADD CONSTRAINT "transactions_internal_transfer_id_internal_transfers_id_fk"
+      FOREIGN KEY ("internal_transfer_id") REFERENCES "internal_transfers"("id")
+      ON DELETE SET NULL;
+  END IF;
+END $$;

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -257,7 +257,7 @@ export const transactions = pgTable(
     debtor: varchar("debtor", { length: 255 }), // Counterparty name for credits (payer)
     counterpartyIbanCiphertext: text("counterparty_iban_ciphertext"),
     counterpartyIbanHash: varchar("counterparty_iban_hash", { length: 64 }),
-    internalTransferId: uuid("internal_transfer_id"),  // FK added in Task 3 when internal_transfers table exists
+    internalTransferId: uuid("internal_transfer_id"), // FK to internal_transfers.id (enforced at DB level in migration 0017)
     categoryId: uuid("category_id").references(() => categories.id), // User-overridden category
     categorySystemId: uuid("category_system_id").references(() => categories.id), // AI-assigned category (never updated by user)
     bookedAt: timestamp("booked_at").notNull(),
@@ -284,6 +284,37 @@ export const transactions = pgTable(
     index("idx_transactions_csv_import").on(table.csvImportId),
     unique("transactions_account_external_id").on(table.accountId, table.externalId),
     index("idx_transactions_user_counterparty_iban").on(table.userId, table.counterpartyIbanHash),
+  ]
+);
+
+export const internalTransfers = pgTable(
+  "internal_transfers",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    sourceTxnId: uuid("source_txn_id")
+      .references(() => transactions.id, { onDelete: "cascade" })
+      .notNull()
+      .unique(),
+    mirrorTxnId: uuid("mirror_txn_id")
+      .references(() => transactions.id, { onDelete: "set null" })
+      .unique(),
+    sourceAccountId: uuid("source_account_id")
+      .references(() => accounts.id, { onDelete: "cascade" })
+      .notNull(),
+    pocketAccountId: uuid("pocket_account_id")
+      .references(() => accounts.id, { onDelete: "cascade" })
+      .notNull(),
+    amount: decimal("amount", { precision: 15, scale: 2 }).notNull(),
+    currency: char("currency", { length: 3 }).notNull(),
+    detectedAt: timestamp("detected_at").defaultNow(),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (table) => [
+    index("idx_internal_transfers_user").on(table.userId),
+    index("idx_internal_transfers_pocket").on(table.pocketAccountId),
   ]
 );
 
@@ -612,6 +643,37 @@ export const transactionsRelations = relations(transactions, ({ one }) => ({
     fields: [transactions.csvImportId],
     references: [csvImports.id],
   }),
+  internalTransfer: one(internalTransfers, {
+    fields: [transactions.internalTransferId],
+    references: [internalTransfers.id],
+  }),
+}));
+
+export const internalTransfersRelations = relations(internalTransfers, ({ one }) => ({
+  user: one(users, {
+    fields: [internalTransfers.userId],
+    references: [users.id],
+  }),
+  sourceTxn: one(transactions, {
+    fields: [internalTransfers.sourceTxnId],
+    references: [transactions.id],
+    relationName: "internalTransferSource",
+  }),
+  mirrorTxn: one(transactions, {
+    fields: [internalTransfers.mirrorTxnId],
+    references: [transactions.id],
+    relationName: "internalTransferMirror",
+  }),
+  sourceAccount: one(accounts, {
+    fields: [internalTransfers.sourceAccountId],
+    references: [accounts.id],
+    relationName: "internalTransferSourceAccount",
+  }),
+  pocketAccount: one(accounts, {
+    fields: [internalTransfers.pocketAccountId],
+    references: [accounts.id],
+    relationName: "internalTransferPocketAccount",
+  }),
 }));
 
 export const recurringTransactionsRelations = relations(recurringTransactions, ({ one, many }) => ({
@@ -759,3 +821,6 @@ export type NewCompanyLogo = typeof companyLogos.$inferInsert;
 
 export type BankConnection = typeof bankConnections.$inferSelect;
 export type NewBankConnection = typeof bankConnections.$inferInsert;
+
+export type InternalTransfer = typeof internalTransfers.$inferSelect;
+export type NewInternalTransfer = typeof internalTransfers.$inferInsert;

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -11,8 +11,9 @@ import {
   jsonb,
   index,
   unique,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 
 // ============================================================================
 // BetterAuth Tables
@@ -145,6 +146,12 @@ export const accounts = pgTable(
       table.externalIdHash
     ),
     index("idx_accounts_user_iban_hash").on(table.userId, table.ibanHash),
+    // Prevent two concurrent create-pocket requests from racing and inserting
+    // duplicate manual IBANs. Partial index scoped to provider='manual' so a
+    // pocket and a synced-bank account can still share an IBAN.
+    uniqueIndex("accounts_user_iban_hash_manual_uq")
+      .on(table.userId, table.ibanHash)
+      .where(sql`${table.provider} = 'manual' AND ${table.ibanHash} IS NOT NULL`),
   ]
 );
 

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -255,6 +255,9 @@ export const transactions = pgTable(
     merchant: varchar("merchant", { length: 255 }),
     creditor: varchar("creditor", { length: 255 }), // Counterparty name for debits (payee)
     debtor: varchar("debtor", { length: 255 }), // Counterparty name for credits (payer)
+    counterpartyIbanCiphertext: text("counterparty_iban_ciphertext"),
+    counterpartyIbanHash: varchar("counterparty_iban_hash", { length: 64 }),
+    internalTransferId: uuid("internal_transfer_id"),  // FK added in Task 3 when internal_transfers table exists
     categoryId: uuid("category_id").references(() => categories.id), // User-overridden category
     categorySystemId: uuid("category_system_id").references(() => categories.id), // AI-assigned category (never updated by user)
     bookedAt: timestamp("booked_at").notNull(),
@@ -280,6 +283,7 @@ export const transactions = pgTable(
     index("idx_transactions_merchant").on(table.merchant),
     index("idx_transactions_csv_import").on(table.csvImportId),
     unique("transactions_account_external_id").on(table.accountId, table.externalId),
+    index("idx_transactions_user_counterparty_iban").on(table.userId, table.counterpartyIbanHash),
   ]
 );
 

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -119,6 +119,8 @@ export const accounts = pgTable(
     externalId: varchar("external_id", { length: 255 }), // Provider's account ID
     externalIdCiphertext: text("external_id_ciphertext"),
     externalIdHash: varchar("external_id_hash", { length: 64 }),
+    ibanCiphertext: text("iban_ciphertext"),
+    ibanHash: varchar("iban_hash", { length: 64 }),
     bankConnectionId: uuid("bank_connection_id").references(() => bankConnections.id, { onDelete: "set null" }),
     balanceAvailable: decimal("balance_available", { precision: 15, scale: 2 }),
     startingBalance: decimal("starting_balance", { precision: 15, scale: 2 }).default("0"), // Starting balance for calculation
@@ -142,6 +144,7 @@ export const accounts = pgTable(
       table.provider,
       table.externalIdHash
     ),
+    index("idx_accounts_user_iban_hash").on(table.userId, table.ibanHash),
   ]
 );
 

--- a/frontend/scripts/migrate.js
+++ b/frontend/scripts/migrate.js
@@ -195,11 +195,15 @@ async function main() {
       if (isPgRelationExistsError(err)) {
         console.warn("[migrate] Detected existing schema without migration tracking. Baseline mode...");
         const baselined = await baselineExistingSchema(sql, migrationsFolder);
-        if (baselined) {
-          // Now that the baseline is recorded, apply the remaining migrations.
-          await migrate(db, { migrationsFolder });
-          console.log("[migrate] Migrations complete (after baseline)");
+        if (!baselined) {
+          // Migration tracking already had entries — the "relation exists" error
+          // is a real schema-drift failure, not a first-run baselining issue.
+          // Re-raise so it is NOT masked by the manual-migration step below.
+          throw err;
         }
+        // Baseline recorded; apply the remaining Drizzle migrations.
+        await migrate(db, { migrationsFolder });
+        console.log("[migrate] Migrations complete (after baseline)");
       } else {
         throw err;
       }

--- a/frontend/scripts/migrate.js
+++ b/frontend/scripts/migrate.js
@@ -199,14 +199,59 @@ async function main() {
           // Now that the baseline is recorded, apply the remaining migrations.
           await migrate(db, { migrationsFolder });
           console.log("[migrate] Migrations complete (after baseline)");
-          return;
         }
+      } else {
+        throw err;
       }
-
-      throw err;
     }
+
+    // Apply any ".manual.sql" migrations. These are hand-authored SQL files
+    // that are intentionally kept outside of drizzle-kit's journal (e.g.
+    // because the current journal snapshot is stale and running db:generate
+    // would produce a destructive diff). Every .manual.sql file must use
+    // idempotent DDL (IF NOT EXISTS guards or DO blocks that check
+    // pg_constraint) — we run them every time.
+    await applyManualSqlMigrations(sql, migrationsFolder);
   } finally {
     await sql.end({ timeout: 5 });
+  }
+}
+
+async function applyManualSqlMigrations(sql, migrationsFolder) {
+  const entries = fs
+    .readdirSync(migrationsFolder, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".manual.sql"))
+    .map((entry) => entry.name)
+    .sort();
+
+  if (entries.length === 0) {
+    console.log("[migrate] No .manual.sql migrations to apply");
+    return;
+  }
+
+  console.log(`[migrate] Applying ${entries.length} .manual.sql migration(s)`);
+  for (const filename of entries) {
+    const fullPath = path.join(migrationsFolder, filename);
+    const contents = fs.readFileSync(fullPath, "utf8");
+    // drizzle-kit splits multi-statement migrations on "--> statement-breakpoint".
+    // We honour the same convention for consistency — statements run in order,
+    // each inside its own implicit transaction block managed by `sql.unsafe`.
+    const statements = contents
+      .split("--> statement-breakpoint")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+    for (const stmt of statements) {
+      try {
+        await sql.unsafe(stmt);
+      } catch (err) {
+        console.error(
+          `[migrate] Failed applying manual migration ${filename}:\n${stmt.slice(0, 200)}${stmt.length > 200 ? "..." : ""}`
+        );
+        throw err;
+      }
+    }
+    console.log(`[migrate]   ✓ ${filename}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Lets users register unsyncable savings accounts ("pockets") by IBAN. Auto-detects internal transfers from synced accounts by matching counterparty IBAN hash, creates mirror transactions on the pocket side (so balances derive naturally from the existing `starting_balance + sum(transactions)` math), and excludes both sides from analytics.

**Spec:** `docs/superpowers/specs/2026-04-19-pocket-accounts-design.md`
**Plan:** `docs/superpowers/plans/2026-04-19-pocket-accounts.md`

## Changes

### Backend
- **Schema (Tasks 1–3):** `accounts.iban_{ciphertext,hash}`, `transactions.counterparty_iban_{ciphertext,hash}` + `internal_transfer_id`, new `internal_transfers` table (links source ↔ mirror txns). Three hand-authored `.manual.sql` migrations with `IF NOT EXISTS` guards. Applied via `pnpm db:push` (matches repo convention).
- **EB adapter (Task 4):** extracts counterparty IBAN from all three EB payload shapes — `creditor_account.iban`, nested `creditor.iban`, and scheme-form `{scheme_name: "IBAN", identification: "..."}`.
- **Sync service (Task 5):** encrypts + blind-indexes `counterparty_iban` on insert AND update branches (5 write sites across `sync_transactions` + `upsert_transaction`). Re-sync backfills existing transactions.
- **InternalTransferService (Task 6):** `detect_for_transactions`, `unlink`, `unlink_all_for_pocket`. Detection is idempotent (guards on `internal_transfer_id IS NULL`), user-scoped (`user_id` + `provider='manual'`), flips `include_in_analytics=False` on both source and mirror, sets `category_system_id=Transfer` (user-override preserved).
- **Pipeline (Task 7):** new step 3 runs detection between functional-amount calc and batch LLM categorization. LLM filter now skips `include_in_analytics=False` transactions (internal transfers + user-hidden rows).
- **API (Tasks 8–10):** `POST /api/accounts/pocket` (create + backfill), `DELETE /api/accounts/internal-transfers/:id` (unlink), `DELETE /api/accounts/:id` (now hard-deletes with pre-cleanup of linked transfers; mirror txns removed via `ON DELETE CASCADE` after adding `passive_deletes=True` to the `Account.transactions` relationship).

### Frontend
- **Server actions (Task 11):** `createPocketAccount`, `unlinkInternalTransfer` — follows the existing HMAC-signed internal-auth pattern.
- **AccountForm (Task 12):** "Register as pocket account" toggle + IBAN input + client-side format validation. Success toast includes backfill count (e.g. "Account created — 3 transfers linked").
- **Transaction sheet (Task 13):** chip at top of the detail view showing "Internal transfer — {pocket account name}" with an Unlink button.
- **Account list (Task 14):** `<Badge variant="secondary">Pocket</Badge>` next to the name for manual accounts with a registered IBAN.

## Tests

34 passing across 5 test files — adapter IBAN extraction (all three payload shapes + precedence + non-IBAN scheme), sync encryption round-trip, service-level detection/unlink/idempotency/cross-user isolation/user-override preservation/LLM-overwrite, pipeline ordering, API endpoints (happy path + duplicate rejection + scope-limited duplicate check + invalid IBAN + cross-user 404 + cascade cleanup).

## Deploy checklist

- [ ] Merge PR
- [ ] Apply schema to Railway Postgres (`pnpm db:push` or the 3 `.manual.sql` files)
- [ ] `RAILWAY_ENVIRONMENT=production railway redeploy --service backend --yes`
- [ ] `RAILWAY_ENVIRONMENT=production railway redeploy --service worker --yes`
- [ ] Create a pocket via Assets → Add Account → "Register as pocket account" with a known ABN IBAN → verify backfill count in toast
- [ ] Trigger a sync → confirm new transfers auto-link and appear as mirrors on the pocket

## Risk

Low. All schema additions are nullable; behavior is inert for users with no pockets registered (detection fires only when `accounts.iban_hash` is set). Rollback = redeploy prior Railway image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds IBAN-based pocket accounts. Detects internal transfers by counterparty IBAN, creates mirror transactions, and excludes both sides from analytics. Also fixes pocket balance recalculation, prevents duplicate manual IBANs per user, and improves migration error surfacing.

- **New Features**
  - DB: IBAN fields on accounts; counterparty IBAN + `internal_transfer_id` on transactions; new `internal_transfers` table; partial unique index on `(user_id, iban_hash)` for manual accounts to block duplicates.
  - Adapter + sync: extract counterparty IBAN from Enable Banking; encrypt and blind-index on insert/update.
  - Detection: `InternalTransferService` links source ↔ mirror (idempotent, user-scoped); matches only transactions with `include_in_analytics=true`; sets category to Transfer and `include_in_analytics=false`; unlink restores analytics safely; returns touched pocket IDs.
  - Pipeline: detection runs before LLM; LLM skips non-analytics transactions; balances and timeseries also recalc for pockets touched by detection.
  - API: `POST /api/accounts/pocket` (create + backfill; duplicate manual IBANs rejected), `DELETE /api/accounts/internal-transfers/:id` (unlink), `DELETE /api/accounts/:id` (hard delete with cleanup).
  - Frontend: account form toggle with IBAN validation; transaction sheet chip with Unlink; Pocket badge on account list; new `createPocketAccount` and `unlinkInternalTransfer` actions.

- **Migration**
  - Apply SQL migrations `0015–0017` (or `pnpm db:push`) to create IBAN fields, `internal_transfers`, indexes (including the partial unique index).
  - Migration runner auto-applies `*.manual.sql` files after journal migrations; safe to re-run.
  - Runner now re-raises when journal migrations fail and baseline is skipped to surface schema-drift errors.

<sup>Written for commit e43e8666abe4a17fae1ba73a09cd3217a9d54641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

