### PR TITLE
fix(oauth): resume authorize after sign-in/sign-up

### DIFF
--- a/backend/app/mcp/auth.py
+++ b/backend/app/mcp/auth.py
@@ -135,6 +135,10 @@ AS_JWKS_URI = os.environ.get(
     "MCP_OAUTH_JWKS_URI", "https://app.syllogic.ai/api/auth/jwks"
 )
 MCP_AUDIENCE = os.environ.get("MCP_OAUTH_AUDIENCE", "https://mcp.syllogic.ai/mcp")
+# Public server root (no path). RemoteAuthProvider uses this as base_url and
+# appends the MCP route on top when advertising the Protected Resource.
+# Keep it separate from MCP_AUDIENCE (which is the JWT `aud` claim value).
+MCP_PUBLIC_URL = os.environ.get("MCP_PUBLIC_URL", "https://mcp.syllogic.ai")
 
 
 class CompositeAuthProvider(AuthProvider):

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -7,13 +7,16 @@ from fastmcp.server.auth import RemoteAuthProvider
 from pydantic import AnyHttpUrl
 
 from app.db_helpers import get_mcp_user_id
-from app.mcp.auth import CompositeAuthProvider, AS_ISSUER, MCP_AUDIENCE
+from app.mcp.auth import CompositeAuthProvider, AS_ISSUER, MCP_PUBLIC_URL
 from app.mcp.tools import accounts, categories, transactions, analytics, recurring
 
 _auth = RemoteAuthProvider(
     token_verifier=CompositeAuthProvider(),
     authorization_servers=[AnyHttpUrl(AS_ISSUER)],
-    base_url=MCP_AUDIENCE,
+    # Server root (no /mcp path). FastMCP appends the route itself when
+    # advertising the Protected Resource, so passing "https://mcp.syllogic.ai/mcp"
+    # here produced a broken resource URL of "https://mcp.syllogic.ai/mcp/mcp".
+    base_url=MCP_PUBLIC_URL,
 )
 
 # Initialize FastMCP server

--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -79,6 +79,20 @@ function LoginPageContent() {
     }
   }, [prefillEmail, prefillPassword, setValue]);
 
+  // If the user landed here because an OAuth authorize request requires
+  // authentication, better-auth's oauth-provider passes the original
+  // authorize query (plus `exp` and `sig`) along. After successful sign-in
+  // we resume the OAuth flow by re-hitting /api/auth/oauth2/authorize with
+  // those same params. Otherwise we fall back to the dashboard.
+  const oauthResumeURL = useMemo(() => {
+    const hasOauthParams =
+      searchParams.has("client_id") &&
+      searchParams.has("response_type") &&
+      searchParams.has("redirect_uri");
+    if (!hasOauthParams) return null;
+    return `/api/auth/oauth2/authorize?${searchParams.toString()}`;
+  }, [searchParams]);
+
   const onSubmit = async (data: LoginFormData) => {
     setIsLoading(true);
     setError(null);
@@ -91,6 +105,13 @@ function LoginPageContent() {
 
       if (result.error) {
         setError(result.error.message || "Failed to sign in");
+        return;
+      }
+
+      if (oauthResumeURL) {
+        // Full navigation so the browser follows the authorize redirect chain
+        // (consent page → client redirect_uri with code).
+        window.location.href = oauthResumeURL;
         return;
       }
 

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -38,8 +38,9 @@ const registerSchema = z
 
 type RegisterFormData = z.infer<typeof registerSchema>;
 
-export default function RegisterPage() {
+function RegisterPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -50,6 +51,17 @@ export default function RegisterPage() {
   } = useForm<RegisterFormData>({
     resolver: zodResolver(registerSchema),
   });
+
+  // If the user was bounced here mid-OAuth-authorize, resume the flow after
+  // successful sign-up instead of going to the dashboard.
+  const oauthResumeURL = useMemo(() => {
+    const hasOauthParams =
+      searchParams.has("client_id") &&
+      searchParams.has("response_type") &&
+      searchParams.has("redirect_uri");
+    if (!hasOauthParams) return null;
+    return `/api/auth/oauth2/authorize?${searchParams.toString()}`;
+  }, [searchParams]);
 
   const onSubmit = async (data: RegisterFormData) => {
     setIsLoading(true);
@@ -64,6 +76,11 @@ export default function RegisterPage() {
 
       if (result.error) {
         setError(result.error.message || "Failed to create account");
+        return;
+      }
+
+      if (oauthResumeURL) {
+        window.location.href = oauthResumeURL;
         return;
       }
 
@@ -157,5 +174,25 @@ export default function RegisterPage() {
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+function RegisterPageFallback() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create an account</CardTitle>
+        <CardDescription>Loading registration form...</CardDescription>
+      </CardHeader>
+      <CardContent />
+    </Card>
+  );
+}
+
+export default function RegisterPage() {
+  return (
+    <Suspense fallback={<RegisterPageFallback />}>
+      <RegisterPageContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- After better-auth bounces an unauthenticated OAuth user to `/login` (or `/register`) with the signed authorize query, our pages were hard-redirecting to `/` on success, leaving Claude's connector stranded on the dashboard.
- Detect the OAuth params (`client_id`, `response_type`, `redirect_uri`) and, after sign-in/sign-up, navigate to `/api/auth/oauth2/authorize?<same-query>` to resume → consent → client callback.

## Test plan
- [ ] Local: open Claude connector flow while signed out, sign in, land on `/oauth/consent`, accept, redirect to client callback
- [ ] Prod: retest Claude iOS connector end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resumes the OAuth authorize flow after sign-in/sign-up and fixes the MCP protected resource URL, so clients (e.g., Claude iOS) reach consent and complete auth.

- **Bug Fixes**
  - Login/Register: detect OAuth params (`client_id`, `response_type`, `redirect_uri`) and, after success, hard-navigate to `/api/auth/oauth2/authorize?<same-query>` to resume consent → client callback. Added `Suspense` on register to use `useSearchParams`.
  - MCP server: split `MCP_PUBLIC_URL` (server root) from `MCP_AUDIENCE` (JWT `aud`). Set `base_url` to `MCP_PUBLIC_URL` to avoid advertising `.../mcp/mcp`, letting `better-auth` accept the `resource` and complete authorize.

<sup>Written for commit e62b7e0eb566d20db8d5380e15c2ba122d8f2b28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

