### PR TITLE
feat(categories): allow editing description/instructions on system categories

### DIFF
--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -188,7 +188,9 @@ def update_category(
     is under €5") so that future AI categorization applies the same rules.
 
     Only provided fields are written. Pass an empty string ("") to explicitly
-    clear a field. System categories cannot be updated.
+    clear a field. System categories (e.g. Internal Transfer, External
+    Transfer) are editable via this tool — description and
+    categorization_instructions are user-tailored context.
 
     Args:
         category_id: The category's ID

--- a/backend/app/mcp/tools/categories.py
+++ b/backend/app/mcp/tools/categories.py
@@ -92,7 +92,9 @@ def update_category(
     Used by agents to persist learned categorization context so that the AI
     can apply consistent rules on future transactions. Only the provided
     fields are updated; omitted fields are left untouched. Pass an empty
-    string to explicitly clear a field.
+    string to explicitly clear a field. System categories are editable here
+    because description/instructions are user-tailored context, not
+    structural identity.
 
     Args:
         user_id: The user's ID
@@ -121,9 +123,6 @@ def update_category(
 
         if not category:
             return {"success": False, "error": "Category not found"}
-
-        if category.is_system:
-            return {"success": False, "error": "Cannot update system categories"}
 
         try:
             if description is not None:

--- a/backend/tests/test_mcp_update_category.py
+++ b/backend/tests/test_mcp_update_category.py
@@ -146,13 +146,26 @@ def test_update_category_rejects_foreign_user() -> None:
         _cleanup(cat_id)
 
 
-def test_update_category_rejects_system_category() -> None:
+def test_update_category_allows_system_category() -> None:
+    """System categories (e.g. Internal Transfer) accept description and
+    categorization_instructions updates — those fields are user-tailored
+    context, not part of the category's structural identity."""
     user_id, cat_id = _seed_category(is_system=True)
     try:
-        result = update_category(user_id, cat_id, description="x")
-        assert result["success"] is False
-        assert "system" in result["error"].lower()
-        print("✓ update_category refuses to modify system categories")
+        result = update_category(
+            user_id,
+            cat_id,
+            description="Money moved between my accounts",
+            categorization_instructions="Treat as Internal Transfer when IBAN belongs to me.",
+        )
+        assert result["success"] is True, result
+        assert result["category"]["is_system"] is True
+        assert result["category"]["description"] == "Money moved between my accounts"
+        assert (
+            result["category"]["categorization_instructions"]
+            == "Treat as Internal Transfer when IBAN belongs to me."
+        )
+        print("✓ update_category allows description/instructions on system categories")
     finally:
         _cleanup(cat_id)
 
@@ -164,5 +177,5 @@ if __name__ == "__main__":
     test_update_category_requires_at_least_one_field()
     test_update_category_rejects_invalid_uuid()
     test_update_category_rejects_foreign_user()
-    test_update_category_rejects_system_category()
+    test_update_category_allows_system_category()
     print("All update_category tests passed.")

--- a/frontend/components/onboarding/category-color-picker.tsx
+++ b/frontend/components/onboarding/category-color-picker.tsx
@@ -12,9 +12,10 @@ import { Button } from "@/components/ui/button";
 interface CategoryColorPickerProps {
   value: string;
   onChange: (color: string) => void;
+  disabled?: boolean;
 }
 
-export function CategoryColorPicker({ value, onChange }: CategoryColorPickerProps) {
+export function CategoryColorPicker({ value, onChange, disabled = false }: CategoryColorPickerProps) {
   return (
     <Popover>
       <PopoverTrigger
@@ -23,6 +24,7 @@ export function CategoryColorPicker({ value, onChange }: CategoryColorPickerProp
             type="button"
             variant="outline"
             className="h-8 w-8 p-0"
+            disabled={disabled}
           >
             <div
               className="h-5 w-5 rounded-full"

--- a/frontend/components/onboarding/category-form-dialog.tsx
+++ b/frontend/components/onboarding/category-form-dialog.tsx
@@ -35,6 +35,7 @@ export function CategoryFormDialog({
   existingCount = 0,
 }: CategoryFormDialogProps) {
   const isEditing = !!category;
+  const isSystem = !!category?.isSystem;
 
   const [name, setName] = useState("");
   const [color, setColor] = useState<string>(CATEGORY_COLORS[0].value);
@@ -63,9 +64,9 @@ export function CategoryFormDialog({
     if (!name.trim() || !description.trim()) return;
 
     const updatedCategory: CategoryInput = {
-      name: name.trim(),
+      name: isSystem && category ? category.name : name.trim(),
       categoryType,
-      color,
+      color: isSystem && category ? category.color : color,
       icon: category?.icon || "RiFolderLine",
       description: description.trim(),
       categorizationInstructions: categorizationInstructions.trim() || undefined,
@@ -95,22 +96,25 @@ export function CategoryFormDialog({
             {isEditing ? "Edit Category" : `Add ${getCategoryTypeLabel()} Category`}
           </DialogTitle>
           <DialogDescription>
-            {isEditing
+            {isSystem
+              ? "System category — only description and categorization instructions can be edited."
+              : isEditing
               ? "Update the category details below."
               : "Create a new category to organize your transactions."}
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 py-4">
           <div className="space-y-2">
-            <Label htmlFor="name">Name *</Label>
+            <Label htmlFor="name">Name{isSystem ? "" : " *"}</Label>
             <div className="flex items-center gap-3">
-              <CategoryColorPicker value={color} onChange={setColor} />
+              <CategoryColorPicker value={color} onChange={setColor} disabled={isSystem} />
               <Input
                 id="name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Enter category name"
                 className="flex-1"
+                disabled={isSystem}
               />
             </div>
           </div>

--- a/frontend/components/onboarding/category-row.tsx
+++ b/frontend/components/onboarding/category-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RiDeleteBinLine, RiEditLine, RiLockLine } from "@remixicon/react";
+import { RiDeleteBinLine, RiEditLine } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
 import { type CategoryInput } from "@/lib/actions/categories";
 
@@ -40,40 +40,27 @@ export function CategoryRow({ category, onEdit, onDelete }: CategoryRowProps) {
 
       {/* Action buttons */}
       <div className="flex items-center gap-1 shrink-0">
-        {isSystem ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={onEdit}
+          title={isSystem ? "Edit description and categorization instructions" : "Edit category"}
+        >
+          <RiEditLine className="h-4 w-4" />
+        </Button>
+        {!isSystem && (
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            className="h-8 w-8"
-            disabled
-            title="Not able to modify."
+            className="h-8 w-8 text-destructive hover:text-destructive"
+            onClick={onDelete}
+            title="Delete category"
           >
-            <RiLockLine className="h-4 w-4 text-muted-foreground" />
+            <RiDeleteBinLine className="h-4 w-4" />
           </Button>
-        ) : (
-          <>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={onEdit}
-              title="Edit category"
-            >
-              <RiEditLine className="h-4 w-4" />
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 text-destructive hover:text-destructive"
-              onClick={onDelete}
-              title="Delete category"
-            >
-              <RiDeleteBinLine className="h-4 w-4" />
-            </Button>
-          </>
         )}
       </div>
     </div>

--- a/frontend/lib/actions/categories.ts
+++ b/frontend/lib/actions/categories.ts
@@ -102,8 +102,34 @@ export async function updateCategory(
       return { success: false, error: "Category not found" };
     }
 
+    // System categories accept description/categorization_instructions updates
+    // (user-tailored context) but reject structural changes.
     if (existing.isSystem) {
-      return { success: false, error: "System categories cannot be modified" };
+      const attemptingStructuralChange =
+        (input.name !== undefined && input.name.trim() !== existing.name) ||
+        (input.color !== undefined && input.color !== existing.color) ||
+        (input.icon !== undefined && input.icon !== existing.icon);
+
+      if (attemptingStructuralChange) {
+        return {
+          success: false,
+          error: "System categories only allow editing description and categorization instructions",
+        };
+      }
+
+      await db
+        .update(categories)
+        .set({
+          ...(input.description !== undefined && { description: input.description?.trim() || null }),
+          ...(input.categorizationInstructions !== undefined && {
+            categorizationInstructions: input.categorizationInstructions?.trim() || null,
+          }),
+        })
+        .where(eq(categories.id, categoryId));
+
+      revalidatePath("/");
+      revalidatePath("/settings");
+      return { success: true };
     }
 
     // Check for duplicate name if name is being changed


### PR DESCRIPTION
## Summary
- Unlocks `description` and `categorization_instructions` editing for system categories (Internal Transfer, External Transfer, Balancing Transfer) across MCP, the server action, and the UI. Name/color/icon and deletion remain locked.
- Rationale: those two fields are user-tailored AI context, not structural identity of the category.

## Changes
- `backend/app/mcp/tools/categories.py`: drop the `is_system` rejection in `update_category`.
- `frontend/lib/actions/categories.ts:updateCategory`: for system rows, reject structural changes but accept description/categorizationInstructions.
- `frontend/components/onboarding/category-row.tsx`: replace the lock icon with an edit button for system rows (delete stays hidden).
- `frontend/components/onboarding/category-form-dialog.tsx`: disable name input and color picker for system categories; update helper copy.
- `frontend/components/onboarding/category-color-picker.tsx`: add `disabled` prop.
- `backend/tests/test_mcp_update_category.py`: flip the "rejects system" test to "allows description/instructions on system".

## Test plan
- [ ] `python backend/tests/test_mcp_update_category.py` — full suite incl. new `test_update_category_allows_system_category`.
- [ ] UI smoke: open **Settings → Categories → Transfers**, edit Internal Transfer, change `categorization_instructions`, save, reload — persists. Name/color inputs are disabled.
- [ ] UI smoke: try to rename a system category via a crafted server action call — returns "System categories only allow editing description and categorization instructions".
- [ ] MCP smoke: call `update_category` with the Internal Transfer ID and new `categorization_instructions`, then `get_category` to confirm round-trip.

https://claude.ai/code/session_015WQ5skwPqVshYjd3jVJLpP

---
_Generated by [Claude Code](https://claude.ai/code/session_015WQ5skwPqVshYjd3jVJLpP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow editing description and categorization instructions for system categories (Internal, External, Balancing Transfer) while keeping name, color, icon, and deletion locked. This lets users fine-tune categorization context without changing category identity.

- **New Features**
  - MCP `update_category` now accepts `description` and `categorization_instructions` updates for system categories; help text updated.
  - Server action `updateCategory` allows these fields and blocks structural changes; triggers revalidation.
  - UI: system rows show an Edit button (no Delete). In the form, name and color are disabled; `CategoryColorPicker` supports `disabled`.
  - Tests updated to verify allowed edits on system categories.

<sup>Written for commit b30fbc3ddf8428aeb741f945fd2c008783e8962b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

