### PR TITLE
feat(mcp+categorizer): audit filters, cursor pagination, prompt enrichment, alias_patterns

### DIFF
--- a/backend/app/mcp/dependencies.py
+++ b/backend/app/mcp/dependencies.py
@@ -1,6 +1,8 @@
 """
 Database session management for MCP tools.
 """
+from __future__ import annotations
+
 from contextlib import contextmanager
 from datetime import datetime
 from uuid import UUID

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -530,7 +530,9 @@ def get_top_merchants(
     from_date: str | None = None,
     to_date: str | None = None,
     limit: int = 10,
-    user_id: str | None = None
+    category_id: str | None = None,
+    uncategorized: bool = False,
+    user_id: str | None = None,
 ) -> list[dict]:
     """
     Get top merchants by total spending.
@@ -539,12 +541,18 @@ def get_top_merchants(
         from_date: Start date in ISO format YYYY-MM-DD (optional)
         to_date: End date in ISO format YYYY-MM-DD (optional)
         limit: Max number of merchants (default: 10, max: 50)
+        category_id: Filter to transactions in this category (optional).
+            Mutually exclusive with uncategorized.
+        uncategorized: If True, return only transactions with no category.
+            Mutually exclusive with category_id.
         user_id: The user's ID (optional, defaults to configured user)
 
     Returns:
         List of merchants with total spending and transaction count
     """
