### PR TITLE
feat(auth): extend OAuth access token and session TTL to 30 days

### DIFF
--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -57,8 +57,8 @@ export const auth = betterAuth({
     }),
     oauthProvider({
       scopes: ["mcp:access"],
-      accessTokenExpiresIn: 60 * 60, // 1 hour
-      refreshTokenExpiresIn: 60 * 60 * 24 * 30, // 30 days
+      accessTokenExpiresIn: 60 * 60 * 24 * 30, // 30 days
+      refreshTokenExpiresIn: 60 * 60 * 24 * 90, // 90 days
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
       loginPage: "/login",
@@ -90,8 +90,8 @@ export const auth = betterAuth({
     requireEmailVerification: false,
   },
   session: {
-    expiresIn: 60 * 60 * 24, // 24 hours - appropriate for financial app security
-    updateAge: 60 * 60, // 1 hour
+    expiresIn: 60 * 60 * 24 * 30, // 30 days — must outlive OAuth access token TTL
+    updateAge: 60 * 60 * 24, // 1 day
     cookieCache: {
       enabled: false,
       maxAge: 5 * 60, // 5 minutes


### PR DESCRIPTION
## Summary
- Bump OAuth `accessTokenExpiresIn` from 1h → 30d and `refreshTokenExpiresIn` from 30d → 90d
- Bump `session.expiresIn` from 24h → 30d so better-auth doesn't clamp the JWT `exp` to the session lifetime
- Bump `session.updateAge` from 1h → 1d to match the new cadence

## Why
MCP connectors (Claude custom connector for the Syllogic MCP server) were forced to re-login every hour. Root cause was the 1h access token TTL, and even bumping that alone would've been silently clamped to 24h by the session lifetime.

## Tradeoffs
- Revocation gets harder: a 30-day JWT can only be invalidated by rotating JWKS (which nukes every session). Acceptable for current single/low-tenant use; revisit if multi-tenant.
- Larger blast radius for a leaked access token. Mitigation: refresh tokens still rotate, and JWKS rotation remains the nuclear option.

## Test plan
- [ ] Deploy frontend, reconnect MCP connector, confirm new JWT `exp` is ~30 days out (decode at jwt.io)
- [ ] Leave connector idle >1h, confirm it no longer prompts re-auth
- [ ] Existing browser sessions still valid (no forced logout wave)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend OAuth and session lifetimes so MCP connectors stay signed in for up to 30 days and JWT exp isn’t clamped by the session.
Access token: 30d (was 1h), refresh token: 90d (was 30d), session TTL: 30d (was 24h), session update age: 1d (was 1h).

<sup>Written for commit 562468cb8dd74bcd4f31c0d65204b9c740ad831c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

