### PR TITLE
fix(db): re-apply 0014 sync_started_at as manual migration

### DIFF
--- a/frontend/lib/db/migrations/0014_bank_connection_sync_started_at.manual.sql
+++ b/frontend/lib/db/migrations/0014_bank_connection_sync_started_at.manual.sql
@@ -1,0 +1,11 @@
+-- Hotfix: 0014 was recorded in the Drizzle journal but never applied to
+-- production (baselining on an existing schema marked it as applied without
+-- running the ALTER). Celery's `sync_all_bank_connections` and
+-- `check_consent_expiry` crash on every run with
+-- `column bank_connections.sync_started_at does not exist`.
+--
+-- Re-apply idempotently via the manual-migration channel so it runs on every
+-- deploy regardless of the Drizzle tracking state.
+
+ALTER TABLE "bank_connections"
+	ADD COLUMN IF NOT EXISTS "sync_started_at" timestamp;


### PR DESCRIPTION
## Summary
- Bank sync has been failing on every Celery run since 6b334d4 shipped with `psycopg.errors.UndefinedColumn: column bank_connections.sync_started_at does not exist` (confirmed in today's worker logs at 06:00, 09:00, 12:00 UTC).
- 0014 is recorded in the Drizzle journal but was never applied to the prod DB — when the frontend was first redeployed against the existing schema, the baseline path in `scripts/migrate.js` marked every journal entry as applied without running the SQL, including 0014.
- Adds an idempotent `.manual.sql` twin that re-applies `ADD COLUMN IF NOT EXISTS sync_started_at timestamp` on every deploy, matching the 0015/0016/0017 pattern.

## Impact
- `sync_all_bank_connections` (cron `0 */6 * * *` UTC) and `check_consent_expiry` (cron `0 9 * * *` UTC) fail at the first SELECT, so **zero connections have synced** since the broken deploy.
- Once this merges and the `app` Railway service redeploys, the next scheduled run (18:00 UTC today) should succeed. Users can also hit `/enable-banking/connections/{id}/sync` to trigger manually.

## Test plan
- [ ] Merge to main and redeploy the `app` service on Railway (preDeployCommand runs `node scripts/migrate.js`, which applies `.manual.sql` every time).
- [ ] Confirm `[migrate]   ✓ 0014_bank_connection_sync_started_at.manual.sql` appears in app logs.
- [ ] Verify `SELECT column_name FROM information_schema.columns WHERE table_name='bank_connections' AND column_name='sync_started_at';` returns one row.
- [ ] Watch the worker service through the next scheduled sync (or trigger one via the API) and confirm `Dispatched sync for N active connections` appears without a traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an idempotent manual migration to ensure `bank_connections.sync_started_at` exists in production, fixing the UndefinedColumn error. This restores Celery bank sync and consent expiry jobs.

- **Bug Fixes**
  - Added 0014_bank_connection_sync_started_at.manual.sql to run on every deploy and apply `ADD COLUMN IF NOT EXISTS sync_started_at timestamp`.
  - Unblocks `sync_all_bank_connections` and `check_consent_expiry` by preventing `UndefinedColumn` failures.

<sup>Written for commit d6a70e6e9cc6871eb6026a0875d9bd851184dd1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