-    return analytics.get_top_merchants(get_mcp_user_id(user_id), from_date, to_date, limit)
+    return analytics.get_top_merchants(
+        get_mcp_user_id(user_id), from_date, to_date, limit, category_id, uncategorized
+    )
 
 
 # ============================================================================

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -399,18 +399,23 @@ def update_transaction_category(
 def bulk_update_transaction_categories(
     category_id: str,
     transaction_ids: list[str],
-    user_id: str | None = None
+    dry_run: bool = False,
+    user_id: str | None = None,
 ) -> dict:
     """
     Bulk update category for multiple transactions.
 
     Args:
         category_id: The category ID to assign to all transactions
-        transaction_ids: List of transaction IDs to update
+        transaction_ids: List of transaction IDs to update (max 2000)
+        dry_run: If True, preview what would change without committing (default: False)
         user_id: The user's ID (optional, defaults to configured user)
 
     Returns:
-        Dict with success status, updated_count, and any errors
+        Dict with success status and:
+        - updated_count (or would_update_count if dry_run=True)
+        - requested_count, invalid_ids, not_found_ids,
+          skipped_already_in_category_ids, sample_changes (up to 10)
 
     Recommended workflow using search_transactions_multi:
         # Find all grocery store transactions not yet categorized
@@ -420,14 +425,20 @@ def bulk_update_transaction_categories(
             match_mode="word",
             ids_only=True
         )
-        # Update them all at once
+        # Preview first
+        bulk_update_transaction_categories(
+            category_id="<groceries-id>",
+            transaction_ids=result["transaction_ids"],
+            dry_run=True,
+        )
+        # Then commit
         bulk_update_transaction_categories(
             category_id="<groceries-id>",
             transaction_ids=result["transaction_ids"]
         )
     """
     return transactions.bulk_update_transaction_categories(
-        get_mcp_user_id(user_id), category_id, transaction_ids
+        get_mcp_user_id(user_id), category_id, transaction_ids, dry_run
     )
 
 

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -440,7 +440,8 @@ def get_spending_by_category(
     from_date: str | None = None,
     to_date: str | None = None,
     account_id: str | None = None,
-    user_id: str | None = None
+    include_uncategorized: bool = False,
+    user_id: str | None = None,
 ) -> list[dict]:
     """
     Get spending breakdown by category.
@@ -449,12 +450,17 @@ def get_spending_by_category(
         from_date: Start date in ISO format YYYY-MM-DD (optional)
         to_date: End date in ISO format YYYY-MM-DD (optional)
         account_id: Filter by account ID (optional)
+        include_uncategorized: If True, include an "Uncategorized" bucket for
+            transactions with no category assigned (default: False)
         user_id: The user's ID (optional, defaults to configured user)
 
     Returns:
-        List of categories with total spending amount and transaction count
+        List of categories with total spending amount, transaction count, and
+        merchant_count
     """
-    return analytics.get_spending_by_category(get_mcp_user_id(user_id), from_date, to_date, account_id)
+    return analytics.get_spending_by_category(
+        get_mcp_user_id(user_id), from_date, to_date, account_id, include_uncategorized
+    )
 
 
 @mcp.tool

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -78,6 +78,32 @@ Use `match_mode="word"` for merchant names to avoid false positives!
 When using `search_transactions`, ALWAYS check `has_more` in the response.
 If true, you MUST call again with page=2, 3, etc. until has_more=false.
 The `total_count` field tells you how many total results exist.
+
+## Pagination & sort
+
+All list/search tools accept:
+- `cursor` (opaque string) — preferred for paging through large result sets; pass
+  `next_cursor` from the previous response.
+- `sort_by`: one of `booked_at_desc` (default), `booked_at_asc`, `amount_desc`,
+  `amount_asc`, `abs_amount_desc`.
+- `account_id` — limit to a single account.
+
+## Audit filters
+
+- `list_transactions(uncategorized=True)` — only rows with no category at all.
+- `list_transactions(category_type="expense"|"income"|"transfer")` — filter by type.
+- `get_spending_by_category(include_uncategorized=True)` — include an
+  "Uncategorized" bucket with `merchant_count`.
+- `get_top_merchants(category_id=...)` or `get_top_merchants(uncategorized=True)` —
+  audit miscategorized or unassigned merchants.
+
+## Safe bulk updates
+
+`bulk_update_transaction_categories(dry_run=True)` returns what *would* change
+(`would_update_count`, `sample_changes`) without mutating. Hard cap: 2000 IDs
+per call. Response also includes `invalid_ids`, `not_found_ids`, and
+`skipped_already_in_category_ids` so the agent can narrate exactly what
+happened.
 """,
     auth=_auth,
 )

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -200,10 +200,14 @@ def list_transactions(
     search: str | None = None,
     limit: int = 50,
     page: int = 1,
-    user_id: str | None = None
-) -> list[dict]:
+    cursor: str | None = None,
+    sort_by: str = "booked_at_desc",
+    uncategorized: bool = False,
+    category_type: str | None = None,
+    user_id: str | None = None,
+) -> dict:
     """
-    List transactions with optional filtering.
+    List transactions with optional filtering, cursor pagination, and sort.
 
     Args:
         account_id: Filter by account ID (optional)
@@ -212,14 +216,20 @@ def list_transactions(
         to_date: End date in ISO format YYYY-MM-DD (optional)
         search: Search in description/merchant (optional)
         limit: Max results per page (default: 50, max: 100)
-        page: Page number (default: 1)
+        page: Page number (default: 1) - ignored when cursor is provided
+        cursor: Opaque cursor from previous response for stable pagination
+        sort_by: Sort order - booked_at_desc (default), booked_at_asc,
+            amount_desc, amount_asc, abs_amount_desc
+        uncategorized: If True, return only transactions with no category
+        category_type: Filter by resolved category type (expense, income, transfer)
         user_id: The user's ID (optional, defaults to configured user)
 
     Returns:
-        List of transaction dictionaries with account and category info
+        Dict with transactions list, limit, page (or None), and next_cursor
     """
     return transactions.list_transactions(
-        get_mcp_user_id(user_id), account_id, category_id, from_date, to_date, search, limit, page
+        get_mcp_user_id(user_id), account_id, category_id, from_date, to_date, search,
+        limit, page, cursor, sort_by, uncategorized, category_type,
     )
 
 
@@ -246,13 +256,17 @@ def search_transactions(
     ids_only: bool = False,
     limit: int = 50,
     page: int = 1,
-    user_id: str | None = None
+    cursor: str | None = None,
+    sort_by: str = "booked_at_desc",
+    account_id: str | None = None,
+    user_id: str | None = None,
 ) -> dict:
     """
     Search transactions by description or merchant name.
 
     ⚠️ PAGINATION WARNING: Always check `has_more` in the response!
     If true, you MUST call again with page=2, page=3, etc. until has_more=false.
+    Prefer `cursor`/`next_cursor` for stable pagination over large result sets.
 
     Args:
         query: Search query string (case-insensitive)
@@ -263,16 +277,21 @@ def search_transactions(
             - "word": Word boundary match - "Action" matches "Action Store" but NOT "Transaction"
         ids_only: If True, return only transaction IDs (faster, less tokens for bulk ops)
         limit: Max results per page (default: 50, max: 100)
-        page: Page number (default: 1)
+        page: Page number (default: 1) - ignored when cursor is provided
+        cursor: Opaque cursor from previous response for stable pagination
+        sort_by: Sort order - booked_at_desc (default), booked_at_asc,
+            amount_desc, amount_asc, abs_amount_desc
+        account_id: Filter results to a single account (optional)
         user_id: The user's ID (optional, defaults to configured user)
 
     Returns:
         Dict with:
         - transactions: List of matching transactions (or transaction_ids if ids_only=True)
-        - page: Current page number
+        - page: Current page number (None when cursor-paginated)
         - limit: Results per page
         - has_more: Boolean - KEEP PAGINATING until this is false!
         - total_count: Total matches across all pages (use to plan pagination)
+        - next_cursor: Opaque cursor for next page (None when exhausted)
 
     Example - find transactions to recategorize:
         search_transactions(
@@ -283,7 +302,8 @@ def search_transactions(
         )
     """
     return transactions.search_transactions(
-        get_mcp_user_id(user_id), query, exclude_category_id, match_mode, ids_only, limit, page
+        get_mcp_user_id(user_id), query, exclude_category_id, match_mode, ids_only,
+        limit, page, cursor, sort_by, account_id,
     )
 
 
@@ -294,13 +314,20 @@ def search_transactions_multi(
     match_mode: str = "contains",
     ids_only: bool = False,
     max_results: int = 500,
-    user_id: str | None = None
+    cursor: str | None = None,
+    sort_by: str = "booked_at_desc",
+    account_id: str | None = None,
+    user_id: str | None = None,
 ) -> dict:
     """
     Search transactions matching ANY of multiple queries in a single call.
 
     Use this instead of multiple search_transactions calls when you need to find
     transactions from several merchants at once (e.g., for bulk recategorization).
+
+    Pass `cursor=""` (or a real cursor from `next_cursor`) to enable cursor
+    pagination. Without a cursor, all results up to `max_results` are returned
+    in one shot.
 
     Args:
         queries: List of search terms (e.g., ["Jumbo", "Albert Heijn", "ALDI", "LIDL"])
@@ -311,6 +338,10 @@ def search_transactions_multi(
             - "word": Word boundary match (recommended for merchant names)
         ids_only: If True, return only transaction IDs (recommended for bulk updates)
         max_results: Maximum results to return (default: 500, max: 1000)
+        cursor: Opaque cursor; pass "" or a real cursor to enable cursor pagination
+        sort_by: Sort order - booked_at_desc (default), booked_at_asc,
+            amount_desc, amount_asc, abs_amount_desc
+        account_id: Filter results to a single account (optional)
         user_id: The user's ID (optional, defaults to configured user)
 
     Returns:
@@ -319,6 +350,7 @@ def search_transactions_multi(
         - total_count: Total matches found
         - capped: True if results hit max_results limit
         - query_counts: Matches per query (e.g., {"Jumbo": 127, "ALDI": 45})
+        - next_cursor: Opaque cursor for next page (only in cursor mode)
 
     Example - recategorize grocery store transactions:
         # Step 1: Find all grocery transactions not yet categorized
@@ -335,7 +367,8 @@ def search_transactions_multi(
         )
     """
     return transactions.search_transactions_multi(
-        get_mcp_user_id(user_id), queries, exclude_category_id, match_mode, ids_only, max_results
+        get_mcp_user_id(user_id), queries, exclude_category_id, match_mode, ids_only,
+        max_results, cursor, sort_by, account_id,
     )
 
 

--- a/backend/app/mcp/tools/accounts.py
+++ b/backend/app/mcp/tools/accounts.py
@@ -39,6 +39,7 @@ def list_accounts(user_id: str, include_inactive: bool = False) -> list[dict]:
                 "starting_balance": float(account.starting_balance) if account.starting_balance else 0,
                 "functional_balance": float(account.functional_balance) if account.functional_balance else None,
                 "is_active": account.is_active,
+                "alias_patterns": account.alias_patterns or [],
                 "last_synced_at": account.last_synced_at.isoformat() if account.last_synced_at else None,
                 "created_at": account.created_at.isoformat() if account.created_at else None,
             }
@@ -82,6 +83,7 @@ def get_account(user_id: str, account_id: str) -> dict | None:
             "starting_balance": float(account.starting_balance) if account.starting_balance else 0,
             "functional_balance": float(account.functional_balance) if account.functional_balance else None,
             "is_active": account.is_active,
+            "alias_patterns": account.alias_patterns or [],
             "last_synced_at": account.last_synced_at.isoformat() if account.last_synced_at else None,
             "created_at": account.created_at.isoformat() if account.created_at else None,
             "updated_at": account.updated_at.isoformat() if account.updated_at else None,

--- a/backend/app/mcp/tools/analytics.py
+++ b/backend/app/mcp/tools/analytics.py
@@ -396,7 +396,9 @@ def get_top_merchants(
     user_id: str,
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
-    limit: int = 10
+    limit: int = 10,
+    category_id: Optional[str] = None,
+    uncategorized: bool = False,
 ) -> list[dict]:
     """
     Get top merchants by total spending.
@@ -406,10 +408,18 @@ def get_top_merchants(
         from_date: Start date in ISO format (optional)
         to_date: End date in ISO format (optional)
         limit: Max number of merchants (default: 10, max: 50)
+        category_id: Filter to transactions in this category (optional).
+            Mutually exclusive with uncategorized.
+        uncategorized: If True, return only transactions with no category.
+            Mutually exclusive with category_id.
 
     Returns:
         List of merchants with total spending and transaction count
     """
+    if category_id and uncategorized:
+        raise ValueError("category_id and uncategorized are mutually exclusive")
+
+    cat_uuid = validate_uuid(category_id) if category_id else None
     limit = min(max(1, limit), 50)
 
     # Validate parameters
@@ -428,6 +438,23 @@ def get_top_merchants(
             Transaction.merchant != "",
             Transaction.include_in_analytics == True
         )
+
+        if cat_uuid:
+            query = query.filter(
+                or_(
+                    Transaction.category_id == cat_uuid,
+                    and_(
+                        Transaction.category_id.is_(None),
+                        Transaction.category_system_id == cat_uuid,
+                    ),
+                )
+            )
+
+        if uncategorized:
+            query = query.filter(
+                Transaction.category_id.is_(None),
+                Transaction.category_system_id.is_(None),
+            )
 
         if from_dt:
             query = query.filter(Transaction.booked_at >= from_dt)

--- a/backend/app/mcp/tools/analytics.py
+++ b/backend/app/mcp/tools/analytics.py
@@ -29,7 +29,8 @@ def get_spending_by_category(
     user_id: str,
     from_date: Optional[str] = None,
     to_date: Optional[str] = None,
-    account_id: Optional[str] = None
+    account_id: Optional[str] = None,
+    include_uncategorized: bool = False,
 ) -> list[dict]:
     """
     Get spending breakdown by category.
@@ -41,9 +42,12 @@ def get_spending_by_category(
         from_date: Start date in ISO format (optional)
         to_date: End date in ISO format (optional)
         account_id: Filter by account ID (optional)
+        include_uncategorized: If True, include an "Uncategorized" bucket for
+            transactions with no category assigned (default: False)
 
     Returns:
-        List of categories with total spending amount and transaction count
+        List of categories with total spending amount, transaction count, and
+        merchant_count
     """
     # Validate parameters
     from_dt = validate_date(from_date)
@@ -61,12 +65,17 @@ def get_spending_by_category(
     if account_uuid:
         account_filter = f" AND t.account_id = '{account_uuid}'"
 
+    join_type = "LEFT JOIN" if include_uncategorized else "INNER JOIN"
+    # When include_uncategorized=False, restrict to expense categories only.
+    # With a LEFT JOIN we must omit this filter so null-category rows appear.
+    uncategorized_filter = "" if include_uncategorized else "AND c.category_type = 'expense'"
+
     with get_db() as db:
         sql = text(f"""
             {_get_link_group_nets_cte(user_id)}
             SELECT
                 COALESCE(t.category_id, t.category_system_id) as category_id,
-                c.name as category_name,
+                COALESCE(c.name, 'Uncategorized') as category_name,
                 c.color as category_color,
                 COALESCE(SUM(
                     CASE
@@ -76,15 +85,16 @@ def get_spending_by_category(
                         ELSE ABS(t.amount)
                     END
                 ), 0) as total,
-                COUNT(t.id) as count
+                COUNT(t.id) as count,
+                COUNT(DISTINCT t.merchant) FILTER (WHERE t.merchant IS NOT NULL AND t.merchant <> '') as merchant_count
             FROM transactions t
-            INNER JOIN categories c ON c.id = COALESCE(t.category_id, t.category_system_id)
+            {join_type} categories c ON c.id = COALESCE(t.category_id, t.category_system_id)
             LEFT JOIN transaction_links tl ON t.id = tl.transaction_id
             LEFT JOIN link_group_nets lgn ON tl.group_id = lgn.group_id
             WHERE t.user_id = '{user_id}'
                 AND t.transaction_type = 'debit'
                 AND t.include_in_analytics = true
-                AND c.category_type = 'expense'
+                {uncategorized_filter}
                 {date_filter}
                 {account_filter}
             GROUP BY COALESCE(t.category_id, t.category_system_id), c.name, c.color
@@ -100,6 +110,7 @@ def get_spending_by_category(
                 "category_color": r.category_color,
                 "total": float(r.total) if r.total else 0,
                 "count": r.count,
+                "merchant_count": r.merchant_count,
             }
             for r in results
         ]

--- a/backend/app/mcp/tools/analytics.py
+++ b/backend/app/mcp/tools/analytics.py
@@ -66,9 +66,15 @@ def get_spending_by_category(
         account_filter = f" AND t.account_id = '{account_uuid}'"
 
     join_type = "LEFT JOIN" if include_uncategorized else "INNER JOIN"
-    # When include_uncategorized=False, restrict to expense categories only.
-    # With a LEFT JOIN we must omit this filter so null-category rows appear.
-    uncategorized_filter = "" if include_uncategorized else "AND c.category_type = 'expense'"
+    # With INNER JOIN we already exclude null-category rows, so restrict to
+    # expense categories only. With LEFT JOIN we keep all debit rows but still
+    # require categorised rows to be expenses — null-category rows are allowed
+    # via the OR arm so they appear as the "Uncategorized" bucket.
+    uncategorized_filter = (
+        "AND (c.category_type = 'expense' OR c.id IS NULL)"
+        if include_uncategorized
+        else "AND c.category_type = 'expense'"
+    )
 
     with get_db() as db:
         sql = text(f"""

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -766,7 +766,7 @@ def bulk_update_transaction_categories(
                 "amount": float(t.amount),
                 "previous_category_name": t.category.name if t.category else None,
             }
-            for t in to_change[:10]
+            for t in sorted(to_change, key=lambda t: (t.booked_at, t.id))[:10]
         ]
 
         base_response = {

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -574,6 +574,8 @@ def search_transactions_multi(
                     Transaction.user_id == user_id,
                     _build_search_filter(q_str, match_mode)
                 )
+                if account_uuid:
+                    q_filter = and_(q_filter, Transaction.account_id == account_uuid)
                 if exclude_cat_uuid:
                     q_filter = and_(
                         q_filter,
@@ -586,7 +588,7 @@ def search_transactions_multi(
 
         result = {
             "total_count": total_count,
-            "capped": len(transactions_rows) < total_count,
+            "capped": (not cursor_mode) and (len(transactions_rows) >= max_results) and (total_count > max_results),
             "query_counts": query_counts,
             "next_cursor": next_cursor,
         }

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -687,7 +687,8 @@ def update_transaction_category(
 def bulk_update_transaction_categories(
     user_id: str,
     category_id: str,
-    transaction_ids: list[str]
+    transaction_ids: list[str],
+    dry_run: bool = False,
 ) -> dict:
     """
     Bulk update category for multiple transactions.
@@ -695,13 +696,23 @@ def bulk_update_transaction_categories(
     Args:
         user_id: The user's ID
         category_id: The category ID to assign
-        transaction_ids: List of transaction IDs to update
+        transaction_ids: List of transaction IDs to update (max 2000)
+        dry_run: If True, preview the change without committing
 
     Returns:
-        Dict with success, updated_count, and any errors
+        Dict with success flag and:
+        - updated_count (or would_update_count if dry_run)
+        - requested_count, invalid_ids, not_found_ids,
+          skipped_already_in_category_ids, sample_changes
     """
+    MAX_IDS = 2000
     if not transaction_ids:
         return {"success": False, "error": "Must provide transaction_ids"}
+    if len(transaction_ids) > MAX_IDS:
+        return {
+            "success": False,
+            "error": f"Too many transaction_ids ({len(transaction_ids)}). Max {MAX_IDS} per call.",
+        }
 
     cat_uuid = validate_uuid(category_id)
     if not cat_uuid:
@@ -711,44 +722,79 @@ def bulk_update_transaction_categories(
         # Verify category belongs to user
         category = db.query(Category).filter(
             Category.id == cat_uuid,
-            Category.user_id == user_id
+            Category.user_id == user_id,
         ).first()
 
         if not category:
             return {"success": False, "error": "Category not found"}
 
-        try:
-            valid_uuids = []
-            invalid_ids = []
-            for tid in transaction_ids:
-                uuid = validate_uuid(tid)
-                if uuid:
-                    valid_uuids.append(uuid)
-                else:
-                    invalid_ids.append(tid)
+        valid_uuids = []
+        invalid_ids = []
+        for tid in transaction_ids:
+            u = validate_uuid(tid)
+            if u:
+                valid_uuids.append(u)
+            else:
+                invalid_ids.append(tid)
 
-            if not valid_uuids:
-                return {"success": False, "error": "No valid transaction IDs provided"}
-
-            result = db.query(Transaction).filter(
+        found = (
+            db.query(Transaction)
+            .filter(
                 Transaction.user_id == user_id,
-                Transaction.id.in_(valid_uuids)
-            ).update(
-                {Transaction.category_id: cat_uuid},
-                synchronize_session=False
+                Transaction.id.in_(valid_uuids),
             )
-            db.commit()
+            .options(joinedload(Transaction.category))
+            .all()
+        ) if valid_uuids else []
 
-            response = {
-                "success": True,
-                "updated_count": result,
-                "category_name": category.name,
-                "requested_count": len(transaction_ids)
+        found_by_id = {str(t.id): t for t in found}
+        not_found_ids = [str(u) for u in valid_uuids if str(u) not in found_by_id]
+
+        to_change = []
+        skipped_already = []
+        for t in found:
+            if t.category_id == cat_uuid:
+                skipped_already.append(str(t.id))
+            else:
+                to_change.append(t)
+
+        sample_changes = [
+            {
+                "id": str(t.id),
+                "description": t.description,
+                "merchant": t.merchant,
+                "amount": float(t.amount),
+                "previous_category_name": t.category.name if t.category else None,
             }
-            if invalid_ids:
-                response["invalid_ids"] = invalid_ids
-            return response
+            for t in to_change[:10]
+        ]
 
+        base_response = {
+            "success": True,
+            "category_name": category.name,
+            "requested_count": len(transaction_ids),
+            "invalid_ids": invalid_ids,
+            "not_found_ids": not_found_ids,
+            "skipped_already_in_category_ids": skipped_already,
+            "sample_changes": sample_changes,
+        }
+
+        if dry_run:
+            base_response["would_update_count"] = len(to_change)
+            return base_response
+
+        try:
+            change_uuids = [t.id for t in to_change]
+            updated = 0
+            if change_uuids:
+                updated = db.query(Transaction).filter(
+                    Transaction.user_id == user_id,
+                    Transaction.id.in_(change_uuids),
+                ).update({Transaction.category_id: cat_uuid}, synchronize_session=False)
+                db.commit()
         except Exception as e:
             db.rollback()
             return {"success": False, "error": f"Database error: {str(e)}"}
+
+        base_response["updated_count"] = updated
+        return base_response

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -4,6 +4,7 @@ Transaction tools for the MCP server.
 import base64
 import json
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional, Literal
 
 from sqlalchemy import or_, and_, func
@@ -57,6 +58,13 @@ def _paginate_query(query, cursor: Optional[str], sort_by: SortBy, limit: int):
             v, last_id = _decode_cursor(cursor)
         except Exception:
             raise ValueError("Invalid cursor")
+        # Coerce the primary value to a type Postgres can compare against the
+        # primary column: timestamps must not be compared as strings, and
+        # numeric columns are safer as Decimal/float.
+        if sort_by in ("booked_at_desc", "booked_at_asc"):
+            v = datetime.fromisoformat(v)
+        else:
+            v = Decimal(v)
         # Sort-aware cursor filter: rows "after" (primary, id) tuple
         is_desc = sort_by in ("booked_at_desc", "amount_desc", "abs_amount_desc")
         if is_desc:
@@ -67,7 +75,7 @@ def _paginate_query(query, cursor: Optional[str], sort_by: SortBy, limit: int):
             query = query.filter(
                 or_(primary_col > v, and_(primary_col == v, Transaction.id > last_id))
             )
-    return query.order_by(direction(primary_col), Transaction.id.desc()).limit(limit)
+    return query.order_by(direction(primary_col), direction(Transaction.id)).limit(limit)
 
 
 def _build_next_cursor(rows: list, sort_by: SortBy, limit: int) -> Optional[str]:
@@ -178,7 +186,7 @@ def list_transactions(
             offset = (page - 1) * limit
             primary_col, direction = _sort_expr(sort_by)
             paginated = (
-                query.order_by(direction(primary_col), Transaction.id.desc())
+                query.order_by(direction(primary_col), direction(Transaction.id))
                 .offset(offset)
                 .limit(limit)
             )

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -323,13 +323,17 @@ def search_transactions(
     match_mode: MatchMode = "contains",
     ids_only: bool = False,
     limit: int = 50,
-    page: int = 1
+    page: int = 1,
+    cursor: Optional[str] = None,
+    sort_by: SortBy = "booked_at_desc",
+    account_id: Optional[str] = None,
 ) -> dict:
     """
     Search transactions by description or merchant name.
 
     ⚠️ PAGINATION: Check `has_more` in the response! If true, call again with
     page=2, page=3, etc. until has_more=false to get all results.
+    Prefer `cursor`/`next_cursor` for stable pagination over large result sets.
 
     Args:
         user_id: The user's ID
@@ -341,25 +345,30 @@ def search_transactions(
             - "word": Word boundary match - "Action" matches "Action Store" but not "Transaction"
         ids_only: If True, return only transaction IDs (faster for bulk operations)
         limit: Max results per page (default: 50, max: 100)
-        page: Page number (default: 1)
+        page: Page number (default: 1) - ignored when cursor is provided
+        cursor: Opaque pagination cursor (preferred over page)
+        sort_by: Sort order - one of booked_at_desc (default),
+            booked_at_asc, amount_desc, amount_asc, abs_amount_desc
+        account_id: Filter results to a single account (optional)
 
     Returns:
         Dict with:
         - transactions: List of matching transactions (or transaction_ids if ids_only=True)
-        - page: Current page number
+        - page: Current page number (None when cursor-paginated)
         - limit: Results per page
-        - has_more: Boolean - if true, call again with next page!
+        - has_more: Boolean - if true, more results exist
         - total_count: Total number of matching transactions across all pages
+        - next_cursor: Opaque cursor for the next page (None when exhausted)
     """
     page = max(1, page)
     limit = min(max(1, limit), 100)
-    offset = (page - 1) * limit
 
     # Limit search string length to prevent excessive memory usage
     query_str = query[:500] if query else ""
 
-    # Validate exclude_category_id if provided
+    # Validate IDs if provided
     exclude_cat_uuid = validate_uuid(exclude_category_id) if exclude_category_id else None
+    account_uuid = validate_uuid(account_id) if account_id else None
 
     with get_db() as db:
         # Build base query with user filter
@@ -378,17 +387,15 @@ def search_transactions(
                 )
             )
 
+        # Add account filter if specified
+        if account_uuid:
+            base_filter = and_(base_filter, Transaction.account_id == account_uuid)
+
         # Get total count first
         total_count = db.query(func.count(Transaction.id)).filter(base_filter).scalar()
 
-        # Fetch transactions
-        query_obj = (
-            db.query(Transaction)
-            .filter(base_filter)
-            .order_by(Transaction.booked_at.desc())
-            .offset(offset)
-            .limit(limit)
-        )
+        # Build base query object
+        query_obj = db.query(Transaction).filter(base_filter)
 
         # Only load relationships if we need full data
         if not ids_only:
@@ -397,18 +404,30 @@ def search_transactions(
                 joinedload(Transaction.category)
             )
 
-        transactions = query_obj.all()
+        # Apply cursor or offset pagination
+        if cursor:
+            paginated = _paginate_query(query_obj, cursor, sort_by, limit)
+        else:
+            offset = (page - 1) * limit
+            primary_col, direction = _sort_expr(sort_by)
+            paginated = (
+                query_obj.order_by(direction(primary_col), direction(Transaction.id))
+                .offset(offset)
+                .limit(limit)
+            )
 
-        # Check if there are more results beyond this page
-        has_more = (offset + len(transactions)) < total_count
+        rows = paginated.all()
+        next_cursor = _build_next_cursor(rows, sort_by, limit)
+        has_more = next_cursor is not None if cursor else ((page - 1) * limit + len(rows) < total_count)
 
         if ids_only:
             return {
-                "transaction_ids": [str(txn.id) for txn in transactions],
-                "page": page,
+                "transaction_ids": [str(t.id) for t in rows],
+                "page": page if not cursor else None,
                 "limit": limit,
                 "has_more": has_more,
                 "total_count": total_count,
+                "next_cursor": next_cursor,
             }
 
         return {
@@ -425,12 +444,13 @@ def search_transactions(
                     "category_name": txn.category.name if txn.category else None,
                     "booked_at": txn.booked_at.isoformat() if txn.booked_at else None,
                 }
-                for txn in transactions
+                for txn in rows
             ],
-            "page": page,
+            "page": page if not cursor else None,
             "limit": limit,
             "has_more": has_more,
             "total_count": total_count,
+            "next_cursor": next_cursor,
         }
 
 

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -1,6 +1,9 @@
 """
 Transaction tools for the MCP server.
 """
+import base64
+import json
+from datetime import datetime
 from typing import Optional, Literal
 
 from sqlalchemy import or_, and_, func
@@ -13,6 +16,73 @@ from app.models import Transaction, Account, Category
 # Type alias for match modes
 MatchMode = Literal["contains", "starts_with", "word"]
 
+# Type alias for sort modes
+SortBy = Literal[
+    "booked_at_desc",
+    "booked_at_asc",
+    "amount_desc",
+    "amount_asc",
+    "abs_amount_desc",
+]
+
+
+def _sort_expr(sort_by: SortBy):
+    """Return (primary_col, direction_func) for the given sort mode."""
+    if sort_by == "booked_at_asc":
+        return Transaction.booked_at, lambda c: c.asc()
+    if sort_by == "amount_desc":
+        return Transaction.amount, lambda c: c.desc()
+    if sort_by == "amount_asc":
+        return Transaction.amount, lambda c: c.asc()
+    if sort_by == "abs_amount_desc":
+        return func.abs(Transaction.amount), lambda c: c.desc()
+    return Transaction.booked_at, lambda c: c.desc()  # booked_at_desc default
+
+
+def _encode_cursor(primary_value, txn_id: str) -> str:
+    payload = {"v": str(primary_value), "id": txn_id}
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
+def _decode_cursor(cursor: str) -> tuple[str, str]:
+    payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+    return payload["v"], payload["id"]
+
+
+def _paginate_query(query, cursor: Optional[str], sort_by: SortBy, limit: int):
+    """Apply sort and (optionally) cursor filter. Returns ordered, limited query."""
+    primary_col, direction = _sort_expr(sort_by)
+    if cursor:
+        try:
+            v, last_id = _decode_cursor(cursor)
+        except Exception:
+            raise ValueError("Invalid cursor")
+        # Sort-aware cursor filter: rows "after" (primary, id) tuple
+        is_desc = sort_by in ("booked_at_desc", "amount_desc", "abs_amount_desc")
+        if is_desc:
+            query = query.filter(
+                or_(primary_col < v, and_(primary_col == v, Transaction.id < last_id))
+            )
+        else:
+            query = query.filter(
+                or_(primary_col > v, and_(primary_col == v, Transaction.id > last_id))
+            )
+    return query.order_by(direction(primary_col), Transaction.id.desc()).limit(limit)
+
+
+def _build_next_cursor(rows: list, sort_by: SortBy, limit: int) -> Optional[str]:
+    if len(rows) < limit:
+        return None
+    last = rows[-1]
+    # Extract raw primary value for the sort mode
+    if sort_by in ("booked_at_desc", "booked_at_asc"):
+        v = last.booked_at.isoformat()
+    elif sort_by == "abs_amount_desc":
+        v = str(abs(float(last.amount)))
+    else:
+        v = str(float(last.amount))
+    return _encode_cursor(v, str(last.id))
+
 
 def list_transactions(
     user_id: str,
@@ -22,10 +92,14 @@ def list_transactions(
     to_date: Optional[str] = None,
     search: Optional[str] = None,
     limit: int = 50,
-    page: int = 1
-) -> list[dict]:
+    page: int = 1,
+    cursor: Optional[str] = None,
+    sort_by: SortBy = "booked_at_desc",
+    uncategorized: bool = False,
+    category_type: Optional[Literal["expense", "income", "transfer"]] = None,
+) -> dict:
     """
-    List transactions with optional filtering.
+    List transactions with optional filtering, cursor pagination, and sort.
 
     Args:
         user_id: The user's ID
@@ -35,21 +109,25 @@ def list_transactions(
         to_date: End date in ISO format (optional)
         search: Search in description/merchant (optional)
         limit: Max results per page (default: 50, max: 100)
-        page: Page number (default: 1)
+        page: Page number (default: 1) - ignored when cursor is provided
+        cursor: Opaque pagination cursor (preferred over page)
+        sort_by: Sort order - one of booked_at_desc (default),
+            booked_at_asc, amount_desc, amount_asc, abs_amount_desc
+        uncategorized: If True, return only transactions with no category
+        category_type: Filter by resolved category type
+            (expense, income, transfer)
 
     Returns:
-        List of transaction dictionaries with account and category info
+        Dict with:
+        - transactions: list of transaction dicts
+        - page: current page (None when cursor-paginated)
+        - limit: effective page size
+        - next_cursor: opaque cursor for the next page (None when exhausted)
     """
-    # Validate pagination parameters
     page = max(1, page)
     limit = min(max(1, limit), 100)
-    offset = (page - 1) * limit
-
-    # Validate UUID parameters
     account_uuid = validate_uuid(account_id) if account_id else None
     category_uuid = validate_uuid(category_id) if category_id else None
-
-    # Validate date parameters
     from_dt = validate_date(from_date)
     to_dt = validate_date(to_date)
 
@@ -59,11 +137,9 @@ def list_transactions(
             .filter(Transaction.user_id == user_id)
             .options(joinedload(Transaction.account), joinedload(Transaction.category))
         )
-
-        if account_id and account_uuid:
+        if account_uuid:
             query = query.filter(Transaction.account_id == account_uuid)
-
-        if category_id and category_uuid:
+        if category_uuid:
             query = query.filter(
                 (Transaction.category_id == category_uuid) |
                 and_(
@@ -71,17 +147,24 @@ def list_transactions(
                     Transaction.category_system_id == category_uuid
                 )
             )
-
+        if uncategorized:
+            query = query.filter(
+                Transaction.category_id.is_(None),
+                Transaction.category_system_id.is_(None),
+            )
+        if category_type:
+            query = query.join(
+                Category,
+                Category.id == func.coalesce(
+                    Transaction.category_id, Transaction.category_system_id
+                ),
+            ).filter(Category.category_type == category_type)
         if from_dt:
             query = query.filter(Transaction.booked_at >= from_dt)
-
         if to_dt:
             query = query.filter(Transaction.booked_at <= to_dt)
-
         if search:
-            # Limit search string length to prevent excessive memory usage
-            search = search[:500]
-            search_term = f"%{search}%"
+            search_term = f"%{search[:500]}%"
             query = query.filter(
                 or_(
                     Transaction.description.ilike(search_term),
@@ -89,33 +172,44 @@ def list_transactions(
                 )
             )
 
-        transactions = (
-            query.order_by(Transaction.booked_at.desc())
-            .offset(offset)
-            .limit(limit)
-            .all()
-        )
+        if cursor:
+            paginated = _paginate_query(query, cursor, sort_by, limit)
+        else:
+            offset = (page - 1) * limit
+            primary_col, direction = _sort_expr(sort_by)
+            paginated = (
+                query.order_by(direction(primary_col), Transaction.id.desc())
+                .offset(offset)
+                .limit(limit)
+            )
+        transactions_rows = paginated.all()
+        next_cursor = _build_next_cursor(transactions_rows, sort_by, limit)
 
-        return [
-            {
-                "id": str(txn.id),
-                "account_id": str(txn.account_id),
-                "account_name": txn.account.name if txn.account else None,
-                "amount": float(txn.amount),
-                "currency": txn.currency,
-                "description": txn.description,
-                "merchant": txn.merchant,
-                "category_id": str(txn.category_id) if txn.category_id else None,
-                "category_system_id": str(txn.category_system_id) if txn.category_system_id else None,
-                "category_name": txn.category.name if txn.category else None,
-                "booked_at": txn.booked_at.isoformat() if txn.booked_at else None,
-                "pending": txn.pending,
-                "transaction_type": txn.transaction_type,
-                "include_in_analytics": txn.include_in_analytics,
-                "recurring_transaction_id": str(txn.recurring_transaction_id) if txn.recurring_transaction_id else None,
-            }
-            for txn in transactions
-        ]
+        return {
+            "transactions": [
+                {
+                    "id": str(txn.id),
+                    "account_id": str(txn.account_id),
+                    "account_name": txn.account.name if txn.account else None,
+                    "amount": float(txn.amount),
+                    "currency": txn.currency,
+                    "description": txn.description,
+                    "merchant": txn.merchant,
+                    "category_id": str(txn.category_id) if txn.category_id else None,
+                    "category_system_id": str(txn.category_system_id) if txn.category_system_id else None,
+                    "category_name": txn.category.name if txn.category else None,
+                    "booked_at": txn.booked_at.isoformat() if txn.booked_at else None,
+                    "pending": txn.pending,
+                    "transaction_type": txn.transaction_type,
+                    "include_in_analytics": txn.include_in_analytics,
+                    "recurring_transaction_id": str(txn.recurring_transaction_id) if txn.recurring_transaction_id else None,
+                }
+                for txn in transactions_rows
+            ],
+            "page": page if not cursor else None,
+            "limit": limit,
+            "next_cursor": next_cursor,
+        }
 
 
 def get_transaction(user_id: str, transaction_id: str) -> dict | None:

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -1,6 +1,8 @@
 """
 Transaction tools for the MCP server.
 """
+from __future__ import annotations
+
 import base64
 import json
 from datetime import datetime

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -88,9 +88,9 @@ def _build_next_cursor(rows: list, sort_by: SortBy, limit: int) -> Optional[str]
     if sort_by in ("booked_at_desc", "booked_at_asc"):
         v = last.booked_at.isoformat()
     elif sort_by == "abs_amount_desc":
-        v = str(abs(float(last.amount)))
+        v = str(abs(last.amount))
     else:
-        v = str(float(last.amount))
+        v = str(last.amount)
     return _encode_cursor(v, str(last.id))
 
 

--- a/backend/app/mcp/tools/transactions.py
+++ b/backend/app/mcp/tools/transactions.py
@@ -462,7 +462,10 @@ def search_transactions_multi(
     exclude_category_id: Optional[str] = None,
     match_mode: MatchMode = "contains",
     ids_only: bool = False,
-    max_results: int = 500
+    max_results: int = 500,
+    cursor: Optional[str] = None,
+    sort_by: SortBy = "booked_at_desc",
+    account_id: Optional[str] = None,
 ) -> dict:
     """
     Search transactions matching ANY of the given queries.
@@ -470,6 +473,10 @@ def search_transactions_multi(
     Returns all matching transactions in a single call (no pagination needed).
     Useful for bulk recategorization workflows where you need to find transactions
     from multiple merchants at once.
+
+    Pass `cursor=""` (or a real cursor from `next_cursor`) to enable cursor
+    pagination. Without a cursor, all results up to `max_results` are returned
+    in one shot (original behavior).
 
     Args:
         user_id: The user's ID
@@ -481,6 +488,11 @@ def search_transactions_multi(
             - "word": Word boundary match
         ids_only: If True, return only transaction IDs (faster for bulk operations)
         max_results: Maximum results to return (default: 500, max: 1000)
+        cursor: Opaque pagination cursor; pass "" or a real cursor to enable
+            cursor mode (opt-in). Omit entirely for legacy all-at-once behavior.
+        sort_by: Sort order - one of booked_at_desc (default),
+            booked_at_asc, amount_desc, amount_asc, abs_amount_desc
+        account_id: Filter results to a single account (optional)
 
     Returns:
         Dict with:
@@ -488,14 +500,16 @@ def search_transactions_multi(
         - total_count: Total matches found
         - capped: True if results were limited by max_results
         - query_counts: Dict mapping each query to its match count
+        - next_cursor: Opaque cursor for next page (only present in cursor mode)
     """
     if not queries:
         return {"error": "Must provide at least one query", "success": False}
 
     max_results = min(max(1, max_results), 1000)
 
-    # Validate exclude_category_id if provided
+    # Validate IDs if provided
     exclude_cat_uuid = validate_uuid(exclude_category_id) if exclude_category_id else None
+    account_uuid = validate_uuid(account_id) if account_id else None
 
     with get_db() as db:
         # Build combined filter for all queries
@@ -524,16 +538,15 @@ def search_transactions_multi(
                 )
             )
 
+        # Add account filter if specified
+        if account_uuid:
+            combined_filter = and_(combined_filter, Transaction.account_id == account_uuid)
+
         # Get total count
         total_count = db.query(func.count(Transaction.id)).filter(combined_filter).scalar()
 
-        # Fetch transactions
-        query_obj = (
-            db.query(Transaction)
-            .filter(combined_filter)
-            .order_by(Transaction.booked_at.desc())
-            .limit(max_results)
-        )
+        # Build query object
+        query_obj = db.query(Transaction).filter(combined_filter)
 
         if not ids_only:
             query_obj = query_obj.options(
@@ -541,7 +554,16 @@ def search_transactions_multi(
                 joinedload(Transaction.category)
             )
 
-        transactions = query_obj.all()
+        # cursor is not None means cursor mode is opted-in (even empty string)
+        cursor_mode = cursor is not None
+        if cursor_mode:
+            paginated = _paginate_query(query_obj, cursor or None, sort_by, max_results)
+        else:
+            primary_col, direction = _sort_expr(sort_by)
+            paginated = query_obj.order_by(direction(primary_col), direction(Transaction.id)).limit(max_results)
+
+        transactions_rows = paginated.all()
+        next_cursor = _build_next_cursor(transactions_rows, sort_by, max_results) if cursor_mode else None
 
         # Count matches per query (for transparency)
         query_counts = {}
@@ -564,12 +586,13 @@ def search_transactions_multi(
 
         result = {
             "total_count": total_count,
-            "capped": len(transactions) < total_count,
+            "capped": len(transactions_rows) < total_count,
             "query_counts": query_counts,
+            "next_cursor": next_cursor,
         }
 
         if ids_only:
-            result["transaction_ids"] = [str(txn.id) for txn in transactions]
+            result["transaction_ids"] = [str(txn.id) for txn in transactions_rows]
         else:
             result["transactions"] = [
                 {
@@ -584,7 +607,7 @@ def search_transactions_multi(
                     "category_name": txn.category.name if txn.category else None,
                     "booked_at": txn.booked_at.isoformat() if txn.booked_at else None,
                 }
-                for txn in transactions
+                for txn in transactions_rows
             ]
 
         return result

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -51,6 +51,7 @@ class Account(Base):
     functional_balance = Column(Numeric(15, 2), nullable=True)  # Calculated balance (sum of transactions + starting_balance)
     balance_is_anchored = Column(Boolean, default=False)  # True when starting_balance is from verified bank data
     is_active = Column(Boolean, default=True)
+    alias_patterns = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     last_synced_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -177,6 +177,7 @@ def _serialize_account(account: Account) -> AccountResponse:
         institution=account.institution,
         currency=account.currency,
         is_active=account.is_active,
+        alias_patterns=account.alias_patterns or [],
         provider=account.provider,
         external_id=decrypt_with_fallback(account.external_id_ciphertext, account.external_id),
         created_at=account.created_at,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime
 from decimal import Decimal
 from typing import Optional, List
@@ -22,11 +22,13 @@ class AccountUpdate(BaseModel):
     institution: Optional[str] = None
     balance_current: Optional[Decimal] = None
     is_active: Optional[bool] = None
+    alias_patterns: Optional[list[str]] = None
 
 
 class AccountResponse(AccountBase):
     id: UUID
     is_active: bool
+    alias_patterns: list[str] = Field(default_factory=list)
     provider: Optional[str] = None
     external_id: Optional[str] = None
     created_at: datetime

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -22,7 +22,7 @@ class AccountUpdate(BaseModel):
     institution: Optional[str] = None
     balance_current: Optional[Decimal] = None
     is_active: Optional[bool] = None
-    alias_patterns: Optional[list[str]] = None
+    alias_patterns: list[str] = Field(default_factory=list)
 
 
 class AccountResponse(AccountBase):

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -19,6 +19,10 @@ from app.db_helpers import get_user_id
 # Configure logger
 logger = logging.getLogger(__name__)
 
+# Feature flag: enrich LLM prompt with category descriptions and account context.
+# Disable by setting CATEGORIZER_ENRICHED_PROMPT=false in the environment.
+ENRICHED_PROMPT_ENABLED = os.getenv("CATEGORIZER_ENRICHED_PROMPT", "true").lower() == "true"
+
 
 @dataclass
 class CategoryMatchResult:
@@ -587,6 +591,46 @@ class CategoryMatcher:
             lines.append(f"- {acc.name}{suffix}")
         return "\n".join(lines)
 
+    PROMPT_CONTEXT_BUDGET = 2000
+
+    def _compose_prompt_context(self, relevant_categories) -> tuple[str, str]:
+        """Return (category_list, account_block) sized to fit PROMPT_CONTEXT_BUDGET.
+
+        Degradation order when over budget:
+        1. Truncate each category description to 200 chars (default).
+        2. Drop alias_patterns from accounts (keep name + ends-in).
+        3. Drop all descriptions; names only.
+        """
+        category_list = self._render_category_list(relevant_categories)
+        account_block = self._build_account_context()
+        total = len(category_list) + len(account_block)
+        if total <= self.PROMPT_CONTEXT_BUDGET:
+            return category_list, f"\n\n{account_block}\n" if account_block else ""
+
+        # Step 2: drop alias_patterns
+        if self._account_cache:
+            thin_accounts = []
+            for acc in self._account_cache:
+                identifiers = []
+                ext = (getattr(acc, "external_id", None) or "").strip()
+                if ext and len(ext) >= 4:
+                    identifiers.append(f"ends in {ext[-4:]}")
+                suffix = f" ({'; '.join(identifiers)})" if identifiers else ""
+                thin_accounts.append(f"- {acc.name}{suffix}")
+            thin_account_block = (
+                "Your accounts (transactions referencing these are internal transfers):\n"
+                + "\n".join(thin_accounts)
+            )
+        else:
+            thin_account_block = ""
+        total = len(category_list) + len(thin_account_block)
+        if total <= self.PROMPT_CONTEXT_BUDGET:
+            return category_list, f"\n\n{thin_account_block}\n" if thin_account_block else ""
+
+        # Step 3: drop all descriptions
+        name_only = "\n".join(f"- {c.name}" for c in relevant_categories)
+        return name_only, f"\n\n{thin_account_block}\n" if thin_account_block else ""
+
     def _calculate_llm_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
         """
         Calculate the cost of an LLM API call.
@@ -780,8 +824,20 @@ class CategoryMatcher:
             logger.warning(f"No relevant categories found for {transaction_type_str} transaction")
             return None
 
-        # Build category list for prompt
-        category_list = self._render_category_list(relevant_categories)
+        # Build category list and account block for prompt
+        if ENRICHED_PROMPT_ENABLED:
+            category_list, account_block = self._compose_prompt_context(relevant_categories)
+        else:
+            category_list = "\n".join(f"- {c.name}" for c in relevant_categories)
+            account_block = ""
+
+        logger.debug(
+            "categorizer.prompt_context chars: categories=%d accounts=%d total=%d",
+            len(category_list), len(account_block),
+            len(category_list) + len(account_block),
+        )
+        if len(category_list) + len(account_block) >= self.PROMPT_CONTEXT_BUDGET:
+            logger.info("categorizer.prompt_budget_hit user_id=%s", self.user_id)
 
         # Build enhanced prompt with additional instructions and user overrides
         instructions_text = ""
@@ -798,13 +854,11 @@ class CategoryMatcher:
                 overrides_text += f"- Description: '{desc}', Merchant: '{merch}' → Category: '{cat}'\n"
             overrides_text += "\n"
 
-        # Build account context block and transfer rule
-        account_context = self._build_account_context()
-        account_block = f"\n\n{account_context}\n" if account_context else ""
+        # Build transfer rule (only when account context is present)
         transfer_rule = (
             "If the transaction description, merchant, or counterparty references any of the "
             "accounts listed in \"Your accounts\", treat it as an internal transfer and pick the "
-            "transfer category." if account_context else ""
+            "transfer category." if ENRICHED_PROMPT_ENABLED and account_block else ""
         )
 
         # Build numbered instructions list dynamically so numbering is always correct
@@ -957,8 +1011,20 @@ Category name:"""
             logger.warning(f"No relevant categories found for {transaction_type_str} transaction")
             return None, 0, 0.0
 
-        # Build category list for prompt
-        category_list = self._render_category_list(relevant_categories)
+        # Build category list and account block for prompt
+        if ENRICHED_PROMPT_ENABLED:
+            category_list, account_block = self._compose_prompt_context(relevant_categories)
+        else:
+            category_list = "\n".join(f"- {c.name}" for c in relevant_categories)
+            account_block = ""
+
+        logger.debug(
+            "categorizer.prompt_context chars: categories=%d accounts=%d total=%d",
+            len(category_list), len(account_block),
+            len(category_list) + len(account_block),
+        )
+        if len(category_list) + len(account_block) >= self.PROMPT_CONTEXT_BUDGET:
+            logger.info("categorizer.prompt_budget_hit user_id=%s", self.user_id)
 
         # Build enhanced prompt with additional instructions and user overrides
         instructions_text = ""
@@ -975,13 +1041,11 @@ Category name:"""
                 overrides_text += f"- Description: '{desc}', Merchant: '{merch}' → Category: '{cat}'\n"
             overrides_text += "\n"
 
-        # Build account context block and transfer rule
-        account_context = self._build_account_context()
-        account_block = f"\n\n{account_context}\n" if account_context else ""
+        # Build transfer rule (only when account context is present)
         transfer_rule = (
             "If the transaction description, merchant, or counterparty references any of the "
             "accounts listed in \"Your accounts\", treat it as an internal transfer and pick the "
-            "transfer category." if account_context else ""
+            "transfer category." if ENRICHED_PROMPT_ENABLED and account_block else ""
         )
 
         # Build numbered instructions list dynamically so numbering is always correct

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -133,6 +133,7 @@ class CategoryMatcher:
         self._keyword_rules: Optional[Dict[str, List[str]]] = None
         self._openai_client = None
         self._category_instructions_cache: Optional[List[str]] = None
+        self._account_cache: Optional[list] = None
 
         # Initialize with provided values or empty lists
         self.user_overrides = user_overrides or []
@@ -554,6 +555,36 @@ class CategoryMatcher:
                 lines.append(f"- {cat.name} — {desc}")
             else:
                 lines.append(f"- {cat.name}")
+        return "\n".join(lines)
+
+    def _load_accounts(self) -> list:
+        if self._account_cache is not None:
+            return self._account_cache
+        from app.models import Account  # local import if global causes circularity
+        accounts = (
+            self.db.query(Account)
+            .filter(Account.user_id == self.user_id, Account.is_active == True)
+            .all()
+        )
+        self._account_cache = accounts
+        return accounts
+
+    def _build_account_context(self) -> str:
+        accounts = self._account_cache if self._account_cache is not None else self._load_accounts()
+        if not accounts:
+            return ""
+        lines = ["Your accounts (transactions referencing these are internal transfers):"]
+        for acc in accounts:
+            identifiers = []
+            ext = (getattr(acc, "external_id", None) or "").strip()
+            if ext and len(ext) >= 4:
+                identifiers.append(f"ends in {ext[-4:]}")
+            patterns = getattr(acc, "alias_patterns", None) or []
+            if patterns:
+                quoted = ", ".join(f'"{p}"' for p in patterns)
+                identifiers.append(f"patterns: {quoted}")
+            suffix = f" ({'; '.join(identifiers)})" if identifiers else ""
+            lines.append(f"- {acc.name}{suffix}")
         return "\n".join(lines)
 
     def _calculate_llm_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -804,8 +804,23 @@ class CategoryMatcher:
         transfer_rule = (
             "If the transaction description, merchant, or counterparty references any of the "
             "accounts listed in \"Your accounts\", treat it as an internal transfer and pick the "
-            "transfer category.\n" if account_context else ""
+            "transfer category." if account_context else ""
         )
+
+        # Build numbered instructions list dynamically so numbering is always correct
+        instructions = [
+            "Analyze the transaction description and merchant name",
+            "Select the MOST SPECIFIC category that matches",
+        ]
+        if transfer_rule:
+            instructions.append(transfer_rule.rstrip())
+        instructions += [
+            "Follow any user-specific guidelines and override patterns provided above",
+            "If the transaction matches a user override pattern, use that category",
+            "Respond with ONLY the exact category name from the list",
+            'If no category fits well, respond with "UNKNOWN"',
+        ]
+        instructions_block = "\n".join(f"{i+1}. {step}" for i, step in enumerate(instructions))
 
         # Build enhanced prompt
         prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
@@ -820,12 +835,7 @@ Available categories:
 {category_list}
 {account_block}{overrides_text}{instructions_text}
 Instructions:
-1. Analyze the transaction description and merchant name
-2. Select the MOST SPECIFIC category that matches
-3. {transfer_rule}4. Follow any user-specific guidelines and override patterns provided above
-5. If the transaction matches a user override pattern, use that category
-6. Respond with ONLY the exact category name from the list
-7. If no category fits well, respond with "UNKNOWN"
+{instructions_block}
 
 Category name:"""
 
@@ -971,8 +981,23 @@ Category name:"""
         transfer_rule = (
             "If the transaction description, merchant, or counterparty references any of the "
             "accounts listed in \"Your accounts\", treat it as an internal transfer and pick the "
-            "transfer category.\n" if account_context else ""
+            "transfer category." if account_context else ""
         )
+
+        # Build numbered instructions list dynamically so numbering is always correct
+        instructions = [
+            "Analyze the transaction description and merchant name",
+            "Select the MOST SPECIFIC category that matches",
+        ]
+        if transfer_rule:
+            instructions.append(transfer_rule.rstrip())
+        instructions += [
+            "Follow any user-specific guidelines and override patterns provided above",
+            "If the transaction matches a user override pattern, use that category",
+            "Respond with ONLY the exact category name from the list",
+            'If no category fits well, respond with "UNKNOWN"',
+        ]
+        instructions_block = "\n".join(f"{i+1}. {step}" for i, step in enumerate(instructions))
 
         # Build enhanced prompt
         prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
@@ -987,12 +1012,7 @@ Available categories:
 {category_list}
 {account_block}{overrides_text}{instructions_text}
 Instructions:
-1. Analyze the transaction description and merchant name
-2. Select the MOST SPECIFIC category that matches
-3. {transfer_rule}4. Follow any user-specific guidelines and override patterns provided above
-5. If the transaction matches a user override pattern, use that category
-6. Respond with ONLY the exact category name from the list
-7. If no category fits well, respond with "UNKNOWN"
+{instructions_block}
 
 Category name:"""
 

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -629,7 +629,15 @@ class CategoryMatcher:
 
         # Step 3: drop all descriptions
         name_only = "\n".join(f"- {c.name}" for c in relevant_categories)
-        return name_only, f"\n\n{thin_account_block}\n" if thin_account_block else ""
+        if len(name_only) + len(thin_account_block) <= self.PROMPT_CONTEXT_BUDGET:
+            return name_only, f"\n\n{thin_account_block}\n" if thin_account_block else ""
+
+        # Step 4: drop account block entirely
+        if len(name_only) <= self.PROMPT_CONTEXT_BUDGET:
+            return name_only, ""
+
+        # Step 5: category names alone still exceed budget — truncate to hard limit
+        return name_only[: self.PROMPT_CONTEXT_BUDGET], ""
 
     def _calculate_llm_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
         """
@@ -836,7 +844,7 @@ class CategoryMatcher:
             len(category_list), len(account_block),
             len(category_list) + len(account_block),
         )
-        if len(category_list) + len(account_block) >= self.PROMPT_CONTEXT_BUDGET:
+        if len(category_list) + len(account_block) > self.PROMPT_CONTEXT_BUDGET:
             logger.info("categorizer.prompt_budget_hit user_id=%s", self.user_id)
 
         # Build enhanced prompt with additional instructions and user overrides
@@ -1023,7 +1031,7 @@ Category name:"""
             len(category_list), len(account_block),
             len(category_list) + len(account_block),
         )
-        if len(category_list) + len(account_block) >= self.PROMPT_CONTEXT_BUDGET:
+        if len(category_list) + len(account_block) > self.PROMPT_CONTEXT_BUDGET:
             logger.info("categorizer.prompt_budget_hit user_id=%s", self.user_id)
 
         # Build enhanced prompt with additional instructions and user overrides

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -750,13 +750,13 @@ class CategoryMatcher:
             return None
 
         # Build category list for prompt
-        category_list = "\n".join([f"- {cat.name}" for cat in relevant_categories])
+        category_list = self._render_category_list(relevant_categories)
 
         # Build enhanced prompt with additional instructions and user overrides
         instructions_text = ""
         if self.additional_instructions:
             instructions_text = "\n\nUser-specific categorization guidelines:\n" + "\n".join([f"- {inst}" for inst in self.additional_instructions]) + "\n"
-        
+
         overrides_text = ""
         if self.user_overrides:
             overrides_text = "\n\nUser-defined category overrides (use these patterns as examples):\n"
@@ -766,7 +766,7 @@ class CategoryMatcher:
                 cat = override.get("category_name", "N/A")
                 overrides_text += f"- Description: '{desc}', Merchant: '{merch}' → Category: '{cat}'\n"
             overrides_text += "\n"
-        
+
         # Build enhanced prompt
         prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
 
@@ -908,13 +908,13 @@ Category name:"""
             return None, 0, 0.0
 
         # Build category list for prompt
-        category_list = "\n".join([f"- {cat.name}" for cat in relevant_categories])
+        category_list = self._render_category_list(relevant_categories)
 
         # Build enhanced prompt with additional instructions and user overrides
         instructions_text = ""
         if self.additional_instructions:
             instructions_text = "\n\nUser-specific categorization guidelines:\n" + "\n".join([f"- {inst}" for inst in self.additional_instructions]) + "\n"
-        
+
         overrides_text = ""
         if self.user_overrides:
             overrides_text = "\n\nUser-defined category overrides (use these patterns as examples):\n"
@@ -924,7 +924,7 @@ Category name:"""
                 cat = override.get("category_name", "N/A")
                 overrides_text += f"- Description: '{desc}', Merchant: '{merch}' → Category: '{cat}'\n"
             overrides_text += "\n"
-        
+
         # Build enhanced prompt
         prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
 

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -601,9 +601,13 @@ class CategoryMatcher:
         2. Drop alias_patterns from accounts (keep name + ends-in).
         3. Drop all descriptions; names only.
         """
+        def _wrapped_len(block: str) -> int:
+            """Length of block after adding the '\n\n...\n' wrapper used at return time."""
+            return len(block) + 3 if block else 0
+
         category_list = self._render_category_list(relevant_categories)
         account_block = self._build_account_context()
-        total = len(category_list) + len(account_block)
+        total = len(category_list) + _wrapped_len(account_block)
         if total <= self.PROMPT_CONTEXT_BUDGET:
             return category_list, f"\n\n{account_block}\n" if account_block else ""
 
@@ -623,7 +627,7 @@ class CategoryMatcher:
             )
         else:
             thin_account_block = ""
-        total = len(category_list) + len(thin_account_block)
+        total = len(category_list) + _wrapped_len(thin_account_block)
         if total <= self.PROMPT_CONTEXT_BUDGET:
             return category_list, f"\n\n{thin_account_block}\n" if thin_account_block else ""
 

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -96,6 +96,9 @@ class CategoryMatcher:
     LLM_MAX_RETRIES = int(os.getenv("CATEGORIZATION_LLM_MAX_RETRIES", "3"))
     LLM_RETRY_DELAY = float(os.getenv("CATEGORIZATION_LLM_RETRY_DELAY", "1.0"))
 
+    # Max length for category descriptions in LLM prompt
+    MAX_CATEGORY_DESCRIPTION_LEN = 200
+
     # OpenAI Pricing (per 1M tokens, as of January 2025)
     # https://openai.com/api/pricing/
     PRICING = {
@@ -539,6 +542,19 @@ class CategoryMatcher:
         text = re.sub(r'\s+', ' ', text).strip()
 
         return text
+
+    def _render_category_list(self, categories) -> str:
+        """Render the category list for the LLM prompt, with truncated descriptions."""
+        lines = []
+        for cat in categories:
+            desc = (cat.description or "").strip()
+            if desc:
+                if len(desc) > self.MAX_CATEGORY_DESCRIPTION_LEN:
+                    desc = desc[: self.MAX_CATEGORY_DESCRIPTION_LEN].rstrip() + "…"
+                lines.append(f"- {cat.name} — {desc}")
+            else:
+                lines.append(f"- {cat.name}")
+        return "\n".join(lines)
 
     def _calculate_llm_cost(self, input_tokens: int, output_tokens: int, model: str) -> float:
         """

--- a/backend/app/services/category_matcher.py
+++ b/backend/app/services/category_matcher.py
@@ -798,6 +798,15 @@ class CategoryMatcher:
                 overrides_text += f"- Description: '{desc}', Merchant: '{merch}' → Category: '{cat}'\n"
             overrides_text += "\n"
 
+        # Build account context block and transfer rule
+        account_context = self._build_account_context()
+        account_block = f"\n\n{account_context}\n" if account_context else ""
+        transfer_rule = (
+            "If the transaction description, merchant, or counterparty references any of the "
+            "accounts listed in \"Your accounts\", treat it as an internal transfer and pick the "
+            "transfer category.\n" if account_context else ""
+        )
+
         # Build enhanced prompt
         prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
 
@@ -809,14 +818,14 @@ Transaction details:
 
 Available categories:
 {category_list}
-{overrides_text}{instructions_text}
+{account_block}{overrides_text}{instructions_text}
 Instructions:
 1. Analyze the transaction description and merchant name
 2. Select the MOST SPECIFIC category that matches
-3. Follow any user-specific guidelines and override patterns provided above
-4. If the transaction matches a user override pattern, use that category
-5. Respond with ONLY the exact category name from the list
-6. If no category fits well, respond with "UNKNOWN"
+3. {transfer_rule}4. Follow any user-specific guidelines and override patterns provided above
+5. If the transaction matches a user override pattern, use that category
+6. Respond with ONLY the exact category name from the list
+7. If no category fits well, respond with "UNKNOWN"
 
 Category name:"""
 
@@ -956,6 +965,15 @@ Category name:"""
                 overrides_text += f"- Description: '{desc}', Merchant: '{merch}' → Category: '{cat}'\n"
             overrides_text += "\n"
 
+        # Build account context block and transfer rule
+        account_context = self._build_account_context()
+        account_block = f"\n\n{account_context}\n" if account_context else ""
+        transfer_rule = (
+            "If the transaction description, merchant, or counterparty references any of the "
+            "accounts listed in \"Your accounts\", treat it as an internal transfer and pick the "
+            "transfer category.\n" if account_context else ""
+        )
+
         # Build enhanced prompt
         prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
 
@@ -967,14 +985,14 @@ Transaction details:
 
 Available categories:
 {category_list}
-{overrides_text}{instructions_text}
+{account_block}{overrides_text}{instructions_text}
 Instructions:
 1. Analyze the transaction description and merchant name
 2. Select the MOST SPECIFIC category that matches
-3. Follow any user-specific guidelines and override patterns provided above
-4. If the transaction matches a user override pattern, use that category
-5. Respond with ONLY the exact category name from the list
-6. If no category fits well, respond with "UNKNOWN"
+3. {transfer_rule}4. Follow any user-specific guidelines and override patterns provided above
+5. If the transaction matches a user override pattern, use that category
+6. Respond with ONLY the exact category name from the list
+7. If no category fits well, respond with "UNKNOWN"
 
 Category name:"""
 

--- a/backend/postgres_migration/add_account_alias_patterns.py
+++ b/backend/postgres_migration/add_account_alias_patterns.py
@@ -1,0 +1,38 @@
+"""
+One-off migration: add accounts.alias_patterns JSONB column.
+
+Usage (from backend/):
+    python postgres_migration/add_account_alias_patterns.py
+
+Idempotent: safe to re-run.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import create_engine, text
+
+from app.database import db_url
+
+
+SQL = """
+ALTER TABLE accounts
+  ADD COLUMN IF NOT EXISTS alias_patterns JSONB NOT NULL DEFAULT '[]'::jsonb;
+"""
+
+
+def main() -> int:
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(text(SQL))
+    print("OK: accounts.alias_patterns present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,50 @@
+"""
+Shared pytest fixtures for the backend test suite.
+
+Provides a `db_session` fixture that yields a SQLAlchemy session connected
+to the development/test database defined by `app.database.SessionLocal`.
+Each test gets a fresh session; the session is rolled back on teardown so
+test data does not persist between runs.
+
+Tests that need to query the database via the MCP tools (which call
+`app.mcp.dependencies.get_db`) should use this fixture to seed data, then
+rely on the tools to open their own short-lived sessions.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+
+# Ensure the backend/ directory is importable when pytest is run from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    """Deterministic encryption keys so blind_index/encrypted fields work in tests."""
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ.setdefault("DATA_ENCRYPTION_KEY_CURRENT", key)
+    os.environ.setdefault("DATA_ENCRYPTION_KEY_ID", "k-test-conftest")
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
+import pytest  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.security.data_encryption import reset_encryption_config_cache  # noqa: E402
+
+
+reset_encryption_config_cache()
+
+
+@pytest.fixture
+def db_session():
+    """Yield a SQLAlchemy session; roll back and close on teardown."""
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()

--- a/backend/tests/test_category_matcher_llm_transfer.py
+++ b/backend/tests/test_category_matcher_llm_transfer.py
@@ -1,0 +1,58 @@
+"""Verify that with an alias-matched account, the LLM prompt steers toward the transfer category."""
+from decimal import Decimal
+
+import pytest
+
+from app.services.category_matcher import CategoryMatcher
+
+
+class FakeCategory:
+    def __init__(self, name, category_type="expense"):
+        self.name = name
+        self.category_type = category_type
+        self.description = None
+
+
+class FakeAccount:
+    def __init__(self, name, alias_patterns=None):
+        self.name = name
+        self.external_id = None
+        self.alias_patterns = alias_patterns or []
+        self.is_active = True
+
+
+def test_llm_selects_transfers_when_alias_matches(monkeypatch, db_session):
+    import app.services.category_matcher as cm_module
+    monkeypatch.setattr(cm_module, "ENRICHED_PROMPT_ENABLED", True)
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    # The stub "reads" the prompt: if it mentions the alias + transfer rule,
+                    # return the transfer category name.
+                    content = kwargs["messages"][1]["content"]
+                    if "Apple Pay Top-Up by *1234" in content and "internal transfer" in content.lower():
+                        answer = "Transfers"
+                    else:
+                        answer = "UNKNOWN"
+                    return type("R", (), {
+                        "choices": [type("X", (), {"message": type("M", (), {"content": answer})()})()],
+                        "usage": type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})(),
+                    })
+
+    m = CategoryMatcher(db=db_session, user_id="llm-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    monkeypatch.setattr(m, "_load_categories", lambda: {})
+    m._account_cache = [FakeAccount("Revolut Pro", alias_patterns=["Apple Pay Top-Up by *1234"])]
+    cats = [FakeCategory("Transfers", category_type="transfer"), FakeCategory("Food & Dining")]
+    result = m.match_category_llm(
+        description="Apple Pay Top-Up by *1234",
+        merchant="Revolut",
+        amount=-50.0,
+        available_categories=cats,
+    )
+    # match_category_llm returns the matched category object, not the name string
+    assert result is not None
+    assert result.name == "Transfers"

--- a/backend/tests/test_category_matcher_prompt.py
+++ b/backend/tests/test_category_matcher_prompt.py
@@ -191,6 +191,27 @@ def test_prompt_budget_degrades_descriptions_first():
     assert "Cat29" in category_list
 
 
+def test_prompt_budget_stage4_drops_account_block_when_still_oversized():
+    """Stage-4: when name_only + thin_account_block still exceeds the budget,
+    the account block must be dropped entirely so the output is always <= 2000 chars.
+    """
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    # 100 categories with long names → name_only alone approaches the budget
+    cats = [FakeCategory(f"Category With A Very Long Name {i:03d}") for i in range(100)]
+    # 50 accounts → thin_account_block adds several hundred characters
+    m._account_cache = [
+        FakeAccount(f"Account Bank Name {j:02d}", external_id=f"NL91ABNA{j:08d}")
+        for j in range(50)
+    ]
+    category_list, account_block = m._compose_prompt_context(cats)
+    total = sum(len(x) for x in (category_list, account_block))
+    assert total <= 2000, (
+        f"Output exceeded budget ({total} chars); stage-4 fallback not applied"
+    )
+    # Category names must still be present
+    assert "Category With A Very Long Name 000" in category_list
+
+
 # ---------------------------------------------------------------------------
 # Task 9: Feature flag
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_category_matcher_prompt.py
+++ b/backend/tests/test_category_matcher_prompt.py
@@ -69,3 +69,25 @@ def test_prompt_includes_category_descriptions(monkeypatch, db_session):
     )
     prompt_text = captured["messages"][1]["content"]
     assert "Side Projects — Tools like Cloudflare" in prompt_text
+
+
+def test_account_context_empty_returns_empty_string():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    m._account_cache = []
+    assert m._build_account_context() == ""
+
+
+def test_account_context_with_last_four_and_patterns():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    m._account_cache = [
+        FakeAccount("ABN AMRO checking", external_id="NL91ABNA0417164300"),
+        FakeAccount(
+            "Revolut Pro",
+            external_id=None,
+            alias_patterns=["Apple Pay Top-Up by *1234", "Revo Pro"],
+        ),
+    ]
+    ctx = m._build_account_context()
+    assert "Your accounts" in ctx
+    assert "ABN AMRO checking (ends in 4300)" in ctx
+    assert 'Revolut Pro (patterns: "Apple Pay Top-Up by *1234", "Revo Pro")' in ctx

--- a/backend/tests/test_category_matcher_prompt.py
+++ b/backend/tests/test_category_matcher_prompt.py
@@ -127,3 +127,49 @@ def test_prompt_includes_account_context_and_transfer_rule(monkeypatch, db_sessi
     assert "Your accounts" in prompt
     assert "Apple Pay Top-Up by *1234" in prompt
     assert "internal transfer" in prompt.lower()
+
+
+def test_prompt_instructions_numbered_correctly_without_accounts(monkeypatch, db_session):
+    import app.services.category_matcher as cm_module
+    captured = {}
+
+    _stub_response = type("R", (), {
+        "choices": [type("X", (), {"message": type("M", (), {"content": "UNKNOWN"})()})()],
+        "usage": type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})(),
+    })
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    captured["messages"] = kwargs["messages"]
+                    return _stub_response
+
+    m = cm_module.CategoryMatcher(db=db_session, user_id="no-acct-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    monkeypatch.setattr(m, "_load_categories", lambda: {})
+    # Explicitly set no accounts so transfer_rule is empty
+    m._account_cache = []
+
+    cats = [FakeCategory("Groceries", "Food and drink", category_type="expense")]
+    m.match_category_llm(
+        description="ALBERT HEIJN 1234",
+        merchant="Albert Heijn",
+        amount=-15.0,
+        available_categories=cats,
+    )
+    prompt = captured["messages"][1]["content"]
+
+    # No account context should appear
+    assert "Your accounts" not in prompt
+
+    # The merged "3. 4." pattern must not appear anywhere
+    assert "3. 4." not in prompt
+
+    # Without accounts, the list is 6 items (no transfer rule injected)
+    # Items 3 and 4 should be the follow-up instructions, not a blank + merged line
+    assert "3. Follow any user-specific guidelines" in prompt
+    assert "4. If the transaction matches a user override" in prompt
+    assert "5. Respond with ONLY the exact category name" in prompt
+    assert '6. If no category fits well, respond with "UNKNOWN"' in prompt

--- a/backend/tests/test_category_matcher_prompt.py
+++ b/backend/tests/test_category_matcher_prompt.py
@@ -173,3 +173,52 @@ def test_prompt_instructions_numbered_correctly_without_accounts(monkeypatch, db
     assert "4. If the transaction matches a user override" in prompt
     assert "5. Respond with ONLY the exact category name" in prompt
     assert '6. If no category fits well, respond with "UNKNOWN"' in prompt
+
+
+# ---------------------------------------------------------------------------
+# Task 8: Prompt budget degradation
+# ---------------------------------------------------------------------------
+
+def test_prompt_budget_degrades_descriptions_first():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    # Simulate oversized input: 30 categories each with a 200-char description.
+    cats = [FakeCategory(f"Cat{i}", "x" * 200) for i in range(30)]
+    m._account_cache = [FakeAccount("Acc", alias_patterns=["p1", "p2"])]
+    category_list, account_block = m._compose_prompt_context(cats)
+    assert sum(len(x) for x in (category_list, account_block)) <= 2000
+    # Descriptions dropped, but names always present
+    assert "Cat0" in category_list
+    assert "Cat29" in category_list
+
+
+# ---------------------------------------------------------------------------
+# Task 9: Feature flag
+# ---------------------------------------------------------------------------
+
+def test_feature_flag_disabled_falls_back_to_names_only(monkeypatch, db_session):
+    import app.services.category_matcher as cm_module
+    monkeypatch.setattr(cm_module, "ENRICHED_PROMPT_ENABLED", False)
+    captured = {}
+
+    _stub_response = type("R", (), {
+        "choices": [type("X", (), {"message": type("M", (), {"content": "UNKNOWN"})()})()],
+        "usage": type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})(),
+    })
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    captured["messages"] = kwargs["messages"]
+                    return _stub_response
+
+    m = cm_module.CategoryMatcher(db=db_session, user_id="ff-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    monkeypatch.setattr(m, "_load_categories", lambda: {})
+    m._account_cache = [FakeAccount("Acc", alias_patterns=["p"])]
+    cats = [FakeCategory("Food", "Description here")]
+    m.match_category_llm(description="x", merchant="y", amount=-1.0, available_categories=cats)
+    prompt = captured["messages"][1]["content"]
+    assert "Description here" not in prompt
+    assert "Your accounts" not in prompt

--- a/backend/tests/test_category_matcher_prompt.py
+++ b/backend/tests/test_category_matcher_prompt.py
@@ -37,3 +37,35 @@ def test_render_category_list_truncates_long_description():
     long = "A" * 500
     rendered = m._render_category_list([FakeCategory("X", long)])
     assert len(rendered) < 300  # bound: name + " — " + 200 chars max
+
+
+def test_prompt_includes_category_descriptions(monkeypatch, db_session):
+    # Use the real CategoryMatcher with a stub DB; assert prompt contains descriptions.
+    import app.services.category_matcher as cm_module
+    captured = {}
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    captured["messages"] = kwargs["messages"]
+                    class R:
+                        choices = [type("X", (), {"message": type("M", (), {"content": "UNKNOWN"})()})()]
+                        usage = type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+                    return R()
+
+    m = cm_module.CategoryMatcher(db=db_session, user_id="prompt-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    # Also monkeypatch _load_categories so we don't depend on DB having categories
+    monkeypatch.setattr(m, "_load_categories", lambda: {})
+
+    cats = [FakeCategory("Side Projects", "Tools like Cloudflare, Framer, GitHub.")]
+    m.match_category_llm(
+        description="Cloudflare workers",
+        merchant="Cloudflare",
+        amount=-5.0,
+        available_categories=cats,
+    )
+    prompt_text = captured["messages"][1]["content"]
+    assert "Side Projects — Tools like Cloudflare" in prompt_text

--- a/backend/tests/test_category_matcher_prompt.py
+++ b/backend/tests/test_category_matcher_prompt.py
@@ -1,0 +1,39 @@
+"""Tests for SYL-32 / SYL-29 prompt enrichment."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.category_matcher import CategoryMatcher
+
+
+class FakeCategory:
+    def __init__(self, name, description=None, category_type="expense"):
+        self.name = name
+        self.description = description
+        self.category_type = category_type
+
+
+class FakeAccount:
+    def __init__(self, name, external_id=None, alias_patterns=None):
+        self.name = name
+        self.external_id = external_id
+        self.alias_patterns = alias_patterns or []
+
+
+def test_render_category_list_with_descriptions():
+    m = CategoryMatcher.__new__(CategoryMatcher)  # avoid __init__ for this unit test
+    cats = [
+        FakeCategory("Side Projects", "Tools used for side projects (Cloudflare, Framer)"),
+        FakeCategory("Food & Dining", None),
+    ]
+    rendered = m._render_category_list(cats)
+    assert "- Side Projects — Tools used for side projects (Cloudflare, Framer)" in rendered
+    assert "- Food & Dining" in rendered
+    assert "None" not in rendered
+
+
+def test_render_category_list_truncates_long_description():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    long = "A" * 500
+    rendered = m._render_category_list([FakeCategory("X", long)])
+    assert len(rendered) < 300  # bound: name + " — " + 200 chars max

--- a/backend/tests/test_category_matcher_prompt.py
+++ b/backend/tests/test_category_matcher_prompt.py
@@ -91,3 +91,39 @@ def test_account_context_with_last_four_and_patterns():
     assert "Your accounts" in ctx
     assert "ABN AMRO checking (ends in 4300)" in ctx
     assert 'Revolut Pro (patterns: "Apple Pay Top-Up by *1234", "Revo Pro")' in ctx
+
+
+def test_prompt_includes_account_context_and_transfer_rule(monkeypatch, db_session):
+    import app.services.category_matcher as cm_module
+    captured = {}
+
+    _stub_response = type("R", (), {
+        "choices": [type("X", (), {"message": type("M", (), {"content": "UNKNOWN"})()})()],
+        "usage": type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})(),
+    })
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    captured["messages"] = kwargs["messages"]
+                    return _stub_response
+
+    m = cm_module.CategoryMatcher(db=db_session, user_id="tr-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    monkeypatch.setattr(m, "_load_categories", lambda: {})
+    m._account_cache = [
+        FakeAccount("Revolut Pro", alias_patterns=["Apple Pay Top-Up by *1234"])
+    ]
+    cats = [FakeCategory("Transfers", "Internal transfers", category_type="transfer")]
+    m.match_category_llm(
+        description="Apple Pay Top-Up by *1234",
+        merchant="Revolut",
+        amount=-50.0,
+        available_categories=cats,
+    )
+    prompt = captured["messages"][1]["content"]
+    assert "Your accounts" in prompt
+    assert "Apple Pay Top-Up by *1234" in prompt
+    assert "internal transfer" in prompt.lower()

--- a/backend/tests/test_mcp_audit_filters.py
+++ b/backend/tests/test_mcp_audit_filters.py
@@ -1,0 +1,104 @@
+"""Tests for SYL-31 audit filters."""
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.mcp.tools import transactions as tx_tools
+from app.mcp.tools import analytics as an_tools
+from app.models import Transaction, Account, Category, User
+
+
+@pytest.fixture
+def audit_data(db_session):
+    user = User(id="audit-user", email="audit@test.com")
+    db_session.add(user)
+    acc = Account(user_id=user.id, name="A", account_type="checking")
+    db_session.add(acc)
+    db_session.flush()
+    expense_cat = Category(user_id=user.id, name="Food", category_type="expense")
+    income_cat = Category(user_id=user.id, name="Salary", category_type="income")
+    db_session.add_all([expense_cat, income_cat])
+    db_session.flush()
+    # 3 uncategorized, 2 expense-categorized, 1 income-categorized
+    specs = [
+        (None, -10, "debit"), (None, -20, "debit"), (None, -30, "debit"),
+        (expense_cat.id, -40, "debit"), (expense_cat.id, -50, "debit"),
+        (income_cat.id, 100, "credit"),
+    ]
+    for i, (cid, amt, ttype) in enumerate(specs):
+        db_session.add(Transaction(
+            user_id=user.id,
+            account_id=acc.id,
+            amount=Decimal(str(amt)),
+            currency="EUR",
+            description=f"Txn {i}",
+            merchant=f"M{i}",
+            category_id=cid,
+            booked_at=datetime(2026, 4, 1 + i),
+            transaction_type=ttype,
+        ))
+    db_session.commit()
+    try:
+        yield user, acc, expense_cat, income_cat
+    finally:
+        # Clean up committed data so tests are idempotent across runs.
+        db_session.query(Transaction).filter(Transaction.user_id == user.id).delete()
+        db_session.query(Category).filter(Category.user_id == user.id).delete()
+        db_session.query(Account).filter(Account.user_id == user.id).delete()
+        db_session.query(User).filter(User.id == user.id).delete()
+        db_session.commit()
+
+
+def test_list_transactions_uncategorized(audit_data):
+    user, *_ = audit_data
+    result = tx_tools.list_transactions(user_id=user.id, uncategorized=True, limit=50)
+    assert len(result["transactions"]) == 3
+    assert all(t["category_id"] is None for t in result["transactions"])
+
+
+def test_list_transactions_category_type(audit_data):
+    user, *_ = audit_data
+    result = tx_tools.list_transactions(user_id=user.id, category_type="expense", limit=50)
+    assert len(result["transactions"]) == 2  # Only categorized-as-expense
+    result_income = tx_tools.list_transactions(user_id=user.id, category_type="income", limit=50)
+    assert len(result_income["transactions"]) == 1
+
+
+def test_spending_by_category_include_uncategorized(audit_data):
+    user, *_ = audit_data
+    # Without flag: only categorized expense rows
+    baseline = an_tools.get_spending_by_category(user_id=user.id)
+    assert all(r["category_id"] is not None for r in baseline)
+
+    enriched = an_tools.get_spending_by_category(user_id=user.id, include_uncategorized=True)
+    names = [r["category_name"] for r in enriched]
+    assert "Uncategorized" in names
+    uncat = next(r for r in enriched if r["category_name"] == "Uncategorized")
+    assert uncat["total"] == 60  # 10 + 20 + 30
+    assert uncat["count"] == 3
+    assert "merchant_count" in uncat
+    assert uncat["merchant_count"] == 3
+
+
+def test_top_merchants_category_filter(audit_data):
+    user, _, expense_cat, _ = audit_data
+    result = an_tools.get_top_merchants(user_id=user.id, category_id=str(expense_cat.id))
+    # Only the 2 expense-categorized txns (M3, M4)
+    merchants = {r["merchant"] for r in result}
+    assert merchants == {"M3", "M4"}
+
+
+def test_top_merchants_uncategorized(audit_data):
+    user, *_ = audit_data
+    result = an_tools.get_top_merchants(user_id=user.id, uncategorized=True)
+    merchants = {r["merchant"] for r in result}
+    assert merchants == {"M0", "M1", "M2"}
+
+
+def test_top_merchants_mutual_exclusion(audit_data):
+    user, _, expense_cat, _ = audit_data
+    with pytest.raises(ValueError):
+        an_tools.get_top_merchants(
+            user_id=user.id, category_id=str(expense_cat.id), uncategorized=True,
+        )

--- a/backend/tests/test_mcp_audit_filters.py
+++ b/backend/tests/test_mcp_audit_filters.py
@@ -102,3 +102,68 @@ def test_top_merchants_mutual_exclusion(audit_data):
         an_tools.get_top_merchants(
             user_id=user.id, category_id=str(expense_cat.id), uncategorized=True,
         )
+
+
+def test_uncategorized_excludes_system_categorized(db_session):
+    """list_transactions(uncategorized=True) must require BOTH category_id IS NULL
+    AND category_system_id IS NULL.  A row with only category_system_id set (AI-
+    assigned, not user-confirmed) must NOT appear in the uncategorized list.
+    """
+    from app.models import Transaction, Account, Category, User
+    from decimal import Decimal
+    from datetime import datetime
+
+    user = User(id="sys-cat-user", email="syscat@test.com")
+    db_session.add(user)
+    acc = Account(user_id=user.id, name="A", account_type="checking")
+    db_session.add(acc)
+    db_session.flush()
+
+    sys_cat = Category(user_id=user.id, name="SysCat", category_type="expense")
+    db_session.add(sys_cat)
+    db_session.flush()
+
+    # Row 1: category_system_id set, category_id NULL → AI-assigned, not uncategorized
+    txn_sys = Transaction(
+        user_id=user.id,
+        account_id=acc.id,
+        amount=Decimal("-15"),
+        currency="EUR",
+        description="AI-categorized txn",
+        merchant="MerchSys",
+        category_id=None,
+        category_system_id=sys_cat.id,
+        booked_at=datetime(2026, 5, 1),
+        transaction_type="debit",
+    )
+    # Row 2: both NULL → truly uncategorized
+    txn_none = Transaction(
+        user_id=user.id,
+        account_id=acc.id,
+        amount=Decimal("-25"),
+        currency="EUR",
+        description="Fully uncategorized txn",
+        merchant="MerchNone",
+        category_id=None,
+        category_system_id=None,
+        booked_at=datetime(2026, 5, 2),
+        transaction_type="debit",
+    )
+    db_session.add_all([txn_sys, txn_none])
+    db_session.commit()
+
+    try:
+        result = tx_tools.list_transactions(user_id=user.id, uncategorized=True, limit=50)
+        ids = {t["id"] for t in result["transactions"]}
+
+        assert str(txn_none.id) in ids, "Truly uncategorized row must be returned"
+        assert str(txn_sys.id) not in ids, (
+            "Row with category_system_id set must NOT be returned as uncategorized"
+        )
+        assert len(result["transactions"]) == 1
+    finally:
+        db_session.query(Transaction).filter(Transaction.user_id == user.id).delete()
+        db_session.query(Category).filter(Category.user_id == user.id).delete()
+        db_session.query(Account).filter(Account.user_id == user.id).delete()
+        db_session.query(User).filter(User.id == user.id).delete()
+        db_session.commit()

--- a/backend/tests/test_mcp_bulk_update.py
+++ b/backend/tests/test_mcp_bulk_update.py
@@ -1,0 +1,117 @@
+"""Tests for SYL-33: dry_run and rich response on bulk_update_transaction_categories."""
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.mcp.tools import transactions as tx_tools
+from app.models import Transaction, Account, Category, User
+
+
+@pytest.fixture
+def bulk_data(db_session):
+    user = User(id="bulk-user", email="bulk@test.com")
+    other_user = User(id="other-user", email="other@test.com")
+    db_session.add_all([user, other_user])
+    acc = Account(user_id=user.id, name="A", account_type="checking")
+    other_acc = Account(user_id=other_user.id, name="B", account_type="checking")
+    db_session.add_all([acc, other_acc])
+    db_session.flush()
+    target = Category(user_id=user.id, name="Groceries", category_type="expense")
+    other_cat = Category(user_id=user.id, name="Other", category_type="expense")
+    db_session.add_all([target, other_cat])
+    db_session.flush()
+    # 3 to update (t1, t2, t3), 1 already in target (t4), 1 belongs to other user (t5)
+    t1 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-10"),
+                     currency="EUR", description="D1", merchant="M1",
+                     category_id=other_cat.id, booked_at=datetime(2026, 4, 1),
+                     transaction_type="debit")
+    t2 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-20"),
+                     currency="EUR", description="D2", merchant="M2",
+                     category_id=other_cat.id, booked_at=datetime(2026, 4, 2),
+                     transaction_type="debit")
+    t3 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-30"),
+                     currency="EUR", description="D3", merchant="M3",
+                     category_id=None, booked_at=datetime(2026, 4, 3),
+                     transaction_type="debit")
+    t4 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-40"),
+                     currency="EUR", description="D4", merchant="M4",
+                     category_id=target.id, booked_at=datetime(2026, 4, 4),
+                     transaction_type="debit")
+    t5 = Transaction(user_id=other_user.id, account_id=other_acc.id, amount=Decimal("-50"),
+                     currency="EUR", description="D5", merchant="M5",
+                     category_id=other_cat.id, booked_at=datetime(2026, 4, 5),
+                     transaction_type="debit")
+    db_session.add_all([t1, t2, t3, t4, t5])
+    db_session.commit()
+    try:
+        yield user, target, [t1, t2, t3, t4, t5]
+    finally:
+        # Clean up committed data in FK order so tests are idempotent across runs.
+        db_session.query(Transaction).filter(Transaction.user_id == user.id).delete()
+        db_session.query(Transaction).filter(Transaction.user_id == other_user.id).delete()
+        db_session.query(Category).filter(Category.user_id == user.id).delete()
+        db_session.query(Account).filter(Account.user_id == user.id).delete()
+        db_session.query(Account).filter(Account.user_id == other_user.id).delete()
+        db_session.query(User).filter(User.id.in_([user.id, other_user.id])).delete()
+        db_session.commit()
+
+
+def test_bulk_update_dry_run_no_mutation(bulk_data, db_session):
+    user, target, txns = bulk_data
+    ids = [str(t.id) for t in txns[:3]]
+    result = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id),
+        transaction_ids=ids, dry_run=True,
+    )
+    assert result["success"] is True
+    assert result["would_update_count"] == 3
+    assert result["requested_count"] == 3
+    assert len(result["sample_changes"]) == 3
+    assert result["sample_changes"][0]["description"] in ("D1", "D2", "D3")
+    # Verify DB untouched
+    for t in txns[:3]:
+        db_session.refresh(t)
+        assert t.category_id != target.id
+
+
+def test_bulk_update_rich_response_categorizes_ids(bulk_data):
+    user, target, txns = bulk_data
+    bogus = "00000000-0000-0000-0000-000000000000"
+    ids = [str(txns[0].id), str(txns[3].id), str(txns[4].id), bogus, "not-a-uuid"]
+    result = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id), transaction_ids=ids,
+    )
+    assert result["success"] is True
+    assert result["updated_count"] == 1  # only txns[0] is actually changed
+    assert result["requested_count"] == 5
+    assert result["invalid_ids"] == ["not-a-uuid"]
+    assert bogus in result["not_found_ids"] or str(txns[4].id) in result["not_found_ids"]
+    assert str(txns[3].id) in result["skipped_already_in_category_ids"]
+
+
+def test_bulk_update_hard_cap():
+    result = tx_tools.bulk_update_transaction_categories(
+        user_id="x", category_id="00000000-0000-0000-0000-000000000001",
+        transaction_ids=[f"id-{i}" for i in range(2001)],
+    )
+    assert result["success"] is False
+    assert "2000" in result["error"]
+
+
+def test_bulk_update_dry_run_matches_real_run(bulk_data):
+    user, target, txns = bulk_data
+    ids = [str(t.id) for t in txns[:3]]
+
+    preview = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id),
+        transaction_ids=ids, dry_run=True,
+    )
+    real = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id), transaction_ids=ids,
+    )
+
+    assert preview["would_update_count"] == real["updated_count"]
+    preview_ids = {s["id"] for s in preview["sample_changes"]}
+    real_ids = {s["id"] for s in real["sample_changes"]}
+    assert preview_ids == real_ids

--- a/backend/tests/test_mcp_pagination.py
+++ b/backend/tests/test_mcp_pagination.py
@@ -124,3 +124,26 @@ def test_booked_at_asc_cursor_pagination_with_ties(user_with_tied_booked_at):
     assert len(collected_ids) == 7, (
         f"cursor walk skipped rows; got {len(collected_ids)}/7: {collected_ids}"
     )
+
+
+def test_list_transactions_cursor_round_trip(seeded_user):
+    user, _, _, _ = seeded_user
+    page1 = tx_tools.list_transactions(user_id=user.id, limit=4, sort_by="booked_at_desc")
+    assert len(page1["transactions"]) == 4
+    assert page1["next_cursor"] is not None
+
+    page2 = tx_tools.list_transactions(
+        user_id=user.id, limit=4, sort_by="booked_at_desc", cursor=page1["next_cursor"]
+    )
+    assert len(page2["transactions"]) == 4
+
+    ids_page1 = {t["id"] for t in page1["transactions"]}
+    ids_page2 = {t["id"] for t in page2["transactions"]}
+    assert ids_page1.isdisjoint(ids_page2), "Pages must not overlap"
+
+    page3 = tx_tools.list_transactions(
+        user_id=user.id, limit=4, sort_by="booked_at_desc", cursor=page2["next_cursor"]
+    )
+    # Total 10 rows, 4+4+2 = 10, final page returns fewer than limit → no next_cursor
+    assert len(page3["transactions"]) == 2
+    assert page3["next_cursor"] is None

--- a/backend/tests/test_mcp_pagination.py
+++ b/backend/tests/test_mcp_pagination.py
@@ -1,0 +1,56 @@
+"""Tests for cursor pagination, sort_by, and account_id filter on MCP search/list tools."""
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.mcp.tools import transactions as tx_tools
+from app.models import Transaction, Account, Category, User
+
+
+@pytest.fixture
+def seeded_user(db_session):
+    """Create a user with 2 accounts and 10 transactions spanning 10 days."""
+    user = User(id="test-user-1", email="test@test.com")
+    db_session.add(user)
+    acc1 = Account(user_id=user.id, name="ABN", account_type="checking")
+    acc2 = Account(user_id=user.id, name="Revolut", account_type="checking")
+    db_session.add_all([acc1, acc2])
+    db_session.flush()
+    cat = Category(user_id=user.id, name="Food", category_type="expense")
+    db_session.add(cat)
+    db_session.flush()
+    base = datetime(2026, 4, 1)
+    for i in range(10):
+        db_session.add(Transaction(
+            user_id=user.id,
+            account_id=acc1.id if i % 2 == 0 else acc2.id,
+            amount=Decimal(f"-{(i + 1) * 10}"),
+            currency="EUR",
+            description=f"Purchase {i}",
+            merchant=f"Merchant {i}",
+            category_id=cat.id if i < 5 else None,
+            booked_at=base + timedelta(days=i),
+            transaction_type="debit",
+        ))
+    db_session.commit()
+    try:
+        yield user, acc1, acc2, cat
+    finally:
+        # Clean up committed data so tests are idempotent.
+        db_session.query(Transaction).filter(Transaction.user_id == user.id).delete()
+        db_session.query(Category).filter(Category.user_id == user.id).delete()
+        db_session.query(Account).filter(Account.user_id == user.id).delete()
+        db_session.query(User).filter(User.id == user.id).delete()
+        db_session.commit()
+
+
+def test_list_transactions_sort_by_amount_desc(seeded_user):
+    user, _, _, _ = seeded_user
+    result = tx_tools.list_transactions(
+        user_id=user.id, sort_by="amount_desc", limit=3
+    )
+    # amount_desc over negative expenses: -10 is largest, -100 smallest
+    amounts = [r["amount"] for r in result["transactions"]]
+    assert amounts == sorted(amounts, reverse=True)
+    assert len(result["transactions"]) == 3

--- a/backend/tests/test_mcp_pagination.py
+++ b/backend/tests/test_mcp_pagination.py
@@ -155,8 +155,5 @@ def test_search_transactions_account_id_filter(seeded_user):
         user_id=user.id, query="Purchase", account_id=str(acc1.id), match_mode="contains"
     )
     assert result["total_count"] > 0
-    assert all(
-        # Only acc1 transactions; acc1 got even indices 0,2,4,6,8 → 5 txns
-        True for t in result["transactions"]
-    )
+    assert all(t["account_id"] == str(acc1.id) for t in result["transactions"])
     assert result["total_count"] == 5

--- a/backend/tests/test_mcp_pagination.py
+++ b/backend/tests/test_mcp_pagination.py
@@ -54,3 +54,73 @@ def test_list_transactions_sort_by_amount_desc(seeded_user):
     amounts = [r["amount"] for r in result["transactions"]]
     assert amounts == sorted(amounts, reverse=True)
     assert len(result["transactions"]) == 3
+
+
+@pytest.fixture
+def user_with_tied_booked_at(db_session):
+    """Seed a user whose transactions all share the same booked_at timestamp.
+
+    Exercises the tie-breaker in _paginate_query: pagination must visit every
+    row exactly once when the primary sort column is constant across rows.
+    """
+    user = User(id="test-user-ties", email="ties@test.com")
+    db_session.add(user)
+    acc = Account(user_id=user.id, name="ABN", account_type="checking")
+    db_session.add(acc)
+    db_session.flush()
+    same_ts = datetime(2026, 4, 15, 12, 0, 0)
+    for i in range(7):
+        db_session.add(Transaction(
+            user_id=user.id,
+            account_id=acc.id,
+            amount=Decimal(f"-{(i + 1) * 5}"),
+            currency="EUR",
+            description=f"Tied purchase {i}",
+            merchant=f"Merchant {i}",
+            booked_at=same_ts,
+            transaction_type="debit",
+        ))
+    db_session.commit()
+    try:
+        yield user
+    finally:
+        db_session.query(Transaction).filter(Transaction.user_id == user.id).delete()
+        db_session.query(Account).filter(Account.user_id == user.id).delete()
+        db_session.query(User).filter(User.id == user.id).delete()
+        db_session.commit()
+
+
+def test_booked_at_asc_cursor_pagination_with_ties(user_with_tied_booked_at):
+    """Ascending-sort cursor walk must not skip or duplicate rows on ties.
+
+    Regression test: the id tie-breaker must match the primary sort
+    direction. If the secondary order_by is id.desc() but the cursor
+    filter uses `id > last_id` for ascending sorts, rows tied on
+    booked_at silently disappear between pages.
+    """
+    user = user_with_tied_booked_at
+    collected_ids: list[str] = []
+    cursor = None
+    # 7 rows, page size 2 -> need at least 4 iterations; cap to avoid looping forever.
+    for _ in range(10):
+        result = tx_tools.list_transactions(
+            user_id=user.id,
+            sort_by="booked_at_asc",
+            limit=2,
+            cursor=cursor,
+        )
+        page_ids = [t["id"] for t in result["transactions"]]
+        collected_ids.extend(page_ids)
+        cursor = result["next_cursor"]
+        if cursor is None:
+            break
+
+    assert cursor is None, "pagination did not terminate"
+    # No duplicates.
+    assert len(collected_ids) == len(set(collected_ids)), (
+        f"cursor walk produced duplicates: {collected_ids}"
+    )
+    # No gaps - every seeded row is present.
+    assert len(collected_ids) == 7, (
+        f"cursor walk skipped rows; got {len(collected_ids)}/7: {collected_ids}"
+    )

--- a/backend/tests/test_mcp_pagination.py
+++ b/backend/tests/test_mcp_pagination.py
@@ -157,3 +157,27 @@ def test_search_transactions_account_id_filter(seeded_user):
     assert result["total_count"] > 0
     assert all(t["account_id"] == str(acc1.id) for t in result["transactions"])
     assert result["total_count"] == 5
+
+
+def test_search_multi_cursor_opt_in(seeded_user):
+    user, _, _, _ = seeded_user
+    # Default (no cursor) behavior: returns all capped results, no next_cursor
+    r1 = tx_tools.search_transactions_multi(
+        user_id=user.id, queries=["Purchase"], max_results=100
+    )
+    assert r1["total_count"] == 10
+    assert "next_cursor" not in r1 or r1.get("next_cursor") is None
+
+    # Opt-in to cursor mode via limit + cursor loop
+    r2 = tx_tools.search_transactions_multi(
+        user_id=user.id, queries=["Purchase"], max_results=4, cursor=""
+    )
+    assert len(r2["transactions"]) == 4
+    assert r2["next_cursor"] is not None
+    r3 = tx_tools.search_transactions_multi(
+        user_id=user.id, queries=["Purchase"], max_results=4, cursor=r2["next_cursor"]
+    )
+    assert len(r3["transactions"]) == 4
+    assert set(t["id"] for t in r2["transactions"]).isdisjoint(
+        set(t["id"] for t in r3["transactions"])
+    )

--- a/backend/tests/test_mcp_pagination.py
+++ b/backend/tests/test_mcp_pagination.py
@@ -181,3 +181,53 @@ def test_search_multi_cursor_opt_in(seeded_user):
     assert set(t["id"] for t in r2["transactions"]).isdisjoint(
         set(t["id"] for t in r3["transactions"])
     )
+
+
+def test_amount_asc_cursor_round_trip(seeded_user):
+    """Cursor pagination must visit all rows exactly once with amount_asc sort."""
+    user, _, _, _ = seeded_user
+    collected_ids: list[str] = []
+    cursor = None
+    for _ in range(15):
+        result = tx_tools.list_transactions(
+            user_id=user.id, sort_by="amount_asc", limit=3, cursor=cursor
+        )
+        collected_ids.extend(t["id"] for t in result["transactions"])
+        cursor = result["next_cursor"]
+        if cursor is None:
+            break
+
+    assert cursor is None, "pagination did not terminate"
+    assert len(collected_ids) == len(set(collected_ids)), (
+        f"cursor walk produced duplicates: {collected_ids}"
+    )
+    assert len(collected_ids) == 10, (
+        f"cursor walk skipped rows; got {len(collected_ids)}/10"
+    )
+
+
+def test_abs_amount_desc_cursor_round_trip(seeded_user):
+    """Cursor pagination must visit all rows exactly once with abs_amount_desc sort.
+
+    This exercises the func.abs() branch in _build_next_cursor which encodes
+    str(abs(float(amount))) — a distinct path from the regular amount sorts.
+    """
+    user, _, _, _ = seeded_user
+    collected_ids: list[str] = []
+    cursor = None
+    for _ in range(15):
+        result = tx_tools.list_transactions(
+            user_id=user.id, sort_by="abs_amount_desc", limit=3, cursor=cursor
+        )
+        collected_ids.extend(t["id"] for t in result["transactions"])
+        cursor = result["next_cursor"]
+        if cursor is None:
+            break
+
+    assert cursor is None, "pagination did not terminate"
+    assert len(collected_ids) == len(set(collected_ids)), (
+        f"cursor walk produced duplicates: {collected_ids}"
+    )
+    assert len(collected_ids) == 10, (
+        f"cursor walk skipped rows; got {len(collected_ids)}/10"
+    )

--- a/backend/tests/test_mcp_pagination.py
+++ b/backend/tests/test_mcp_pagination.py
@@ -147,3 +147,16 @@ def test_list_transactions_cursor_round_trip(seeded_user):
     # Total 10 rows, 4+4+2 = 10, final page returns fewer than limit → no next_cursor
     assert len(page3["transactions"]) == 2
     assert page3["next_cursor"] is None
+
+
+def test_search_transactions_account_id_filter(seeded_user):
+    user, acc1, acc2, _ = seeded_user
+    result = tx_tools.search_transactions(
+        user_id=user.id, query="Purchase", account_id=str(acc1.id), match_mode="contains"
+    )
+    assert result["total_count"] > 0
+    assert all(
+        # Only acc1 transactions; acc1 got even indices 0,2,4,6,8 → 5 txns
+        True for t in result["transactions"]
+    )
+    assert result["total_count"] == 5

--- a/docs/superpowers/plans/2026-04-24-ai-categorizer-prompt-enrichment.md
+++ b/docs/superpowers/plans/2026-04-24-ai-categorizer-prompt-enrichment.md
@@ -1,0 +1,849 @@
+# AI Categorizer Prompt Enrichment — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich the LLM categorizer's prompt with category descriptions and the user's account graph so it makes better first-pass decisions (SYL-32 prompt piece + SYL-29).
+
+**Architecture:** All changes are inside `backend/app/services/category_matcher.py`'s LLM-prompt assembly functions. Add one `Account.alias_patterns` JSONB column with a raw-SQL migration script in `backend/postgres_migration/`. Feature flag behind `CATEGORIZER_ENRICHED_PROMPT`.
+
+**Tech Stack:** Python 3.13, SQLAlchemy ORM, PostgreSQL (JSONB), OpenAI SDK, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-ai-categorizer-prompt-enrichment-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+- `backend/app/models.py` — add `alias_patterns` column to `Account`.
+- `backend/app/services/category_matcher.py` — category-description rendering, `_build_account_context`, prompt assembly, budget cap.
+- `backend/app/schemas.py` — expose `alias_patterns` on Pydantic account schemas.
+- `backend/app/routes/*` — allow updating `alias_patterns` on the existing account-update endpoint (one line per route).
+
+**Created:**
+- `backend/postgres_migration/add_account_alias_patterns.py` — one-off migration runner.
+- `backend/tests/test_category_matcher_prompt.py` — prompt-composition unit tests.
+- `backend/tests/test_category_matcher_llm_transfer.py` — stub-OpenAI integration test.
+
+---
+
+## Task 1: Add `alias_patterns` column to `Account` model
+
+**Files:**
+- Modify: `backend/app/models.py:28-56`
+
+- [ ] **Step 1: Update the model**
+
+In `backend/app/models.py`, inside `class Account(Base):`, after the `is_active` column:
+
+```python
+    alias_patterns = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+```
+
+Ensure the imports at the top include:
+
+```python
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import text
+```
+
+(Both are likely already imported — verify with `grep -n "JSONB\|from sqlalchemy import" backend/app/models.py`.)
+
+- [ ] **Step 2: Run existing account tests to verify model still loads**
+
+Run: `cd backend && pytest tests/test_account_sync_encryption.py -v --no-header -q`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/app/models.py
+git commit -m "feat(models): add alias_patterns JSONB column to Account"
+```
+
+---
+
+## Task 2: Write migration script for `alias_patterns` column
+
+**Files:**
+- Create: `backend/postgres_migration/add_account_alias_patterns.py`
+
+- [ ] **Step 1: Create the migration script**
+
+```python
+"""
+One-off migration: add accounts.alias_patterns JSONB column.
+
+Usage (from backend/):
+    python postgres_migration/add_account_alias_patterns.py
+
+Idempotent: safe to re-run.
+"""
+import sys
+from sqlalchemy import create_engine, text
+
+from app.database import get_database_url
+
+
+SQL = """
+ALTER TABLE accounts
+  ADD COLUMN IF NOT EXISTS alias_patterns JSONB NOT NULL DEFAULT '[]'::jsonb;
+"""
+
+
+def main() -> int:
+    engine = create_engine(get_database_url())
+    with engine.begin() as conn:
+        conn.execute(text(SQL))
+    print("OK: accounts.alias_patterns present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+If `get_database_url` doesn't exist, check `backend/app/database.py` for the engine/URL export and adapt the import line accordingly.
+
+- [ ] **Step 2: Smoke-run against a local DB**
+
+Run: `cd backend && python postgres_migration/add_account_alias_patterns.py`
+Expected: `OK: accounts.alias_patterns present.`
+
+- [ ] **Step 3: Re-run to confirm idempotency**
+
+Run the same command again. Expected: same output, no error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/postgres_migration/add_account_alias_patterns.py
+git commit -m "feat(migration): add idempotent migration for Account.alias_patterns"
+```
+
+---
+
+## Task 3: Expose `alias_patterns` on account Pydantic schemas
+
+**Files:**
+- Modify: `backend/app/schemas.py`
+
+- [ ] **Step 1: Locate account schemas**
+
+Run: `grep -n "class Account" backend/app/schemas.py`
+
+- [ ] **Step 2: Add field to read/update schemas**
+
+For every account-shaped schema (typically `AccountRead`, `AccountUpdate`, `AccountBase`), add:
+
+```python
+    alias_patterns: list[str] = Field(default_factory=list)
+```
+
+Import `Field` at the top if not already:
+
+```python
+from pydantic import BaseModel, Field
+```
+
+- [ ] **Step 3: Find the account update route and confirm it accepts `alias_patterns`**
+
+Run: `grep -rn "AccountUpdate\|alias_patterns" backend/app/routes/`
+
+If there's a manual field-copy in the update handler, add `alias_patterns` to it. If it uses `.model_dump(exclude_unset=True)` and applies via `setattr`, no route changes needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/schemas.py backend/app/routes
+git commit -m "feat(schemas): expose alias_patterns on account read/update schemas"
+```
+
+---
+
+## Task 4: Helper `_render_category_list` with descriptions (SYL-32)
+
+**Files:**
+- Modify: `backend/app/services/category_matcher.py`
+- Test: `backend/tests/test_category_matcher_prompt.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `backend/tests/test_category_matcher_prompt.py`:
+
+```python
+"""Tests for SYL-32 / SYL-29 prompt enrichment."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.category_matcher import CategoryMatcher
+
+
+class FakeCategory:
+    def __init__(self, name, description=None, category_type="expense"):
+        self.name = name
+        self.description = description
+        self.category_type = category_type
+
+
+def test_render_category_list_with_descriptions():
+    m = CategoryMatcher.__new__(CategoryMatcher)  # avoid __init__ for this unit test
+    cats = [
+        FakeCategory("Side Projects", "Tools used for side projects (Cloudflare, Framer)"),
+        FakeCategory("Food & Dining", None),
+    ]
+    rendered = m._render_category_list(cats)
+    assert "- Side Projects — Tools used for side projects (Cloudflare, Framer)" in rendered
+    assert "- Food & Dining" in rendered
+    assert "None" not in rendered
+
+
+def test_render_category_list_truncates_long_description():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    long = "A" * 500
+    rendered = m._render_category_list([FakeCategory("X", long)])
+    assert len(rendered) < 300  # bound: name + " — " + 200 chars max
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py::test_render_category_list_with_descriptions -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add helper method**
+
+In `backend/app/services/category_matcher.py`, inside `class CategoryMatcher`, near the other `_` helpers (e.g., after `_normalize_text`):
+
+```python
+    MAX_CATEGORY_DESCRIPTION_LEN = 200
+
+    def _render_category_list(self, categories) -> str:
+        """Render the category list for the LLM prompt, with truncated descriptions."""
+        lines = []
+        for cat in categories:
+            desc = (cat.description or "").strip()
+            if desc:
+                if len(desc) > self.MAX_CATEGORY_DESCRIPTION_LEN:
+                    desc = desc[: self.MAX_CATEGORY_DESCRIPTION_LEN].rstrip() + "…"
+                lines.append(f"- {cat.name} — {desc}")
+            else:
+                lines.append(f"- {cat.name}")
+        return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/category_matcher.py backend/tests/test_category_matcher_prompt.py
+git commit -m "feat(categorizer): add _render_category_list helper with truncated descriptions"
+```
+
+---
+
+## Task 5: Wire `_render_category_list` into both LLM prompt functions
+
+**Files:**
+- Modify: `backend/app/services/category_matcher.py:736-737, 894-895`
+
+- [ ] **Step 1: Replace prompt category-list construction**
+
+In `match_category_llm` (around line 736) and `_match_category_llm_with_details` (around line 894), replace:
+
+```python
+category_list = "\n".join([f"- {cat.name}" for cat in relevant_categories])
+```
+
+with:
+
+```python
+category_list = self._render_category_list(relevant_categories)
+```
+
+- [ ] **Step 2: Write assertion test**
+
+Append to `backend/tests/test_category_matcher_prompt.py`:
+
+```python
+def test_prompt_includes_category_descriptions(monkeypatch, db_session):
+    # Use the real CategoryMatcher with a stub DB; assert prompt contains descriptions.
+    # This test builds the prompt by calling into match_category_llm up to (not through)
+    # the OpenAI client call, using a monkeypatched _get_openai_client that raises to
+    # short-circuit — then we inspect the prompt captured via a side effect.
+    import app.services.category_matcher as cm_module
+    captured = {}
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    captured["messages"] = kwargs["messages"]
+                    class R:
+                        class choices:
+                            class _C:
+                                class message:
+                                    content = "UNKNOWN"
+                            pass
+                        choices = [type("X", (), {"message": type("M", (), {"content": "UNKNOWN"})()})()]
+                        usage = type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})()
+                    return R()
+
+    m = cm_module.CategoryMatcher(db=db_session, user_id="prompt-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+
+    cats = [FakeCategory("Side Projects", "Tools like Cloudflare, Framer, GitHub.")]
+    m.match_category_llm(
+        description="Cloudflare workers",
+        merchant="Cloudflare",
+        amount=-5.0,
+        available_categories=cats,
+    )
+    prompt_text = captured["messages"][1]["content"]
+    assert "Side Projects — Tools like Cloudflare" in prompt_text
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/category_matcher.py backend/tests/test_category_matcher_prompt.py
+git commit -m "feat(categorizer): render category descriptions in LLM prompt"
+```
+
+---
+
+## Task 6: `_build_account_context` helper (SYL-29)
+
+**Files:**
+- Modify: `backend/app/services/category_matcher.py`
+- Test: `backend/tests/test_category_matcher_prompt.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append:
+
+```python
+class FakeAccount:
+    def __init__(self, name, external_id=None, alias_patterns=None):
+        self.name = name
+        self.external_id = external_id
+        self.alias_patterns = alias_patterns or []
+
+
+def test_account_context_empty_returns_empty_string():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    m._account_cache = []
+    assert m._build_account_context() == ""
+
+
+def test_account_context_with_last_four_and_patterns():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    m._account_cache = [
+        FakeAccount("ABN AMRO checking", external_id="NL91ABNA0417164300"),
+        FakeAccount(
+            "Revolut Pro",
+            external_id=None,
+            alias_patterns=["Apple Pay Top-Up by *1234", "Revo Pro"],
+        ),
+    ]
+    ctx = m._build_account_context()
+    assert "Your accounts" in ctx
+    assert "ABN AMRO checking (ends in 4300)" in ctx
+    assert 'Revolut Pro (patterns: "Apple Pay Top-Up by *1234", "Revo Pro")' in ctx
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py -k account_context -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Add helper and loader**
+
+In `backend/app/services/category_matcher.py`:
+
+1. Add an import if not present: `from app.models import Account`.
+2. In `__init__`, initialize `self._account_cache: Optional[list] = None`.
+3. Add two new methods:
+
+```python
+    def _load_accounts(self) -> list:
+        if self._account_cache is not None:
+            return self._account_cache
+        from app.models import Account  # local import if global causes circularity
+        accounts = (
+            self.db.query(Account)
+            .filter(Account.user_id == self.user_id, Account.is_active == True)
+            .all()
+        )
+        self._account_cache = accounts
+        return accounts
+
+    def _build_account_context(self) -> str:
+        accounts = self._account_cache if self._account_cache is not None else self._load_accounts()
+        if not accounts:
+            return ""
+        lines = ["Your accounts (transactions referencing these are internal transfers):"]
+        for acc in accounts:
+            identifiers = []
+            ext = (getattr(acc, "external_id", None) or "").strip()
+            if ext and len(ext) >= 4:
+                identifiers.append(f"ends in {ext[-4:]}")
+            patterns = getattr(acc, "alias_patterns", None) or []
+            if patterns:
+                quoted = ", ".join(f'"{p}"' for p in patterns)
+                identifiers.append(f"patterns: {quoted}")
+            suffix = f" ({'; '.join(identifiers)})" if identifiers else ""
+            lines.append(f"- {acc.name}{suffix}")
+        return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py -k account_context -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/category_matcher.py backend/tests/test_category_matcher_prompt.py
+git commit -m "feat(categorizer): add _build_account_context helper for transfer detection"
+```
+
+---
+
+## Task 7: Inject account context + transfer rule into the prompt
+
+**Files:**
+- Modify: `backend/app/services/category_matcher.py` — prompt assembly in `match_category_llm` and `_match_category_llm_with_details`.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/test_category_matcher_prompt.py`:
+
+```python
+def test_prompt_includes_account_context_and_transfer_rule(monkeypatch, db_session):
+    import app.services.category_matcher as cm_module
+    from app.models import Account
+    captured = {}
+
+    class StubClient:
+        @staticmethod
+        def _make():
+            return type("R", (), {
+                "choices": [type("X", (), {"message": type("M", (), {"content": "UNKNOWN"})()})()],
+                "usage": type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})(),
+            })
+
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    captured["messages"] = kwargs["messages"]
+                    return StubClient._make()
+
+    m = cm_module.CategoryMatcher(db=db_session, user_id="tr-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    m._account_cache = [
+        FakeAccount("Revolut Pro", alias_patterns=["Apple Pay Top-Up by *1234"])
+    ]
+    cats = [FakeCategory("Transfers", "Internal transfers", category_type="transfer")]
+    m.match_category_llm(
+        description="Apple Pay Top-Up by *1234",
+        merchant="Revolut",
+        amount=-50.0,
+        available_categories=cats,
+    )
+    prompt = captured["messages"][1]["content"]
+    assert "Your accounts" in prompt
+    assert "Apple Pay Top-Up by *1234" in prompt
+    assert "internal transfer" in prompt.lower()
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py::test_prompt_includes_account_context_and_transfer_rule -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Modify prompt assembly in both LLM functions**
+
+In `match_category_llm` (around line 754) and `_match_category_llm_with_details` (around line 912), replace the prompt-building section:
+
+```python
+        prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
+
+Transaction details:
+- Description: {description or 'N/A'}
+- Merchant: {merchant or 'N/A'}
+- Amount: {abs(amount)} {transaction_type_str.upper()}
+- Type: {transaction_type_str}
+
+Available categories:
+{category_list}
+{overrides_text}{instructions_text}
+Instructions:
+1. Analyze the transaction description and merchant name
+2. Select the MOST SPECIFIC category that matches
+3. Follow any user-specific guidelines and override patterns provided above
+4. If the transaction matches a user override pattern, use that category
+5. Respond with ONLY the exact category name from the list
+6. If no category fits well, respond with "UNKNOWN"
+
+Category name:"""
+```
+
+with:
+
+```python
+        account_context = self._build_account_context()
+        account_block = f"\n\n{account_context}\n" if account_context else ""
+        transfer_rule = (
+            "If the transaction description, merchant, or counterparty references any of the "
+            "accounts listed in \"Your accounts\", treat it as an internal transfer and pick the "
+            "transfer category.\n" if account_context else ""
+        )
+        prompt = f"""Categorize this financial transaction by selecting the most appropriate category.
+
+Transaction details:
+- Description: {description or 'N/A'}
+- Merchant: {merchant or 'N/A'}
+- Amount: {abs(amount)} {transaction_type_str.upper()}
+- Type: {transaction_type_str}
+
+Available categories:
+{category_list}
+{account_block}{overrides_text}{instructions_text}
+Instructions:
+1. Analyze the transaction description and merchant name
+2. Select the MOST SPECIFIC category that matches
+3. {transfer_rule}4. Follow any user-specific guidelines and override patterns provided above
+5. If the transaction matches a user override pattern, use that category
+6. Respond with ONLY the exact category name from the list
+7. If no category fits well, respond with "UNKNOWN"
+
+Category name:"""
+```
+
+(The transfer rule slots in at step 3; subsequent steps renumber to 4-7.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/services/category_matcher.py backend/tests/test_category_matcher_prompt.py
+git commit -m "feat(categorizer): inject account graph and transfer rule into LLM prompt"
+```
+
+---
+
+## Task 8: Prompt-size budget cap
+
+**Files:**
+- Modify: `backend/app/services/category_matcher.py`
+- Test: `backend/tests/test_category_matcher_prompt.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```python
+def test_prompt_budget_degrades_descriptions_first():
+    m = CategoryMatcher.__new__(CategoryMatcher)
+    # Simulate oversized input: 30 categories each with a 200-char description.
+    cats = [FakeCategory(f"Cat{i}", "x" * 200) for i in range(30)]
+    m._account_cache = [FakeAccount("Acc", alias_patterns=["p1", "p2"])]
+    category_list, account_block = m._compose_prompt_context(cats)
+    assert sum(len(x) for x in (category_list, account_block)) <= 2000
+    # Descriptions dropped, but names always present
+    assert "Cat0" in category_list
+    assert "Cat29" in category_list
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py::test_prompt_budget_degrades_descriptions_first -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `_compose_prompt_context`**
+
+In `CategoryMatcher`:
+
+```python
+    PROMPT_CONTEXT_BUDGET = 2000
+
+    def _compose_prompt_context(self, relevant_categories) -> tuple[str, str]:
+        """Return (category_list, account_block) sized to fit PROMPT_CONTEXT_BUDGET.
+
+        Degradation order when over budget:
+        1. Truncate each category description to 200 chars (default).
+        2. Drop alias_patterns from accounts (keep name + ends-in).
+        3. Drop all descriptions; names only.
+        """
+        category_list = self._render_category_list(relevant_categories)
+        account_block = self._build_account_context()
+        total = len(category_list) + len(account_block)
+        if total <= self.PROMPT_CONTEXT_BUDGET:
+            return category_list, f"\n\n{account_block}\n" if account_block else ""
+
+        # Step 2: drop alias_patterns
+        if self._account_cache:
+            thin_accounts = []
+            for acc in self._account_cache:
+                identifiers = []
+                ext = (getattr(acc, "external_id", None) or "").strip()
+                if ext and len(ext) >= 4:
+                    identifiers.append(f"ends in {ext[-4:]}")
+                suffix = f" ({'; '.join(identifiers)})" if identifiers else ""
+                thin_accounts.append(f"- {acc.name}{suffix}")
+            thin_account_block = (
+                "Your accounts (transactions referencing these are internal transfers):\n"
+                + "\n".join(thin_accounts)
+            )
+        else:
+            thin_account_block = ""
+        total = len(category_list) + len(thin_account_block)
+        if total <= self.PROMPT_CONTEXT_BUDGET:
+            return category_list, f"\n\n{thin_account_block}\n" if thin_account_block else ""
+
+        # Step 3: drop all descriptions
+        name_only = "\n".join(f"- {c.name}" for c in relevant_categories)
+        return name_only, f"\n\n{thin_account_block}\n" if thin_account_block else ""
+```
+
+- [ ] **Step 4: Use it in both LLM functions**
+
+Replace the two lines:
+
+```python
+        category_list = self._render_category_list(relevant_categories)
+        account_context = self._build_account_context()
+        account_block = f"\n\n{account_context}\n" if account_context else ""
+```
+
+with:
+
+```python
+        category_list, account_block = self._compose_prompt_context(relevant_categories)
+```
+
+Note: `transfer_rule` should still check truthiness of `account_block`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/services/category_matcher.py backend/tests/test_category_matcher_prompt.py
+git commit -m "feat(categorizer): enforce 2000-char prompt budget with graceful degradation"
+```
+
+---
+
+## Task 9: Feature flag `CATEGORIZER_ENRICHED_PROMPT`
+
+**Files:**
+- Modify: `backend/app/services/category_matcher.py`
+
+- [ ] **Step 1: Add env-var gated branch**
+
+At the top of `category_matcher.py` with other module-level config:
+
+```python
+import os
+
+ENRICHED_PROMPT_ENABLED = os.getenv("CATEGORIZER_ENRICHED_PROMPT", "true").lower() == "true"
+```
+
+In both LLM prompt functions, replace:
+
+```python
+        category_list, account_block = self._compose_prompt_context(relevant_categories)
+```
+
+with:
+
+```python
+        if ENRICHED_PROMPT_ENABLED:
+            category_list, account_block = self._compose_prompt_context(relevant_categories)
+        else:
+            category_list = "\n".join(f"- {c.name}" for c in relevant_categories)
+            account_block = ""
+```
+
+And wrap the transfer-rule injection with `if ENRICHED_PROMPT_ENABLED and account_block:` instead of just `if account_context:`.
+
+- [ ] **Step 2: Add regression test**
+
+Append to `backend/tests/test_category_matcher_prompt.py`:
+
+```python
+def test_feature_flag_disabled_falls_back_to_names_only(monkeypatch, db_session):
+    import app.services.category_matcher as cm_module
+    monkeypatch.setattr(cm_module, "ENRICHED_PROMPT_ENABLED", False)
+    captured = {}
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    captured["messages"] = kwargs["messages"]
+                    return type("R", (), {
+                        "choices": [type("X", (), {"message": type("M", (), {"content": "UNKNOWN"})()})()],
+                        "usage": type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})(),
+                    })
+
+    m = cm_module.CategoryMatcher(db=db_session, user_id="ff-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    m._account_cache = [FakeAccount("Acc", alias_patterns=["p"])]
+    cats = [FakeCategory("Food", "Description here")]
+    m.match_category_llm(description="x", merchant="y", amount=-1.0, available_categories=cats)
+    prompt = captured["messages"][1]["content"]
+    assert "Description here" not in prompt
+    assert "Your accounts" not in prompt
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd backend && pytest tests/test_category_matcher_prompt.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/services/category_matcher.py backend/tests/test_category_matcher_prompt.py
+git commit -m "feat(categorizer): add CATEGORIZER_ENRICHED_PROMPT feature flag"
+```
+
+---
+
+## Task 10: End-to-end transfer-detection test with stubbed OpenAI
+
+**Files:**
+- Create: `backend/tests/test_category_matcher_llm_transfer.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Verify that with an alias-matched account, the LLM prompt steers toward the transfer category."""
+from decimal import Decimal
+
+import pytest
+
+from app.services.category_matcher import CategoryMatcher
+
+
+class FakeCategory:
+    def __init__(self, name, category_type="expense"):
+        self.name = name
+        self.category_type = category_type
+        self.description = None
+
+
+class FakeAccount:
+    def __init__(self, name, alias_patterns=None):
+        self.name = name
+        self.external_id = None
+        self.alias_patterns = alias_patterns or []
+        self.is_active = True
+
+
+def test_llm_selects_transfers_when_alias_matches(monkeypatch, db_session):
+    import app.services.category_matcher as cm_module
+    monkeypatch.setattr(cm_module, "ENRICHED_PROMPT_ENABLED", True)
+
+    class StubClient:
+        class chat:
+            class completions:
+                @staticmethod
+                def create(**kwargs):
+                    # The stub "reads" the prompt: if it mentions the alias + transfer rule,
+                    # return the transfer category name.
+                    content = kwargs["messages"][1]["content"]
+                    if "Apple Pay Top-Up by *1234" in content and "internal transfer" in content.lower():
+                        answer = "Transfers"
+                    else:
+                        answer = "UNKNOWN"
+                    return type("R", (), {
+                        "choices": [type("X", (), {"message": type("M", (), {"content": answer})()})()],
+                        "usage": type("U", (), {"prompt_tokens": 1, "completion_tokens": 1})(),
+                    })
+
+    m = CategoryMatcher(db=db_session, user_id="llm-user")
+    monkeypatch.setattr(m, "_get_openai_client", lambda: StubClient())
+    m._account_cache = [FakeAccount("Revolut Pro", alias_patterns=["Apple Pay Top-Up by *1234"])]
+    cats = [FakeCategory("Transfers", category_type="transfer"), FakeCategory("Food & Dining")]
+    result = m.match_category_llm(
+        description="Apple Pay Top-Up by *1234",
+        merchant="Revolut",
+        amount=-50.0,
+        available_categories=cats,
+    )
+    assert result == "Transfers"
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd backend && pytest tests/test_category_matcher_llm_transfer.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/test_category_matcher_llm_transfer.py
+git commit -m "test(categorizer): verify alias-matched transfer is recognized at inference time"
+```
+
+---
+
+## Task 11: Observability logs
+
+**Files:**
+- Modify: `backend/app/services/category_matcher.py`
+
+- [ ] **Step 1: Log context lengths**
+
+In both LLM prompt functions, immediately after `category_list, account_block = ...`:
+
+```python
+        logger.debug(
+            "categorizer.prompt_context chars: categories=%d accounts=%d total=%d",
+            len(category_list), len(account_block),
+            len(category_list) + len(account_block),
+        )
+        if len(category_list) + len(account_block) >= self.PROMPT_CONTEXT_BUDGET:
+            logger.info("categorizer.prompt_budget_hit user_id=%s", self.user_id)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/services/category_matcher.py
+git commit -m "chore(categorizer): log prompt-context sizes and budget hits"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: Section A (Tasks 4-5), Section B (Tasks 6-7), Section C (Tasks 1-3), Section D (Task 8), Section E (Tasks 5, 7, 10), Section F (Tasks 9, 11). ✅
+- Placeholder scan: none.
+- Type consistency: `FakeCategory`, `FakeAccount` defined in Task 4 and 6 tests; shared helpers re-declared in later test files for isolation — intentional, each test file is self-contained per the "no cross-file fixture imports" convention in this repo's tests directory.
+- `_compose_prompt_context` always returns `(category_list, account_block)`; both callers use tuple unpacking.
+- `_account_cache` initialized in `__init__`; never `None` when reached via `_build_account_context` because `_load_accounts` is called lazily.

--- a/docs/superpowers/plans/2026-04-24-mcp-categorization-audits.md
+++ b/docs/superpowers/plans/2026-04-24-mcp-categorization-audits.md
@@ -1,0 +1,1263 @@
+# MCP Tool Enhancements for Categorization Audits — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend existing MCP tools with cursor pagination, sort/filter options, audit filters, and dry-run support for bulk updates. Zero new MCP tools.
+
+**Architecture:** All changes are parameter additions to existing functions in `backend/app/mcp/tools/transactions.py` and `backend/app/mcp/tools/analytics.py`, plus matching signature updates in `backend/app/mcp/server.py`. New shared helper `_paginate_query` centralizes cursor/sort logic. Tests added in `backend/tests/`. All parameters default to current behavior (backward compatible).
+
+**Tech Stack:** Python 3.13, FastMCP, SQLAlchemy ORM, PostgreSQL, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-mcp-categorization-audits-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+- `backend/app/mcp/tools/transactions.py` — add `_paginate_query` helper; add `cursor`, `sort_by`, `account_id`, `uncategorized`, `category_type` params; upgrade `bulk_update_transaction_categories` with `dry_run` + rich response.
+- `backend/app/mcp/tools/analytics.py` — add `include_uncategorized`, `merchant_count` to `get_spending_by_category`; add `category_id`, `uncategorized` to `get_top_merchants`.
+- `backend/app/mcp/server.py` — update tool registration signatures to pass new params through.
+
+**Created:**
+- `backend/tests/test_mcp_pagination.py` — cursor/sort/filter tests for list/search tools.
+- `backend/tests/test_mcp_audit_filters.py` — SYL-31 filters.
+- `backend/tests/test_mcp_bulk_update.py` — SYL-33 dry-run + rich response.
+
+---
+
+## Task 1: Add `_paginate_query` helper and `sort_by` support to `list_transactions`
+
+**Files:**
+- Modify: `backend/app/mcp/tools/transactions.py:17-118`
+- Test: `backend/tests/test_mcp_pagination.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/test_mcp_pagination.py`:
+
+```python
+"""Tests for cursor pagination, sort_by, and account_id filter on MCP search/list tools."""
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.mcp.tools import transactions as tx_tools
+from app.models import Transaction, Account, Category, User
+
+
+@pytest.fixture
+def seeded_user(db_session):
+    """Create a user with 3 accounts and 10 transactions spanning 10 days."""
+    user = User(id="test-user-1", email="test@test.com")
+    db_session.add(user)
+    acc1 = Account(user_id=user.id, name="ABN", account_type="checking")
+    acc2 = Account(user_id=user.id, name="Revolut", account_type="checking")
+    db_session.add_all([acc1, acc2])
+    db_session.flush()
+    cat = Category(user_id=user.id, name="Food", category_type="expense")
+    db_session.add(cat)
+    db_session.flush()
+    base = datetime(2026, 4, 1)
+    for i in range(10):
+        db_session.add(Transaction(
+            user_id=user.id,
+            account_id=acc1.id if i % 2 == 0 else acc2.id,
+            amount=Decimal(f"-{(i + 1) * 10}"),
+            currency="EUR",
+            description=f"Purchase {i}",
+            merchant=f"Merchant {i}",
+            category_id=cat.id if i < 5 else None,
+            booked_at=base + timedelta(days=i),
+            transaction_type="debit",
+        ))
+    db_session.commit()
+    return user, acc1, acc2, cat
+
+
+def test_list_transactions_sort_by_amount_desc(seeded_user):
+    user, _, _, _ = seeded_user
+    result = tx_tools.list_transactions(
+        user_id=user.id, sort_by="amount_desc", limit=3
+    )
+    # amount_desc over negative expenses: -10 is largest, -100 smallest
+    amounts = [r["amount"] for r in result]
+    assert amounts == sorted(amounts, reverse=True)
+    assert len(result) == 3
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && pytest tests/test_mcp_pagination.py::test_list_transactions_sort_by_amount_desc -v`
+Expected: FAIL — `list_transactions` does not accept `sort_by`.
+
+- [ ] **Step 3: Add `_paginate_query` helper and `sort_by` parameter**
+
+At the top of `backend/app/mcp/tools/transactions.py`, below `MatchMode`:
+
+```python
+import base64
+import json
+from datetime import datetime
+
+SortBy = Literal["booked_at_desc", "booked_at_asc", "amount_desc", "amount_asc", "abs_amount_desc"]
+
+
+def _sort_expr(sort_by: SortBy):
+    """Return (primary_col, direction_func) for the given sort mode."""
+    if sort_by == "booked_at_asc":
+        return Transaction.booked_at, lambda c: c.asc()
+    if sort_by == "amount_desc":
+        return Transaction.amount, lambda c: c.desc()
+    if sort_by == "amount_asc":
+        return Transaction.amount, lambda c: c.asc()
+    if sort_by == "abs_amount_desc":
+        return func.abs(Transaction.amount), lambda c: c.desc()
+    return Transaction.booked_at, lambda c: c.desc()  # booked_at_desc default
+
+
+def _encode_cursor(primary_value, txn_id: str) -> str:
+    payload = {"v": str(primary_value), "id": txn_id}
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+
+
+def _decode_cursor(cursor: str) -> tuple[str, str]:
+    payload = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+    return payload["v"], payload["id"]
+
+
+def _paginate_query(query, cursor: Optional[str], sort_by: SortBy, limit: int):
+    """Apply sort and (optionally) cursor filter. Returns ordered, limited query."""
+    primary_col, direction = _sort_expr(sort_by)
+    if cursor:
+        try:
+            v, last_id = _decode_cursor(cursor)
+        except Exception:
+            raise ValueError("Invalid cursor")
+        # Sort-aware cursor filter: rows "after" (primary, id) tuple
+        is_desc = sort_by in ("booked_at_desc", "amount_desc", "abs_amount_desc")
+        if is_desc:
+            query = query.filter(
+                or_(primary_col < v, and_(primary_col == v, Transaction.id < last_id))
+            )
+        else:
+            query = query.filter(
+                or_(primary_col > v, and_(primary_col == v, Transaction.id > last_id))
+            )
+    return query.order_by(direction(primary_col), Transaction.id.desc()).limit(limit)
+
+
+def _build_next_cursor(rows: list, sort_by: SortBy, limit: int) -> Optional[str]:
+    if len(rows) < limit:
+        return None
+    primary_col, _ = _sort_expr(sort_by)
+    last = rows[-1]
+    # Extract raw primary value for the sort mode
+    if sort_by in ("booked_at_desc", "booked_at_asc"):
+        v = last.booked_at.isoformat()
+    elif sort_by == "abs_amount_desc":
+        v = str(abs(float(last.amount)))
+    else:
+        v = str(float(last.amount))
+    return _encode_cursor(v, str(last.id))
+```
+
+Update `list_transactions` signature and body:
+
+```python
+def list_transactions(
+    user_id: str,
+    account_id: Optional[str] = None,
+    category_id: Optional[str] = None,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    search: Optional[str] = None,
+    limit: int = 50,
+    page: int = 1,
+    cursor: Optional[str] = None,
+    sort_by: SortBy = "booked_at_desc",
+    uncategorized: bool = False,
+    category_type: Optional[Literal["expense", "income", "transfer"]] = None,
+) -> dict:
+    page = max(1, page)
+    limit = min(max(1, limit), 100)
+    account_uuid = validate_uuid(account_id) if account_id else None
+    category_uuid = validate_uuid(category_id) if category_id else None
+    from_dt = validate_date(from_date)
+    to_dt = validate_date(to_date)
+
+    with get_db() as db:
+        query = (
+            db.query(Transaction)
+            .filter(Transaction.user_id == user_id)
+            .options(joinedload(Transaction.account), joinedload(Transaction.category))
+        )
+        if account_uuid:
+            query = query.filter(Transaction.account_id == account_uuid)
+        if category_uuid:
+            query = query.filter(
+                (Transaction.category_id == category_uuid) |
+                and_(
+                    Transaction.category_id.is_(None),
+                    Transaction.category_system_id == category_uuid
+                )
+            )
+        if uncategorized:
+            query = query.filter(
+                Transaction.category_id.is_(None),
+                Transaction.category_system_id.is_(None),
+            )
+        if category_type:
+            query = query.join(
+                Category,
+                Category.id == func.coalesce(Transaction.category_id, Transaction.category_system_id),
+            ).filter(Category.category_type == category_type)
+        if from_dt:
+            query = query.filter(Transaction.booked_at >= from_dt)
+        if to_dt:
+            query = query.filter(Transaction.booked_at <= to_dt)
+        if search:
+            search_term = f"%{search[:500]}%"
+            query = query.filter(
+                or_(
+                    Transaction.description.ilike(search_term),
+                    Transaction.merchant.ilike(search_term),
+                )
+            )
+
+        if cursor:
+            paginated = _paginate_query(query, cursor, sort_by, limit)
+        else:
+            offset = (page - 1) * limit
+            primary_col, direction = _sort_expr(sort_by)
+            paginated = (
+                query.order_by(direction(primary_col), Transaction.id.desc())
+                .offset(offset)
+                .limit(limit)
+            )
+        transactions_rows = paginated.all()
+        next_cursor = _build_next_cursor(transactions_rows, sort_by, limit)
+
+        return {
+            "transactions": [
+                {
+                    "id": str(txn.id),
+                    "account_id": str(txn.account_id),
+                    "account_name": txn.account.name if txn.account else None,
+                    "amount": float(txn.amount),
+                    "currency": txn.currency,
+                    "description": txn.description,
+                    "merchant": txn.merchant,
+                    "category_id": str(txn.category_id) if txn.category_id else None,
+                    "category_system_id": str(txn.category_system_id) if txn.category_system_id else None,
+                    "category_name": txn.category.name if txn.category else None,
+                    "booked_at": txn.booked_at.isoformat() if txn.booked_at else None,
+                    "pending": txn.pending,
+                    "transaction_type": txn.transaction_type,
+                    "include_in_analytics": txn.include_in_analytics,
+                    "recurring_transaction_id": str(txn.recurring_transaction_id) if txn.recurring_transaction_id else None,
+                }
+                for txn in transactions_rows
+            ],
+            "page": page if not cursor else None,
+            "limit": limit,
+            "next_cursor": next_cursor,
+        }
+```
+
+Note: return shape changes from `list` → `dict`. Update `server.py` (see Task 5).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && pytest tests/test_mcp_pagination.py::test_list_transactions_sort_by_amount_desc -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/mcp/tools/transactions.py backend/tests/test_mcp_pagination.py
+git commit -m "feat(mcp): add sort_by and cursor pagination helper for list_transactions"
+```
+
+---
+
+## Task 2: Add cursor round-trip test for `list_transactions`
+
+**Files:**
+- Test: `backend/tests/test_mcp_pagination.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/test_mcp_pagination.py`:
+
+```python
+def test_list_transactions_cursor_round_trip(seeded_user):
+    user, _, _, _ = seeded_user
+    page1 = tx_tools.list_transactions(user_id=user.id, limit=4, sort_by="booked_at_desc")
+    assert len(page1["transactions"]) == 4
+    assert page1["next_cursor"] is not None
+
+    page2 = tx_tools.list_transactions(
+        user_id=user.id, limit=4, sort_by="booked_at_desc", cursor=page1["next_cursor"]
+    )
+    assert len(page2["transactions"]) == 4
+
+    ids_page1 = {t["id"] for t in page1["transactions"]}
+    ids_page2 = {t["id"] for t in page2["transactions"]}
+    assert ids_page1.isdisjoint(ids_page2), "Pages must not overlap"
+
+    page3 = tx_tools.list_transactions(
+        user_id=user.id, limit=4, sort_by="booked_at_desc", cursor=page2["next_cursor"]
+    )
+    # Total 10 rows, 4+4+2 = 10, final page returns fewer than limit → no next_cursor
+    assert len(page3["transactions"]) == 2
+    assert page3["next_cursor"] is None
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && pytest tests/test_mcp_pagination.py::test_list_transactions_cursor_round_trip -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/test_mcp_pagination.py
+git commit -m "test(mcp): add cursor round-trip test for list_transactions"
+```
+
+---
+
+## Task 3: Apply cursor/sort/account_id to `search_transactions`
+
+**Files:**
+- Modify: `backend/app/mcp/tools/transactions.py:217-332` (`search_transactions`)
+- Test: `backend/tests/test_mcp_pagination.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```python
+def test_search_transactions_account_id_filter(seeded_user):
+    user, acc1, acc2, _ = seeded_user
+    result = tx_tools.search_transactions(
+        user_id=user.id, query="Purchase", account_id=str(acc1.id), match_mode="contains"
+    )
+    assert result["total_count"] > 0
+    assert all(
+        # Only acc1 transactions; acc1 got even indices 0,2,4,6,8 → 5 txns
+        True for t in result["transactions"]
+    )
+    assert result["total_count"] == 5
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && pytest tests/test_mcp_pagination.py::test_search_transactions_account_id_filter -v`
+Expected: FAIL — `account_id` not a parameter.
+
+- [ ] **Step 3: Update `search_transactions` signature**
+
+Replace signature in `backend/app/mcp/tools/transactions.py:217`:
+
+```python
+def search_transactions(
+    user_id: str,
+    query: str,
+    exclude_category_id: Optional[str] = None,
+    match_mode: MatchMode = "contains",
+    ids_only: bool = False,
+    limit: int = 50,
+    page: int = 1,
+    cursor: Optional[str] = None,
+    sort_by: SortBy = "booked_at_desc",
+    account_id: Optional[str] = None,
+) -> dict:
+```
+
+Inside the function, after `exclude_cat_uuid = ...`:
+
+```python
+    account_uuid = validate_uuid(account_id) if account_id else None
+```
+
+Inside the `with get_db()` block, after building `base_filter` with `exclude_cat_uuid`:
+
+```python
+        if account_uuid:
+            base_filter = and_(base_filter, Transaction.account_id == account_uuid)
+```
+
+Replace the pagination/order block (the `.order_by(...).offset(offset).limit(limit)` chain) with:
+
+```python
+        total_count = db.query(func.count(Transaction.id)).filter(base_filter).scalar()
+        query_obj = db.query(Transaction).filter(base_filter)
+        if not ids_only:
+            query_obj = query_obj.options(
+                joinedload(Transaction.account),
+                joinedload(Transaction.category),
+            )
+        if cursor:
+            paginated = _paginate_query(query_obj, cursor, sort_by, limit)
+        else:
+            offset = (page - 1) * limit
+            primary_col, direction = _sort_expr(sort_by)
+            paginated = (
+                query_obj.order_by(direction(primary_col), Transaction.id.desc())
+                .offset(offset)
+                .limit(limit)
+            )
+        rows = paginated.all()
+        next_cursor = _build_next_cursor(rows, sort_by, limit)
+        has_more = next_cursor is not None if cursor else ((page - 1) * limit + len(rows) < total_count)
+```
+
+Replace the final return blocks to use `rows` and add `next_cursor` to both branches (ids_only and full):
+
+```python
+        if ids_only:
+            return {
+                "transaction_ids": [str(t.id) for t in rows],
+                "page": page if not cursor else None,
+                "limit": limit,
+                "has_more": has_more,
+                "total_count": total_count,
+                "next_cursor": next_cursor,
+            }
+
+        return {
+            "transactions": [
+                {
+                    "id": str(txn.id),
+                    "account_id": str(txn.account_id),
+                    "account_name": txn.account.name if txn.account else None,
+                    "amount": float(txn.amount),
+                    "currency": txn.currency,
+                    "description": txn.description,
+                    "merchant": txn.merchant,
+                    "category_id": str(txn.category_id) if txn.category_id else None,
+                    "category_name": txn.category.name if txn.category else None,
+                    "booked_at": txn.booked_at.isoformat() if txn.booked_at else None,
+                }
+                for txn in rows
+            ],
+            "page": page if not cursor else None,
+            "limit": limit,
+            "has_more": has_more,
+            "total_count": total_count,
+            "next_cursor": next_cursor,
+        }
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd backend && pytest tests/test_mcp_pagination.py::test_search_transactions_account_id_filter -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/mcp/tools/transactions.py backend/tests/test_mcp_pagination.py
+git commit -m "feat(mcp): add cursor, sort_by, account_id to search_transactions"
+```
+
+---
+
+## Task 4: Apply cursor/sort/account_id to `search_transactions_multi`
+
+**Files:**
+- Modify: `backend/app/mcp/tools/transactions.py:335-466`
+- Test: `backend/tests/test_mcp_pagination.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```python
+def test_search_multi_cursor_opt_in(seeded_user):
+    user, _, _, _ = seeded_user
+    # Default (no cursor) behavior: returns all capped results, no next_cursor
+    r1 = tx_tools.search_transactions_multi(
+        user_id=user.id, queries=["Purchase"], max_results=100
+    )
+    assert r1["total_count"] == 10
+    assert "next_cursor" not in r1 or r1.get("next_cursor") is None
+
+    # Opt-in to cursor mode via limit + cursor loop
+    r2 = tx_tools.search_transactions_multi(
+        user_id=user.id, queries=["Purchase"], max_results=4, cursor=""
+    )
+    assert len(r2["transactions"]) == 4
+    assert r2["next_cursor"] is not None
+    r3 = tx_tools.search_transactions_multi(
+        user_id=user.id, queries=["Purchase"], max_results=4, cursor=r2["next_cursor"]
+    )
+    assert len(r3["transactions"]) == 4
+    assert set(t["id"] for t in r2["transactions"]).isdisjoint(
+        set(t["id"] for t in r3["transactions"])
+    )
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && pytest tests/test_mcp_pagination.py::test_search_multi_cursor_opt_in -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `search_transactions_multi`**
+
+Replace signature (`backend/app/mcp/tools/transactions.py:335`):
+
+```python
+def search_transactions_multi(
+    user_id: str,
+    queries: list[str],
+    exclude_category_id: Optional[str] = None,
+    match_mode: MatchMode = "contains",
+    ids_only: bool = False,
+    max_results: int = 500,
+    cursor: Optional[str] = None,
+    sort_by: SortBy = "booked_at_desc",
+    account_id: Optional[str] = None,
+) -> dict:
+```
+
+After `exclude_cat_uuid = validate_uuid(...)`:
+
+```python
+    account_uuid = validate_uuid(account_id) if account_id else None
+```
+
+After `combined_filter` is built (and exclude-category is applied), before "Get total count":
+
+```python
+        if account_uuid:
+            combined_filter = and_(combined_filter, Transaction.account_id == account_uuid)
+```
+
+Replace the block that currently reads `.order_by(Transaction.booked_at.desc()).limit(max_results)` with:
+
+```python
+        query_obj = db.query(Transaction).filter(combined_filter)
+        if not ids_only:
+            query_obj = query_obj.options(
+                joinedload(Transaction.account),
+                joinedload(Transaction.category),
+            )
+
+        cursor_mode = cursor is not None  # empty-string opt-in or real cursor
+        if cursor_mode:
+            paginated = _paginate_query(query_obj, cursor or None, sort_by, max_results)
+        else:
+            primary_col, direction = _sort_expr(sort_by)
+            paginated = query_obj.order_by(direction(primary_col), Transaction.id.desc()).limit(max_results)
+        transactions_rows = paginated.all()
+        next_cursor = _build_next_cursor(transactions_rows, sort_by, max_results) if cursor_mode else None
+```
+
+Replace `transactions = query_obj.all()` → use `transactions_rows` in the result assembly. In the final result dict, add:
+
+```python
+        result["next_cursor"] = next_cursor
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd backend && pytest tests/test_mcp_pagination.py::test_search_multi_cursor_opt_in -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/app/mcp/tools/transactions.py backend/tests/test_mcp_pagination.py
+git commit -m "feat(mcp): add cursor, sort_by, account_id to search_transactions_multi"
+```
+
+---
+
+## Task 5: Update `server.py` tool registrations for new params
+
+**Files:**
+- Modify: `backend/app/mcp/server.py` — the `@mcp.tool` wrappers for `list_transactions`, `search_transactions`, `search_transactions_multi`.
+
+- [ ] **Step 1: Read current signatures**
+
+Run: `grep -n "def list_transactions\|def search_transactions\|def search_transactions_multi" backend/app/mcp/server.py`
+
+- [ ] **Step 2: Update each wrapper**
+
+For `list_transactions` wrapper in `server.py`, update signature to include the new params and forward them:
+
+```python
+@mcp.tool
+def list_transactions(
+    account_id: str | None = None,
+    category_id: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    search: str | None = None,
+    limit: int = 50,
+    page: int = 1,
+    cursor: str | None = None,
+    sort_by: str = "booked_at_desc",
+    uncategorized: bool = False,
+    category_type: str | None = None,
+    user_id: str | None = None,
+) -> dict:
+    """List transactions with optional filtering, cursor pagination, and sort."""
+    return transactions.list_transactions(
+        get_mcp_user_id(user_id), account_id, category_id, from_date, to_date, search,
+        limit, page, cursor, sort_by, uncategorized, category_type,
+    )
+```
+
+Apply the same pattern to `search_transactions` and `search_transactions_multi` wrappers — add `cursor`, `sort_by`, `account_id` and pass them through as positional/keyword args matching the underlying function signatures.
+
+- [ ] **Step 3: Run existing MCP server health test**
+
+Run: `cd backend && pytest tests/test_mcp_server_health.py -v`
+Expected: PASS (tool registration still succeeds).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/app/mcp/server.py
+git commit -m "feat(mcp): surface cursor/sort/account_id on MCP tool wrappers"
+```
+
+---
+
+## Task 6: SYL-31 — `list_transactions` `uncategorized` + `category_type` filters
+
+**Files:**
+- Test: `backend/tests/test_mcp_audit_filters.py`
+
+(Implementation already done in Task 1 — this task covers tests.)
+
+- [ ] **Step 1: Write failing test**
+
+Create `backend/tests/test_mcp_audit_filters.py`:
+
+```python
+"""Tests for SYL-31 audit filters."""
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.mcp.tools import transactions as tx_tools
+from app.mcp.tools import analytics as an_tools
+from app.models import Transaction, Account, Category, User
+
+
+@pytest.fixture
+def audit_data(db_session):
+    user = User(id="audit-user", email="audit@test.com")
+    db_session.add(user)
+    acc = Account(user_id=user.id, name="A", account_type="checking")
+    db_session.add(acc)
+    db_session.flush()
+    expense_cat = Category(user_id=user.id, name="Food", category_type="expense")
+    income_cat = Category(user_id=user.id, name="Salary", category_type="income")
+    db_session.add_all([expense_cat, income_cat])
+    db_session.flush()
+    # 3 uncategorized, 2 expense-categorized, 1 income-categorized
+    specs = [
+        (None, -10, "debit"), (None, -20, "debit"), (None, -30, "debit"),
+        (expense_cat.id, -40, "debit"), (expense_cat.id, -50, "debit"),
+        (income_cat.id, 100, "credit"),
+    ]
+    for i, (cid, amt, ttype) in enumerate(specs):
+        db_session.add(Transaction(
+            user_id=user.id,
+            account_id=acc.id,
+            amount=Decimal(str(amt)),
+            currency="EUR",
+            description=f"Txn {i}",
+            merchant=f"M{i}",
+            category_id=cid,
+            booked_at=datetime(2026, 4, 1 + i),
+            transaction_type=ttype,
+        ))
+    db_session.commit()
+    return user, acc, expense_cat, income_cat
+
+
+def test_list_transactions_uncategorized(audit_data):
+    user, *_ = audit_data
+    result = tx_tools.list_transactions(user_id=user.id, uncategorized=True, limit=50)
+    assert len(result["transactions"]) == 3
+    assert all(t["category_id"] is None for t in result["transactions"])
+
+
+def test_list_transactions_category_type(audit_data):
+    user, *_ = audit_data
+    result = tx_tools.list_transactions(user_id=user.id, category_type="expense", limit=50)
+    assert len(result["transactions"]) == 2  # Only categorized-as-expense
+    result_income = tx_tools.list_transactions(user_id=user.id, category_type="income", limit=50)
+    assert len(result_income["transactions"]) == 1
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd backend && pytest tests/test_mcp_audit_filters.py -v`
+Expected: PASS (impl is in Task 1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/test_mcp_audit_filters.py
+git commit -m "test(mcp): cover uncategorized and category_type filters on list_transactions"
+```
+
+---
+
+## Task 7: SYL-31 — `include_uncategorized` + `merchant_count` on `get_spending_by_category`
+
+**Files:**
+- Modify: `backend/app/mcp/tools/analytics.py:28-110`
+- Test: `backend/tests/test_mcp_audit_filters.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/test_mcp_audit_filters.py`:
+
+```python
+def test_spending_by_category_include_uncategorized(audit_data):
+    user, *_ = audit_data
+    # Without flag: only categorized expense rows
+    baseline = an_tools.get_spending_by_category(user_id=user.id)
+    assert all(r["category_id"] is not None for r in baseline)
+
+    enriched = an_tools.get_spending_by_category(user_id=user.id, include_uncategorized=True)
+    names = [r["category_name"] for r in enriched]
+    assert "Uncategorized" in names
+    uncat = next(r for r in enriched if r["category_name"] == "Uncategorized")
+    assert uncat["total"] == 60  # 10 + 20 + 30
+    assert uncat["count"] == 3
+    assert "merchant_count" in uncat
+    assert uncat["merchant_count"] == 3
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd backend && pytest tests/test_mcp_audit_filters.py::test_spending_by_category_include_uncategorized -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `get_spending_by_category`**
+
+In `backend/app/mcp/tools/analytics.py`, change the function signature to:
+
+```python
+def get_spending_by_category(
+    user_id: str,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    account_id: Optional[str] = None,
+    include_uncategorized: bool = False,
+) -> list[dict]:
+```
+
+Rewrite the SQL body to use a LEFT JOIN and conditionally include uncategorized rows, and add `COUNT(DISTINCT t.merchant)`:
+
+```python
+    join_type = "LEFT JOIN" if include_uncategorized else "INNER JOIN"
+    uncategorized_filter = "" if include_uncategorized else "AND c.category_type = 'expense'"
+    sql = text(f"""
+        {_get_link_group_nets_cte(user_id)}
+        SELECT
+            COALESCE(t.category_id, t.category_system_id) as category_id,
+            COALESCE(c.name, 'Uncategorized') as category_name,
+            c.color as category_color,
+            COALESCE(SUM(
+                CASE
+                    WHEN tl.link_role = 'primary' THEN
+                        CASE WHEN lgn.net_amount < 0 THEN ABS(lgn.net_amount) ELSE 0 END
+                    WHEN tl.link_role IS NOT NULL THEN 0
+                    ELSE ABS(t.amount)
+                END
+            ), 0) as total,
+            COUNT(t.id) as count,
+            COUNT(DISTINCT t.merchant) FILTER (WHERE t.merchant IS NOT NULL AND t.merchant <> '') as merchant_count
+        FROM transactions t
+        {join_type} categories c ON c.id = COALESCE(t.category_id, t.category_system_id)
+        LEFT JOIN transaction_links tl ON t.id = tl.transaction_id
+        LEFT JOIN link_group_nets lgn ON tl.group_id = lgn.group_id
+        WHERE t.user_id = '{user_id}'
+            AND t.transaction_type = 'debit'
+            AND t.include_in_analytics = true
+            {uncategorized_filter}
+            {date_filter}
+            {account_filter}
+        GROUP BY COALESCE(t.category_id, t.category_system_id), c.name, c.color
+        ORDER BY total DESC
+    """)
+```
+
+Update the result assembly (the list comprehension) to include `merchant_count`:
+
+```python
+        return [
+            {
+                "category_id": str(r.category_id) if r.category_id else None,
+                "category_name": r.category_name or "Uncategorized",
+                "category_color": r.category_color,
+                "total": float(r.total),
+                "count": r.count,
+                "merchant_count": r.merchant_count,
+            }
+            for r in results
+        ]
+```
+
+- [ ] **Step 4: Run test**
+
+Run: `cd backend && pytest tests/test_mcp_audit_filters.py::test_spending_by_category_include_uncategorized -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update server.py wrapper**
+
+In `backend/app/mcp/server.py`, find the `get_spending_by_category` wrapper and add `include_uncategorized: bool = False` to its signature, pass it through.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/mcp/tools/analytics.py backend/app/mcp/server.py backend/tests/test_mcp_audit_filters.py
+git commit -m "feat(mcp): add include_uncategorized and merchant_count to get_spending_by_category"
+```
+
+---
+
+## Task 8: SYL-31 — `category_id` + `uncategorized` filters on `get_top_merchants`
+
+**Files:**
+- Modify: `backend/app/mcp/tools/analytics.py:384-441`
+- Test: `backend/tests/test_mcp_audit_filters.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append:
+
+```python
+def test_top_merchants_category_filter(audit_data):
+    user, _, expense_cat, _ = audit_data
+    result = an_tools.get_top_merchants(user_id=user.id, category_id=str(expense_cat.id))
+    # Only the 2 expense-categorized txns (M3, M4)
+    merchants = {r["merchant"] for r in result}
+    assert merchants == {"M3", "M4"}
+
+
+def test_top_merchants_uncategorized(audit_data):
+    user, *_ = audit_data
+    result = an_tools.get_top_merchants(user_id=user.id, uncategorized=True)
+    merchants = {r["merchant"] for r in result}
+    assert merchants == {"M0", "M1", "M2"}
+
+
+def test_top_merchants_mutual_exclusion(audit_data):
+    user, _, expense_cat, _ = audit_data
+    with pytest.raises(ValueError):
+        an_tools.get_top_merchants(
+            user_id=user.id, category_id=str(expense_cat.id), uncategorized=True,
+        )
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd backend && pytest tests/test_mcp_audit_filters.py::test_top_merchants_category_filter tests/test_mcp_audit_filters.py::test_top_merchants_uncategorized tests/test_mcp_audit_filters.py::test_top_merchants_mutual_exclusion -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Update `get_top_merchants`**
+
+Replace signature:
+
+```python
+def get_top_merchants(
+    user_id: str,
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+    limit: int = 10,
+    category_id: Optional[str] = None,
+    uncategorized: bool = False,
+) -> list[dict]:
+```
+
+Add validation at top of function body:
+
+```python
+    if category_id and uncategorized:
+        raise ValueError("category_id and uncategorized are mutually exclusive")
+    cat_uuid = validate_uuid(category_id) if category_id else None
+```
+
+Inside the `with get_db()` block, after the initial `query.filter(...)`:
+
+```python
+        if cat_uuid:
+            query = query.filter(
+                or_(
+                    Transaction.category_id == cat_uuid,
+                    and_(
+                        Transaction.category_id.is_(None),
+                        Transaction.category_system_id == cat_uuid,
+                    ),
+                )
+            )
+        if uncategorized:
+            query = query.filter(
+                Transaction.category_id.is_(None),
+                Transaction.category_system_id.is_(None),
+            )
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && pytest tests/test_mcp_audit_filters.py -v`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Update server.py wrapper**
+
+In `backend/app/mcp/server.py`, update `get_top_merchants` wrapper signature to include `category_id: str | None = None, uncategorized: bool = False` and pass them through.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/mcp/tools/analytics.py backend/app/mcp/server.py backend/tests/test_mcp_audit_filters.py
+git commit -m "feat(mcp): add category_id and uncategorized filters to get_top_merchants"
+```
+
+---
+
+## Task 9: SYL-33 — dry_run + rich response on `bulk_update_transaction_categories`
+
+**Files:**
+- Modify: `backend/app/mcp/tools/transactions.py:538-605`
+- Test: `backend/tests/test_mcp_bulk_update.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `backend/tests/test_mcp_bulk_update.py`:
+
+```python
+"""Tests for SYL-33: dry_run and rich response on bulk_update_transaction_categories."""
+from datetime import datetime
+from decimal import Decimal
+
+import pytest
+
+from app.mcp.tools import transactions as tx_tools
+from app.models import Transaction, Account, Category, User
+
+
+@pytest.fixture
+def bulk_data(db_session):
+    user = User(id="bulk-user", email="bulk@test.com")
+    other_user = User(id="other-user", email="other@test.com")
+    db_session.add_all([user, other_user])
+    acc = Account(user_id=user.id, name="A", account_type="checking")
+    other_acc = Account(user_id=other_user.id, name="B", account_type="checking")
+    db_session.add_all([acc, other_acc])
+    db_session.flush()
+    target = Category(user_id=user.id, name="Groceries", category_type="expense")
+    other_cat = Category(user_id=user.id, name="Other", category_type="expense")
+    db_session.add_all([target, other_cat])
+    db_session.flush()
+    # 3 to update, 1 already in target, 1 belongs to other user
+    t1 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-10"),
+                     currency="EUR", description="D1", merchant="M1",
+                     category_id=other_cat.id, booked_at=datetime(2026, 4, 1),
+                     transaction_type="debit")
+    t2 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-20"),
+                     currency="EUR", description="D2", merchant="M2",
+                     category_id=other_cat.id, booked_at=datetime(2026, 4, 2),
+                     transaction_type="debit")
+    t3 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-30"),
+                     currency="EUR", description="D3", merchant="M3",
+                     category_id=None, booked_at=datetime(2026, 4, 3),
+                     transaction_type="debit")
+    t4 = Transaction(user_id=user.id, account_id=acc.id, amount=Decimal("-40"),
+                     currency="EUR", description="D4", merchant="M4",
+                     category_id=target.id, booked_at=datetime(2026, 4, 4),
+                     transaction_type="debit")
+    t5 = Transaction(user_id=other_user.id, account_id=other_acc.id, amount=Decimal("-50"),
+                     currency="EUR", description="D5", merchant="M5",
+                     category_id=other_cat.id, booked_at=datetime(2026, 4, 5),
+                     transaction_type="debit")
+    db_session.add_all([t1, t2, t3, t4, t5])
+    db_session.commit()
+    return user, target, [t1, t2, t3, t4, t5]
+
+
+def test_bulk_update_dry_run_no_mutation(bulk_data, db_session):
+    user, target, txns = bulk_data
+    ids = [str(t.id) for t in txns[:3]]
+    result = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id),
+        transaction_ids=ids, dry_run=True,
+    )
+    assert result["success"] is True
+    assert result["would_update_count"] == 3
+    assert result["requested_count"] == 3
+    assert len(result["sample_changes"]) == 3
+    assert result["sample_changes"][0]["description"] in ("D1", "D2", "D3")
+    # Verify DB untouched
+    for t in txns[:3]:
+        db_session.refresh(t)
+        assert t.category_id != target.id
+
+
+def test_bulk_update_rich_response_categorizes_ids(bulk_data):
+    user, target, txns = bulk_data
+    bogus = "00000000-0000-0000-0000-000000000000"
+    ids = [str(txns[0].id), str(txns[3].id), str(txns[4].id), bogus, "not-a-uuid"]
+    result = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id), transaction_ids=ids,
+    )
+    assert result["success"] is True
+    assert result["updated_count"] == 1  # only txns[0] is actually changed
+    assert result["requested_count"] == 5
+    assert result["invalid_ids"] == ["not-a-uuid"]
+    assert bogus in result["not_found_ids"] or str(txns[4].id) in result["not_found_ids"]
+    assert str(txns[3].id) in result["skipped_already_in_category_ids"]
+
+
+def test_bulk_update_hard_cap():
+    result = tx_tools.bulk_update_transaction_categories(
+        user_id="x", category_id="00000000-0000-0000-0000-000000000001",
+        transaction_ids=[f"id-{i}" for i in range(2001)],
+    )
+    assert result["success"] is False
+    assert "2000" in result["error"]
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd backend && pytest tests/test_mcp_bulk_update.py -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Replace `bulk_update_transaction_categories`**
+
+Replace the function (`backend/app/mcp/tools/transactions.py:538`):
+
+```python
+def bulk_update_transaction_categories(
+    user_id: str,
+    category_id: str,
+    transaction_ids: list[str],
+    dry_run: bool = False,
+) -> dict:
+    """
+    Bulk update category for multiple transactions.
+
+    Args:
+        user_id: The user's ID
+        category_id: The category ID to assign
+        transaction_ids: List of transaction IDs to update (max 2000)
+        dry_run: If True, preview the change without committing
+
+    Returns:
+        Dict with success flag and:
+        - updated_count (or would_update_count if dry_run)
+        - requested_count, invalid_ids, not_found_ids,
+          skipped_already_in_category_ids, sample_changes
+    """
+    MAX_IDS = 2000
+    if not transaction_ids:
+        return {"success": False, "error": "Must provide transaction_ids"}
+    if len(transaction_ids) > MAX_IDS:
+        return {
+            "success": False,
+            "error": f"Too many transaction_ids ({len(transaction_ids)}). Max {MAX_IDS} per call.",
+        }
+
+    cat_uuid = validate_uuid(category_id)
+    if not cat_uuid:
+        return {"success": False, "error": "Invalid category ID format"}
+
+    with get_db() as db:
+        category = db.query(Category).filter(
+            Category.id == cat_uuid, Category.user_id == user_id,
+        ).first()
+        if not category:
+            return {"success": False, "error": "Category not found"}
+
+        valid_uuids = []
+        invalid_ids = []
+        for tid in transaction_ids:
+            u = validate_uuid(tid)
+            if u:
+                valid_uuids.append(u)
+            else:
+                invalid_ids.append(tid)
+
+        found = db.query(Transaction).filter(
+            Transaction.user_id == user_id,
+            Transaction.id.in_(valid_uuids),
+        ).options(joinedload(Transaction.category)).all() if valid_uuids else []
+
+        found_by_id = {str(t.id): t for t in found}
+        not_found_ids = [str(u) for u in valid_uuids if str(u) not in found_by_id]
+
+        to_change = []
+        skipped_already = []
+        for t in found:
+            if t.category_id == cat_uuid:
+                skipped_already.append(str(t.id))
+            else:
+                to_change.append(t)
+
+        sample_changes = [
+            {
+                "id": str(t.id),
+                "description": t.description,
+                "merchant": t.merchant,
+                "amount": float(t.amount),
+                "previous_category_name": t.category.name if t.category else None,
+            }
+            for t in to_change[:10]
+        ]
+
+        base_response = {
+            "success": True,
+            "category_name": category.name,
+            "requested_count": len(transaction_ids),
+            "invalid_ids": invalid_ids,
+            "not_found_ids": not_found_ids,
+            "skipped_already_in_category_ids": skipped_already,
+            "sample_changes": sample_changes,
+        }
+
+        if dry_run:
+            base_response["would_update_count"] = len(to_change)
+            return base_response
+
+        try:
+            change_uuids = [t.id for t in to_change]
+            updated = 0
+            if change_uuids:
+                updated = db.query(Transaction).filter(
+                    Transaction.user_id == user_id,
+                    Transaction.id.in_(change_uuids),
+                ).update({Transaction.category_id: cat_uuid}, synchronize_session=False)
+                db.commit()
+        except Exception as e:
+            db.rollback()
+            return {"success": False, "error": f"Database error: {str(e)}"}
+
+        base_response["updated_count"] = updated
+        return base_response
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && pytest tests/test_mcp_bulk_update.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update server.py wrapper**
+
+In `backend/app/mcp/server.py`, update `bulk_update_transaction_categories` wrapper to add `dry_run: bool = False` parameter and pass it through.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/app/mcp/tools/transactions.py backend/app/mcp/server.py backend/tests/test_mcp_bulk_update.py
+git commit -m "feat(mcp): add dry_run and rich response to bulk_update_transaction_categories"
+```
+
+---
+
+## Task 10: Integration test — dry-run then real-run parity
+
+**Files:**
+- Test: `backend/tests/test_mcp_bulk_update.py`
+
+- [ ] **Step 1: Append test**
+
+```python
+def test_bulk_update_dry_run_matches_real_run(bulk_data):
+    user, target, txns = bulk_data
+    ids = [str(t.id) for t in txns[:3]]
+
+    preview = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id),
+        transaction_ids=ids, dry_run=True,
+    )
+    real = tx_tools.bulk_update_transaction_categories(
+        user_id=user.id, category_id=str(target.id), transaction_ids=ids,
+    )
+
+    assert preview["would_update_count"] == real["updated_count"]
+    preview_ids = {s["id"] for s in preview["sample_changes"]}
+    real_ids = {s["id"] for s in real["sample_changes"]}
+    assert preview_ids == real_ids
+```
+
+- [ ] **Step 2: Run**
+
+Run: `cd backend && pytest tests/test_mcp_bulk_update.py::test_bulk_update_dry_run_matches_real_run -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/tests/test_mcp_bulk_update.py
+git commit -m "test(mcp): verify dry-run and real-run produce matching previews"
+```
+
+---
+
+## Task 11: Update MCP server instructions (docstring)
+
+**Files:**
+- Modify: `backend/app/mcp/server.py` — `instructions=` string in `FastMCP(...)`.
+
+- [ ] **Step 1: Add a "Pagination & sort" section**
+
+In `backend/app/mcp/server.py`, extend the `instructions=` triple-quoted block with:
+
+```
+## Pagination & sort
+
+All list/search tools accept:
+- `cursor` (opaque string) — preferred for paging through large result sets; pass
+  `next_cursor` from the previous response.
+- `sort_by`: one of `booked_at_desc` (default), `booked_at_asc`, `amount_desc`,
+  `amount_asc`, `abs_amount_desc`.
+- `account_id` — limit to a single account.
+
+## Audit filters
+
+- `list_transactions(uncategorized=True)` — only rows with no category at all.
+- `list_transactions(category_type="expense"|"income"|"transfer")` — filter by type.
+- `get_spending_by_category(include_uncategorized=True)` — include an
+  "Uncategorized" bucket with `merchant_count`.
+- `get_top_merchants(category_id=...)` or `get_top_merchants(uncategorized=True)` —
+  audit miscategorized or unassigned merchants.
+
+## Safe bulk updates
+
+`bulk_update_transaction_categories(dry_run=True)` returns what *would* change
+(`would_update_count`, `sample_changes`) without mutating. Hard cap: 2000 IDs
+per call. Response also includes `invalid_ids`, `not_found_ids`, and
+`skipped_already_in_category_ids` so the agent can narrate exactly what
+happened.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/app/mcp/server.py
+git commit -m "docs(mcp): advertise new pagination, audit, and bulk-update options to agents"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: SYL-30 (Tasks 1-5), SYL-31 (Tasks 6-8), SYL-33 (Tasks 9-10), docs (Task 11). ✅
+- Backward compatibility: `list_transactions` return shape changed from list → dict — breaking. Callers must be migrated. The only live caller is `server.py` (updated in Task 5).
+- Placeholder scan: none.
+- Type consistency: `SortBy` defined once in `transactions.py`, referenced elsewhere.
+- Cursor semantics: `_paginate_query` always applies a deterministic `(primary_col, id)` ordering; `_build_next_cursor` returns `None` when result count < limit, matching test expectations.

--- a/docs/superpowers/specs/2026-04-24-ai-categorizer-prompt-enrichment-design.md
+++ b/docs/superpowers/specs/2026-04-24-ai-categorizer-prompt-enrichment-design.md
@@ -1,0 +1,117 @@
+# AI Categorizer Prompt Enrichment
+
+**Date:** 2026-04-24
+**Tickets:** SYL-29 (pipeline piece), SYL-32 (prompt piece)
+**Status:** Draft
+
+## Context
+
+The LLM categorizer in `backend/app/services/category_matcher.py` builds its prompt with category **names only** and no awareness of the user's own accounts. Two classes of failure follow:
+
+- **SYL-32** — Custom categories like "Side Projects" and Greek transliterations like "Efood" / "Sklavenitis" / "Paradosiako" have no training signal, so they consistently land in "Other Expenses".
+- **SYL-29** — Internal transfers (~1,000 transactions, €200K+ in movement) are systematically miscategorized. The post-hoc `InternalTransferService` catches pair-matched cases but misses single-sided references like `Apple Pay Top-Up by *1234` or `Revo Pro`, because the AI at inference time has no knowledge of the user's account graph.
+
+Both problems are solved at the same surface: the prompt that goes into `match_category_llm` and `_match_category_llm_with_details`.
+
+## Goals
+
+- Give the LLM enough context to pick custom and non-English categories correctly on first pass.
+- Catch single-sided internal transfers at inference time, without replacing the existing post-hoc pair-matcher.
+- Keep changes minimal, additive, and safely bounded in prompt size.
+
+## Non-Goals
+
+- Retroactive recategorization of existing transactions (a separate one-off migration, not this spec).
+- Changes to `InternalTransferService` post-hoc pair matching — it continues to run and remains complementary.
+- Embedding-based retrieval (SYL-28, deferred).
+- UI for editing `alias_patterns` (separate follow-up ticket).
+
+## Design
+
+### Section A — SYL-32: Pass category descriptions to the LLM
+
+**File touched:** `backend/app/services/category_matcher.py`, functions `match_category_llm` (line ~683) and `_match_category_llm_with_details` (line ~842).
+
+Replace the flat category list:
+
+```
+- Side Projects
+- Food & Dining
+- Other Expenses
+```
+
+with a description-enriched list:
+
+```
+- Side Projects — Tools and services for personal side projects (Cloudflare, Framer, Moneybird, GitHub, OpenAI API)
+- Food & Dining — Restaurants, takeaway, and groceries (Efood, Paradosiako, Sklavenitis)
+- Other Expenses — Use only as a last resort when no other category fits
+```
+
+Descriptions are read from the existing `Category.description` column (surfaced via `list_categories`, editable via `update_category`). Truncate each description to **200 chars** before emission. If a description is empty, emit the category name alone — preserves current behavior.
+
+### Section B — SYL-29: Inject account graph into the prompt
+
+**File touched:** same file, same two functions. New private helper `_build_account_context(self) -> str`.
+
+Before the `Instructions` block, insert a "Your accounts" section listing the user's own accounts with enough identifying metadata for the LLM to spot references, and add one explicit rule to the numbered instructions:
+
+> If the transaction description, merchant, or counterparty references any of the accounts listed in "Your accounts", the transaction is an **internal transfer** — choose the transfer category.
+
+Block format:
+
+```
+Your accounts (transactions referencing these are internal transfers):
+- ABN AMRO checking (ends in 6789)
+- Revolut Pro (patterns: "Apple Pay Top-Up by *1234", "Revo Pro", "Nlov*")
+- Wise EUR (ends in 4321)
+```
+
+The helper queries `Account` for `self.user_id`, caches results on the service instance analogous to `_category_cache`, and formats each row from: `Account.name`, last-4 of account number where available, and the new `alias_patterns` field (Section C). Accounts with no distinguishing metadata contribute `name` only.
+
+### Section C — Data model addition
+
+- **Migration:** add `alias_patterns JSONB NOT NULL DEFAULT '[]'::jsonb` to the `accounts` table. Uses Alembic (see existing `backend/postgres_migration/` conventions).
+- **Model:** add `alias_patterns: Mapped[list[str]]` to `Account` in `backend/app/models.py` with `default=list`.
+- **Schema:** expose in `AccountRead` / `AccountUpdate` Pydantic schemas.
+- **API surface:** allow updating `alias_patterns` via the existing account update endpoint.
+- **No dedicated UI** in this spec.
+
+### Section D — Prompt budget & safety
+
+Cap total injected dynamic context (category descriptions + account block) at **~2000 characters**. If over budget, degrade gracefully:
+
+1. Truncate each description to 200 chars (baseline).
+2. If still over budget, drop alias pattern lists (keep account name + last-4 only).
+3. If still over budget, drop descriptions entirely and fall back to current behavior.
+
+Category names and the transfer-detection rule are always present — they are the load-bearing additions.
+
+### Section E — Testing
+
+New tests under `backend/tests/`:
+
+- `test_category_matcher_prompt.py`:
+  - `_build_account_context` with: no accounts, accounts without last-4, accounts with `alias_patterns`, accounts with both.
+  - Assembled prompt contains each category's description when present.
+  - Assembled prompt contains "Your accounts" block when accounts exist, and the transfer rule line.
+  - Snapshot test of the full prompt for a representative input — makes future phrasing changes intentional.
+  - Prompt budget: when >2000 chars of context, degradation order matches Section D.
+- `test_category_matcher_llm_transfer.py`:
+  - Stub OpenAI client; synthetic transaction `"Apple Pay Top-Up by *1234"` with a matching account alias → transfer category selected.
+
+### Section F — Rollout
+
+- Feature-flag behind an env var `CATEGORIZER_ENRICHED_PROMPT=true` (default true in dev, opt-in in prod for one release cycle), so regressions can be reverted without redeploy.
+- Log prompt length and injected-context length at DEBUG; add a counter for prompts that hit the 2000-char budget cap.
+
+## Open Questions
+
+None at present.
+
+## References
+
+- `backend/app/services/category_matcher.py` — prompt assembly in `match_category_llm` (line ~683) and `_match_category_llm_with_details` (line ~842).
+- `backend/app/services/internal_transfer_service.py` — complementary post-hoc pair matcher, unchanged.
+- `backend/app/models.py` — `Account` and `Category` models.
+- Commit `d09639f` — `update_category` MCP tool, write path for `Category.description`.

--- a/docs/superpowers/specs/2026-04-24-mcp-categorization-audits-design.md
+++ b/docs/superpowers/specs/2026-04-24-mcp-categorization-audits-design.md
@@ -1,0 +1,96 @@
+# MCP Tool Enhancements for Categorization Audits
+
+**Date:** 2026-04-24
+**Tickets:** SYL-30, SYL-31, SYL-33
+**Status:** Draft
+
+## Context
+
+Bulk categorization sessions on the Syllogic MCP server have surfaced three classes of friction:
+
+- **SYL-30** — `search_transactions_multi` silently truncates at 1000 rows with no pagination. Existing `list_transactions` / `search_transactions` have no sort capability and `search_transactions_multi` has no `account_id` filter.
+- **SYL-31** — There is no first-class way to audit miscategorized data. Agents cannot easily ask "what are the biggest items in Other Expenses?" or "which merchants appear most without a category?" via existing tools.
+- **SYL-33** — `bulk_update_transaction_categories` mutates immediately with no preview, no undo, and the response drops silently-invalid IDs in some cases.
+
+SYL-32's MCP write path and SYL-34 are already handled by the `update_category` tool shipped in commit d09639f. SYL-29 and SYL-32's pipeline piece are deferred to Spec 2 (AI categorizer).
+
+## Goals
+
+- Safer and more efficient bulk categorization audits and updates.
+- **Zero new MCP tools.** Every change is a parameter addition to an existing tool.
+- Fully backward compatible — existing agent call signatures continue to work unchanged.
+
+## Non-Goals
+
+- Embedding-based categorization (SYL-28).
+- Category editing via MCP (already shipped).
+- AI categorizer prompt changes (Spec 2).
+
+## Design
+
+### Section A — SYL-30: Cursor pagination, sort_by, account_id filter
+
+**Tools touched:** `search_transactions`, `search_transactions_multi`, `list_transactions` (all in `backend/app/mcp/tools/transactions.py`).
+
+1. **Cursor pagination — additive.** Add `cursor: Optional[str]` param alongside existing `page` param on `search_transactions` and `list_transactions`. When `cursor` is provided, `page` is ignored. The cursor is an opaque base64-encoded `(booked_at_iso, id_uuid)` tuple that is stable under concurrent inserts. On `search_transactions_multi`, which has no pagination today, cursor mode is opt-in: default behavior (return up to `max_results` capped at 1000) is preserved.
+2. **`sort_by` on all three tools.** `Literal["booked_at_desc", "booked_at_asc", "amount_desc", "amount_asc", "abs_amount_desc"]`. Default: `booked_at_desc` — preserves current behavior. The cursor payload encodes the sort key's value plus the UUID tiebreaker to guarantee deterministic pagination across any sort order.
+3. **`account_id` filter on `search_transactions` and `search_transactions_multi`.** `list_transactions` already has it.
+4. **Response shape.** Add `next_cursor: Optional[str]` to the response. Present iff more results exist under the current filter/sort. Existing `page`, `has_more`, `total_count` fields remain for callers using page mode.
+
+**Shared helper.** A new internal `_paginate_query(query, cursor, sort_by, limit)` function in `transactions.py` used by all three tools. Eliminates duplicated sort/cursor logic and keeps behavior identical.
+
+### Section B — SYL-31: Audit filters
+
+**Tools touched:** `list_transactions`, `get_spending_by_category`, `get_top_merchants`.
+
+1. **`list_transactions`:**
+   - `uncategorized: bool = False` — matches rows where both `category_id IS NULL` and `category_system_id IS NULL`.
+   - `category_type: Optional[Literal["expense", "income", "transfer"]]` — joins on `Category.category_type` through either `category_id` or `category_system_id`.
+2. **`get_spending_by_category`:**
+   - `include_uncategorized: bool = False` — switches the inner-join on categories to a left-join and surfaces null-category rows as `{category_id: null, category_name: "Uncategorized", ...}`.
+   - Every row gains `merchant_count` (distinct non-null merchants in that category).
+3. **`get_top_merchants`:**
+   - `category_id: Optional[str]` — scope to a single category (e.g., "top merchants in Other Expenses").
+   - `uncategorized: bool = False` — top merchants that have no category assigned. Mutually exclusive with `category_id`; return error if both are set.
+
+Together these deliver the two core audit queries ("biggest miscategorized items" and "most frequent uncategorized merchants") without adding a new tool.
+
+### Section C — SYL-33: Dry-run and improved response on bulk_update
+
+**Tool touched:** `bulk_update_transaction_categories`.
+
+1. **`dry_run: bool = False`.** When true, run the same WHERE query the mutation would use and return exactly what *would* change, without committing. No DB write.
+2. **Response upgrade**, applied to both dry-run and real-run:
+   - `updated_count` (or `would_update_count` when `dry_run=true`)
+   - `requested_count` — number of IDs the caller passed
+   - `invalid_ids: list[str]` — malformed UUIDs (already present)
+   - `not_found_ids: list[str]` — valid UUIDs that don't belong to the caller's transactions (**new**; previously silently dropped)
+   - `skipped_already_in_category_ids: list[str]` — IDs already assigned to the target category (**new**; no-op updates)
+   - `sample_changes: list[{id, description, merchant, amount, previous_category_name}]` — up to 10 entries, for agent transparency before/after confirmation
+3. **Hard cap.** `max 2000 transaction_ids per call`. Return a clear error if exceeded. Protects against runaway miscategorizations during a single agent session.
+
+### Section D — Testing
+
+- Unit tests per tool covering:
+  - Cursor round-trip (first page → `next_cursor` → second page → no overlap, no gap).
+  - Each `sort_by` ordering on a seeded transaction set.
+  - `uncategorized` filter excludes system-assigned categories only when both `category_id` and `category_system_id` are null.
+  - `dry_run` preview matches what a subsequent real run actually changes.
+- Integration test in `tests/test_mcp_bulk_update.py` that seeds ~50 transactions with mixed valid/invalid/foreign/same-category IDs and asserts every response field is populated correctly for both dry-run and real-run.
+
+### Section E — Backward compatibility
+
+- All new parameters default to the existing behavior. No call signature changes.
+- Response objects gain new fields; no fields are removed or renamed.
+- Docstrings updated with usage examples so agents discover the new params. The MCP server's tool description is the documentation surface.
+
+## Open Questions
+
+None at present.
+
+## References
+
+- `backend/app/mcp/tools/transactions.py`
+- `backend/app/mcp/tools/categories.py`
+- `backend/app/mcp/tools/analytics.py`
+- Commit `d09639f` — `update_category` (prior work that resolved SYL-34 and SYL-32's MCP-write piece).

--- a/frontend/lib/db/migrations/0018_add_alias_patterns.manual.sql
+++ b/frontend/lib/db/migrations/0018_add_alias_patterns.manual.sql
@@ -1,0 +1,6 @@
+-- Add alias_patterns JSONB column to accounts table.
+-- Used by the AI categorizer to detect internal transfers via account aliases.
+-- Hand-authored; applied via scripts/migrate.js (.manual.sql runner).
+
+ALTER TABLE "accounts"
+  ADD COLUMN IF NOT EXISTS "alias_patterns" jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -224,6 +224,7 @@ export const accounts = pgTable(
     functionalBalance: decimal("functional_balance", { precision: 15, scale: 2 }), // Calculated balance (sum of transactions + starting_balance)
     balanceIsAnchored: boolean("balance_is_anchored").default(false), // True when startingBalance is derived from known bank data (CSV with verified opening/closing balance)
     isActive: boolean("is_active").default(true),
+    aliasPatterns: jsonb("alias_patterns").$type<string[]>().default([]).notNull(),
     lastSyncedAt: timestamp("last_synced_at"),
     createdAt: timestamp("created_at").defaultNow(),
     updatedAt: timestamp("updated_at").defaultNow(),


### PR DESCRIPTION
## Summary

- **MCP pagination & sort** — `list_transactions` gains cursor-based pagination with `booked_at_asc/desc`, `amount_asc/desc`, `abs_amount_desc` sort modes; `search_transactions` and `search_transactions_multi` gain the same cursor opt-in plus `account_id` filtering
- **MCP audit filters** — `list_transactions` gains `uncategorized` and `category_type` filters; `get_spending_by_category` gains `include_uncategorized` + `merchant_count`; `get_top_merchants` gains `category_id`, `uncategorized`, and mutual-exclusion guard; `bulk_update_transaction_categories` gains `dry_run` preview mode
- **AI categorizer prompt enrichment** — LLM prompt now includes category descriptions (truncated to 200 chars), account graph for transfer detection, dynamic transfer rule, feature-flagged via `CATEGORIZER_ENRICHED_PROMPT`; 5-stage budget degradation guarantees output ≤ 2000 chars
- **Account `alias_patterns`** — new JSONB column on `Account`, idempotent migration, exposed on read/update schemas and in `get_account` / `list_accounts` MCP tools
- **Bug fixes** — direction-aware id tie-breaker in cursor pagination (prevented data loss on ascending sorts), corrected `capped` semantics in search_multi, dynamic instruction numbering when no accounts present

## Test Plan
- [ ] `pytest tests/test_mcp_pagination.py` — cursor round-trips including ties, amount_asc, abs_amount_desc
- [ ] `pytest tests/test_mcp_audit_filters.py` — uncategorized/category_type filters, category_system_id edge case
- [ ] `pytest tests/test_category_matcher_prompt.py` — prompt enrichment, budget degradation, feature flag
- [ ] `pytest tests/test_mcp_bulk_update.py` — dry_run preview
- [ ] Apply `postgres_migration/add_alias_patterns.sql` on staging before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cursor pagination, sorting, and audit filters to MCP transaction tools, and enriches the categorizer prompt with category descriptions and account aliases to better detect transfers. Introduces `alias_patterns` on accounts and dry-run bulk updates. Addresses SYL‑30/31/33 and SYL‑29/32.

- **New Features**
  - Cursor pagination + `sort_by` on `list_transactions`, `search_transactions`, `search_transactions_multi` (booked_at asc/desc, amount asc/desc, abs_amount_desc); `account_id` filter (SYL‑30).
  - Audit filters (SYL‑31):
    - `list_transactions`: `uncategorized`, `category_type`.
    - `get_spending_by_category`: `include_uncategorized`, `merchant_count`.
    - `get_top_merchants`: `category_id` or `uncategorized` (mutually exclusive).
  - `bulk_update_transaction_categories`: `dry_run` preview with rich response and 2,000‑ID cap (SYL‑33).
  - Categorizer prompt (SYL‑29/SYL‑32):
    - Includes truncated category descriptions and account graph for transfer detection.
    - Feature flag `CATEGORIZER_ENRICHED_PROMPT`; prompt budget ≤ 2000 chars with staged degradation.
  - Accounts: new `alias_patterns` JSONB; exposed in schemas, REST, and in `get_account` / `list_accounts`. Run `backend/postgres_migration/add_account_alias_patterns.py`.

- **Bug Fixes**
  - Direction‑aware ID tie‑breaker in cursor pagination; encode Decimal amounts as strings in cursors to avoid precision loss.
  - `get_spending_by_category(include_uncategorized=True)` keeps expense filter for categorized rows.
  - `search_transactions_multi` capped semantics and `account_id` handling in counts.
  - Stable instruction numbering in the categorizer; prompt budget accounting includes wrapper chars to always fit ≤ 2000.
  - REST accounts serialization returns stored `alias_patterns`; add Drizzle migration and frontend schema update for `alias_patterns`.

<sup>Written for commit 475d0c67d325a6ce0aa4ac36962c554fc407bb9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

