### PR TITLE
feat(mcp): add update_category tool for persisting categorization context

### DIFF
--- a/backend/app/mcp/__init__.py
+++ b/backend/app/mcp/__init__.py
@@ -1,6 +1,7 @@
 """
 MCP (Model Context Protocol) server for Syllogic.
-Provides read-only access to financial data with one write operation (update transaction category).
+Provides read-only access to financial data with write operations for
+transaction categorization and category metadata.
 
 Usage:
     from app.mcp.server import mcp
@@ -15,6 +16,7 @@ Tools available:
         - list_categories
         - get_category
         - get_category_tree
+        - update_category (WRITE)
 
     Transactions:
         - list_transactions

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -36,7 +36,7 @@ The `user_id` parameter is optional on all tools but must match the authenticate
 
 ## Available functionality
 - **Accounts**: List, view, and check balance history
-- **Categories**: List, view, and get category tree structure
+- **Categories**: List, view, get tree structure, and update description/categorization_instructions
 - **Transactions**: List, search, view, and update categories
 - **Analytics**: Spending/income by category, monthly cashflow, financial summary
 - **Recurring**: List and view subscriptions/bills
@@ -171,6 +171,41 @@ def get_category(category_id: str, user_id: str | None = None) -> dict | None:
         Category dictionary or None if not found
     """
     return categories.get_category(get_mcp_user_id(user_id), category_id)
+
+
+@mcp.tool
+def update_category(
+    category_id: str,
+    description: str | None = None,
+    categorization_instructions: str | None = None,
+    user_id: str | None = None,
+) -> dict:
+    """
+    Update a category's description and/or categorization_instructions.
+
+    Use this to persist categorization context you learn during a conversation
+    (e.g. "transactions from <merchant> should be Groceries unless the amount
+    is under €5") so that future AI categorization applies the same rules.
+
+    Only provided fields are written. Pass an empty string ("") to explicitly
+    clear a field. System categories cannot be updated.
+
+    Args:
+        category_id: The category's ID
+        description: New human-readable description for this category (optional)
+        categorization_instructions: Instructions the AI should follow when
+            deciding whether a transaction belongs in this category (optional)
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        Dict with success status and updated category, or error message
+    """
+    return categories.update_category(
+        get_mcp_user_id(user_id),
+        category_id,
+        description,
+        categorization_instructions,
+    )
 
 
 @mcp.tool

--- a/backend/app/mcp/tools/categories.py
+++ b/backend/app/mcp/tools/categories.py
@@ -80,6 +80,78 @@ def get_category(user_id: str, category_id: str) -> dict | None:
         }
 
 
