### PR TITLE
fix(mcp): stop double /mcp in Protected Resource Metadata

### DIFF
--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -135,6 +135,10 @@ AS_JWKS_URI = os.environ.get(
     "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )
 MCP_AUDIENCE = os.environ.get("MCP_OAUTH_AUDIENCE", "https://mcp.syllogic.ai/mcp")
+# Public server root (no path). RemoteAuthProvider uses this as base_url and
+# appends the MCP route on top when advertising the Protected Resource.
+# Keep it separate from MCP_AUDIENCE (which is the JWT `aud` claim value).
+MCP_PUBLIC_URL = os.environ.get("MCP_PUBLIC_URL", "https://mcp.syllogic.ai")
 
 
 class CompositeAuthProvider(AuthProvider):

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -7,13 +7,16 @@ from fastmcp.server.auth import RemoteAuthProvider
 from pydantic import AnyHttpUrl
 
 from app.db_helpers import get_mcp_user_id
-from app.mcp.auth import CompositeAuthProvider, AS_ISSUER, MCP_AUDIENCE
+from app.mcp.auth import CompositeAuthProvider, AS_ISSUER, MCP_PUBLIC_URL
 from app.mcp.tools import accounts, categories, transactions, analytics, recurring
 
 _auth = RemoteAuthProvider(
     token_verifier=CompositeAuthProvider(),
     authorization_servers=[AnyHttpUrl(AS_ISSUER)],
-    base_url=MCP_AUDIENCE,
+    # Server root (no /mcp path). FastMCP appends the route itself when
+    # advertising the Protected Resource, so passing "https://mcp.syllogic.ai/mcp"
+    # here produced a broken resource URL of "https://mcp.syllogic.ai/mcp/mcp".
+    base_url=MCP_PUBLIC_URL,
 )
 
 # Initialize FastMCP server


### PR DESCRIPTION
## Summary

Complements #74. After #74 landed, Claude iOS could discover the authorization server, but adding the connector still failed with **Failed to generate authorization URL**. Desktop users also hit "Couldn't reach the MCP server".

Root cause: the Protected Resource Metadata endpoint served:

\`\`\`json
{ "resource": "https://mcp.syllogic.ai/mcp/mcp", ... }
\`\`\`

— note the **double \`/mcp\`**. Claude forwards that value as the \`resource\` parameter on \`/oauth2/authorize\`, better-auth checks it against \`validAudiences\` (which contains \`https://mcp.syllogic.ai/mcp\`, no double), the check fails, no auth URL is generated.

Cause in code: \`server.py\` passed \`base_url=MCP_AUDIENCE\` (\`"https://mcp.syllogic.ai/mcp"\`) to \`RemoteAuthProvider\`, but FastMCP already appends its internal \`/mcp\` route when publishing the resource, so \`base_url\` must be the server root.

Split the two concerns:

- \`MCP_PUBLIC_URL\` → server root (\`https://mcp.syllogic.ai\`) → \`base_url\`
- \`MCP_AUDIENCE\` → JWT \`aud\` claim (\`https://mcp.syllogic.ai/mcp\`) → \`JWTVerifier\`

## Verification after deploy

\`\`\`bash
# Should now serve (was 404):
curl -s https://mcp.syllogic.ai/.well-known/oauth-protected-resource/mcp | jq .resource
# expect "https://mcp.syllogic.ai/mcp"

# Previous (wrong) path should 404 or match:
curl -s https://mcp.syllogic.ai/.well-known/oauth-protected-resource/mcp/mcp
\`\`\`

Then re-add \`https://mcp.syllogic.ai/mcp\` from Claude iOS — authorize step should succeed.

## Deployment

Only the \`mcp\` Railway service needs redeploy. No migration, no DB change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Protected Resource Metadata URL that advertised a double /mcp path, which blocked authorization URL generation in clients. Sets the auth provider base URL to the server root to produce the correct resource value.

- **Bug Fixes**
  - PRM now returns resource=https://mcp.syllogic.ai/mcp (was …/mcp/mcp).
  - Introduced MCP_PUBLIC_URL (server root) for `RemoteAuthProvider.base_url`; kept MCP_AUDIENCE for the JWT `aud` claim.
  - Resolves client failures (“Failed to generate authorization URL”) caused by `better-auth` `validAudiences` mismatch.

<sup>Written for commit 3f217a8cdab118e796b6b10c6a9073c5c8e76f6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

