### PR TITLE
chore: diagnostic logging for EB creditor/debtor IBAN

### DIFF
--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -149,10 +149,13 @@ class EnableBankingAdapter(BankAdapter):
             ])
             external_id = "synth-" + _hashlib.sha256(_parts.encode()).hexdigest()[:16]
 
-        # Log raw text fields to debug missing descriptions (TEMPORARY - remove after diagnosis)
+        # Log raw text fields to debug missing descriptions (TEMPORARY - remove after diagnosis).
+        # Also includes creditor_account / debtor_account / extracted IBAN so we can verify
+        # whether ABN AMRO populates the structured account-IBAN field per the EB spec.
         _log.info(
             "[EB_DEBUG] txn=%s amount=%s fields: riu=%r riua=%r ri=%r ai=%r note=%r refnum=%r "
-            "cn=%r dn=%r creditor=%r debtor=%r keys=%s",
+            "cn=%r dn=%r creditor=%r debtor=%r creditor_account=%r debtor_account=%r "
+            "extracted_creditor_iban=%r extracted_debtor_iban=%r keys=%s",
             external_id,
             amount,
             raw.get("remittance_information_unstructured"),
@@ -165,6 +168,10 @@ class EnableBankingAdapter(BankAdapter):
             raw.get("debtor_name"),
             raw.get("creditor"),
             raw.get("debtor"),
+            raw.get("creditor_account"),
+            raw.get("debtor_account"),
+            _extract_iban(raw.get("creditor_account")) or _extract_iban(raw.get("creditor")),
+            _extract_iban(raw.get("debtor_account")) or _extract_iban(raw.get("debtor")),
             sorted(raw.keys()),
         )
 


### PR DESCRIPTION
## Summary

Temporary diagnostic. Extends the existing \`[EB_DEBUG]\` log line in \`enable_banking_adapter.py\` to print:
- \`creditor_account\` and \`debtor_account\` objects (currently the keys are listed but values aren't logged)
- The IBAN that \`_extract_iban\` actually pulls from each side

## Why

Verifying that ABN AMRO's EB integration populates \`creditor_account.iban\` per the EB spec. Per the API docs (https://enablebanking.com/docs/api/reference) the field is documented:
\`\`\`json
"creditor_account": { "iban": "FI0455231152453547" }
\`\`\`
But our current logs only show the parent \`creditor\` object (which only has \`name\`/\`postal_address\`), so we can't tell from existing data whether the structured account-IBAN field is populated.

## Plan after merge

1. Redeploy worker
2. User triggers a sync on ABN connection
3. Read the next \`[EB_DEBUG]\` log lines — confirm \`extracted_creditor_iban\` / \`extracted_debtor_iban\` are non-null for SEPA transfer transactions
4. If non-null → pocket detection works as designed
5. If null → we need a fallback that parses IBANs from \`remittance_information\` text (e.g. \`'IBAN: NL23ABNA0126656150'\`)

Either way, this log will be removed after diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add temporary diagnostic logging to [EB_DEBUG] in `enable_banking_adapter.py` to print `creditor_account`/`debtor_account` and the IBAN extracted for each side. This verifies whether ABN AMRO’s Enable Banking integration sets `creditor_account.iban` per the spec; no behavior changes.

<sup>Written for commit a0f64010498c01cf936c513a36612ce984319b61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

