### PR TITLE
fix(oauth): expose AS metadata at RFC 8414 issuer-path URL

### DIFF
--- a/frontend/app/.well-known/oauth-authorization-server/api/auth/route.ts
+++ b/frontend/app/.well-known/oauth-authorization-server/api/auth/route.ts
@@ -1,0 +1,9 @@
+import { oauthProviderAuthServerMetadata } from "@better-auth/oauth-provider";
+import { auth } from "@/lib/auth";
+
+// RFC 8414 requires the discovery URL to interpolate the issuer's path
+// component: for issuer `https://app.syllogic.ai/api/auth`, the metadata
+// lives at `/.well-known/oauth-authorization-server/api/auth`. Claude on
+// iOS follows the spec strictly and only probes this path; Claude Desktop
+// also accepts the path-less form at the site root. Expose both.
+export const GET = oauthProviderAuthServerMetadata(auth);


### PR DESCRIPTION
## Summary

Fixes the Claude iOS app's "Couldn't connect Syllogic — Failed to generate authorization URL" error when adding the Syllogic custom connector.

## Root cause

Our authorization server issuer is `https://app.syllogic.ai/api/auth`. Per [RFC 8414 §3](https://datatracker.ietf.org/doc/html/rfc8414#section-3), the metadata discovery URL interpolates the issuer's path component between the host and `/.well-known/oauth-authorization-server`:

```
issuer   = https://app.syllogic.ai/api/auth
metadata = https://app.syllogic.ai/.well-known/oauth-authorization-server/api/auth
```

We only exposed the path-less variant (`/.well-known/oauth-authorization-server`) at the site root in #66. Claude Desktop accepts that form as a fallback, but Claude iOS probes the RFC 8414–compliant URL only, hits a 404, and aborts before ever reaching the `/oauth2/register` (DCR) + `/oauth2/authorize` flow — surfacing as the generic "Failed to generate authorization URL" error in the app.

The `@better-auth/oauth-provider` plugin itself logs this expectation at init:

> Please ensure `/.well-known/oauth-authorization-server/api/auth` exists.

## Fix

Add a second Next.js route handler at `frontend/app/.well-known/oauth-authorization-server/api/auth/route.ts` that delegates to the same `oauthProviderAuthServerMetadata(auth)` helper, so both the RFC 8414 path and the site-root path resolve to the same metadata document. The existing route is left in place for backwards compatibility with Claude Desktop and any other clients that use the path-less form.

## Test plan

- [ ] `curl -s https://app.syllogic.ai/.well-known/oauth-authorization-server/api/auth | jq` returns the AS metadata with `issuer: https://app.syllogic.ai/api/auth` and the `/api/auth/oauth2/*` endpoints.
- [ ] `curl -s https://app.syllogic.ai/.well-known/oauth-authorization-server | jq` still returns the same metadata (no regression).
- [ ] From Claude iOS: add custom connector `https://mcp.syllogic.ai/mcp`, confirm the OAuth consent page loads and the connector ends up in the "connected" state.
- [ ] From Claude Desktop / web: reconnect the existing Syllogic connector and confirm nothing regressed.

https://claude.ai/code/session_015o8ZNK1rvtRaCgYzGfkcfs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose OAuth Authorization Server metadata at the RFC 8414 issuer-path URL to fix Claude iOS connection errors. Claude iOS can now discover our issuer and complete the OAuth flow.

- **Bug Fixes**
  - Add `/.well-known/oauth-authorization-server/api/auth` route that serves the same metadata via `oauthProviderAuthServerMetadata(auth)` from `@better-auth/oauth-provider`.
  - Keep the root `/.well-known/oauth-authorization-server` endpoint for compatibility with clients using the path-less form (e.g., Claude Desktop).

<sup>Written for commit ffc610737bf14df5d94308c9b20f0bfd04e96f55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