+def update_category(
+    user_id: str,
+    category_id: str,
+    description: Optional[str] = None,
+    categorization_instructions: Optional[str] = None,
+) -> dict:
+    """
+    Update a category's description and/or categorization_instructions.
+
+    Used by agents to persist learned categorization context so that the AI
+    can apply consistent rules on future transactions. Only the provided
+    fields are updated; omitted fields are left untouched. Pass an empty
+    string to explicitly clear a field.
+
+    Args:
+        user_id: The user's ID
+        category_id: The category's ID
+        description: New description text (optional)
+        categorization_instructions: New categorization instructions (optional)
+
+    Returns:
+        Dict with success status and updated category, or error message
+    """
+    if description is None and categorization_instructions is None:
+        return {
+            "success": False,
+            "error": "At least one of description or categorization_instructions must be provided",
+        }
+
+    category_uuid = validate_uuid(category_id)
+    if not category_uuid:
+        return {"success": False, "error": "Invalid category ID format"}
+
+    with get_db() as db:
+        category = db.query(Category).filter(
+            Category.id == category_uuid,
+            Category.user_id == user_id,
+        ).first()
+
+        if not category:
+            return {"success": False, "error": "Category not found"}
+
+        if category.is_system:
+            return {"success": False, "error": "Cannot update system categories"}
+
+        try:
+            if description is not None:
+                category.description = description or None
+            if categorization_instructions is not None:
+                category.categorization_instructions = categorization_instructions or None
+            db.commit()
+            db.refresh(category)
+        except Exception as e:
+            db.rollback()
+            return {"success": False, "error": f"Database error: {str(e)}"}
+
+        return {
+            "success": True,
+            "category": {
+                "id": str(category.id),
+                "name": category.name,
+                "category_type": category.category_type,
+                "color": category.color,
+                "icon": category.icon,
+                "description": category.description,
+                "categorization_instructions": category.categorization_instructions,
+                "parent_id": str(category.parent_id) if category.parent_id else None,
+                "is_system": category.is_system,
+            },
+        }
+
+
 def get_category_tree(user_id: str) -> list[dict]:
     """
     Get categories in a hierarchical tree structure.

--- a/backend/tests/test_mcp_update_category.py
+++ b/backend/tests/test_mcp_update_category.py
@@ -1,0 +1,168 @@
+"""
+Tests for the update_category MCP tool.
+
+Exercises the tool function directly against the database (no HTTP),
+mirroring the setup style used in test_categorizer.py.
+"""
+import os
+import sys
+import uuid
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.database import SessionLocal, Base, engine
+from app.models import Category
+from app.db_helpers import get_or_create_system_user
+from app.mcp.tools.categories import update_category
+
+
+def _seed_category(is_system: bool = False) -> tuple[str, str]:
+    """Create a user + category, return (user_id, category_id)."""
+    db = SessionLocal()
+    try:
+        Base.metadata.create_all(bind=engine)
+        user = get_or_create_system_user(db)
+        user_id = str(user.id)
+
+        # Use a unique name to avoid colliding with the (user_id, name, parent_id)
+        # unique constraint across repeated test runs.
+        cat = Category(
+            user_id=user_id,
+            name=f"UpdateTest-{uuid.uuid4().hex[:8]}",
+            category_type="expense",
+            is_system=is_system,
+        )
+        db.add(cat)
+        db.commit()
+        db.refresh(cat)
+        return user_id, str(cat.id)
+    finally:
+        db.close()
+
+
+def _cleanup(category_id: str) -> None:
+    db = SessionLocal()
+    try:
+        cat = db.query(Category).filter(Category.id == uuid.UUID(category_id)).first()
+        if cat:
+            db.delete(cat)
+            db.commit()
+    finally:
+        db.close()
+
+
+def test_update_category_sets_both_fields() -> None:
+    user_id, cat_id = _seed_category()
+    try:
+        result = update_category(
+            user_id,
+            cat_id,
+            description="Day-to-day grocery shopping",
+            categorization_instructions="Assign when merchant is a supermarket chain.",
+        )
+        assert result["success"] is True, result
+        assert result["category"]["description"] == "Day-to-day grocery shopping"
+        assert (
+            result["category"]["categorization_instructions"]
+            == "Assign when merchant is a supermarket chain."
+        )
+
+        # Round-trip through DB.
+        db = SessionLocal()
+        try:
+            cat = db.query(Category).filter(Category.id == uuid.UUID(cat_id)).first()
+            assert cat.description == "Day-to-day grocery shopping"
+            assert cat.categorization_instructions == "Assign when merchant is a supermarket chain."
+        finally:
+            db.close()
+        print("✓ update_category sets both fields")
+    finally:
+        _cleanup(cat_id)
+
+
+def test_update_category_partial_update_preserves_other_field() -> None:
+    user_id, cat_id = _seed_category()
+    try:
+        update_category(
+            user_id,
+            cat_id,
+            description="initial description",
+            categorization_instructions="initial instructions",
+        )
+        result = update_category(user_id, cat_id, description="updated description")
+        assert result["success"] is True
+        assert result["category"]["description"] == "updated description"
+        # Instructions should be untouched.
+        assert result["category"]["categorization_instructions"] == "initial instructions"
+        print("✓ update_category preserves unspecified fields")
+    finally:
+        _cleanup(cat_id)
+
+
+def test_update_category_empty_string_clears_field() -> None:
+    user_id, cat_id = _seed_category()
+    try:
+        update_category(user_id, cat_id, description="something")
+        result = update_category(user_id, cat_id, description="")
+        assert result["success"] is True
+        assert result["category"]["description"] is None
+        print("✓ update_category clears field when passed empty string")
+    finally:
+        _cleanup(cat_id)
+
+
+def test_update_category_requires_at_least_one_field() -> None:
+    user_id, cat_id = _seed_category()
+    try:
+        result = update_category(user_id, cat_id)
+        assert result["success"] is False
+        assert "at least one" in result["error"].lower()
+        print("✓ update_category rejects no-op calls")
+    finally:
+        _cleanup(cat_id)
+
+
+def test_update_category_rejects_invalid_uuid() -> None:
+    user_id, cat_id = _seed_category()
+    try:
+        result = update_category(user_id, "not-a-uuid", description="x")
+        assert result["success"] is False
+        assert "invalid" in result["error"].lower()
+        print("✓ update_category rejects invalid UUID")
+    finally:
+        _cleanup(cat_id)
+
+
+def test_update_category_rejects_foreign_user() -> None:
+    user_id, cat_id = _seed_category()
+    try:
+        other_user = f"user_{uuid.uuid4().hex}"
+        result = update_category(other_user, cat_id, description="x")
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+        print("✓ update_category rejects access from foreign user")
+    finally:
+        _cleanup(cat_id)
+
+
+def test_update_category_rejects_system_category() -> None:
+    user_id, cat_id = _seed_category(is_system=True)
+    try:
+        result = update_category(user_id, cat_id, description="x")
+        assert result["success"] is False
+        assert "system" in result["error"].lower()
+        print("✓ update_category refuses to modify system categories")
+    finally:
+        _cleanup(cat_id)
+
+
+if __name__ == "__main__":
+    test_update_category_sets_both_fields()
+    test_update_category_partial_update_preserves_other_field()
+    test_update_category_empty_string_clears_field()
+    test_update_category_requires_at_least_one_field()
+    test_update_category_rejects_invalid_uuid()
+    test_update_category_rejects_foreign_user()
+    test_update_category_rejects_system_category()
+    print("All update_category tests passed.")


### PR DESCRIPTION
## Summary
- Adds `update_category` MCP tool that writes `description` and `categorization_instructions` on a user's category, so agents can persist learned categorization context for future AI runs.
- Only provided fields are written; passing `""` explicitly clears a field. System categories are rejected and ownership is enforced per user.
- Registers the tool in `app/mcp/server.py`, updates the server instructions blurb, and updates the tools index in `app/mcp/__init__.py`.

## Implementation
- `backend/app/mcp/tools/categories.py`: new `update_category(user_id, category_id, description=None, categorization_instructions=None)` — UUID validation, per-user ownership filter, system-category guard, partial-update semantics, try/except with rollback, returns `{success, category}` or `{success: False, error}` matching the existing `update_transaction_category` shape.
- `backend/app/mcp/server.py`: `@mcp.tool def update_category(...)` wrapper that resolves the user via `get_mcp_user_id` and delegates.

## Test plan
- [ ] `python tests/test_mcp_update_category.py` — covers happy path (both fields), partial update preserving unspecified field, empty-string clears, no-arg rejection, invalid UUID, foreign user, and system-category guard.
- [ ] Smoke: call `update_category` from an MCP client, then `get_category` to confirm fields round-trip.

https://claude.ai/code/session_015WQ5skwPqVshYjd3jVJLpP

---
_Generated by [Claude Code](https://claude.ai/code/session_015WQ5skwPqVshYjd3jVJLpP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `update_category` MCP tool to persist a category’s `description` and `categorization_instructions`, so learned categorization rules carry over to future runs. Registers the tool on the server and updates the MCP instructions.

- New Features
  - New `update_category(user_id, category_id, description?, categorization_instructions?)` that updates only provided fields; pass "" to clear.
  - Enforces per-user ownership, rejects system categories, validates UUIDs; returns `{success, category}` or `{success: False, error}` consistent with `update_transaction_category`.
  - Exposed via `app/mcp/server.py` as an `@mcp.tool` using `get_mcp_user_id`; `app/mcp/__init__.py` and server instructions updated.
  - Tests added (`backend/tests/test_mcp_update_category.py`) covering happy path, partial update, clear-on-empty, no-op rejection, invalid UUID, foreign user, and system-category guard.

<sup>Written for commit d09639fe43829a6a5b2bff8879dccf144d45b34c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

