### PR TITLE
fix(transfers): redact raw IBAN hashes from collision warning

### DIFF
--- a/backend/app/services/internal_transfer_service.py
+++ b/backend/app/services/internal_transfer_service.py
@@ -65,12 +65,14 @@ class InternalTransferService:
             else:
                 seen[h] = a
         if duplicates:
+            # Don't log raw hashes — they're pseudo-identifiers tied to a
+            # specific encryption key and shouldn't end up in log aggregators.
+            # Counts + user context are enough to investigate.
             logger.warning(
                 "[INTERNAL_TRANSFER] %d IBAN hash(es) map to multiple accounts "
-                "for user %s — those hashes will be skipped to avoid mis-routing: %s",
+                "for user %s — those hashes will be skipped to avoid mis-routing",
                 len(duplicates),
                 self.user_id,
-                duplicates,
             )
         return {h: a for h, a in seen.items() if h not in duplicates}
 


### PR DESCRIPTION
## Summary

Addresses cubic P2 finding on PR #89's duplicate-IBAN-hash safety guard in \`InternalTransferService._load_user_account_iban_map\`.

The warning previously logged the raw blind-index hashes when two of the user's accounts share the same hash. Even though those values are blinded HMAC outputs, they're pseudo-identifiers tied to the current encryption key — they shouldn't end up in log aggregators. The new wording keeps the count and the \`user_id\` for investigation but drops the hash list.

## Test plan

- [x] Existing 11 \`test_internal_transfer_service.py\` tests still pass
- [x] No assertion in tests on the log message content (verified)

## Risk

Trivial. One log-format change. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts raw IBAN blind-index hashes from the duplicate-hash warning in internal transfers to avoid leaking pseudo-identifiers to logs. The warning now includes only the count and `user_id`; no behavior change.

<sup>Written for commit 26f78332de93d116a6fc71a22b7aab05ce861fdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

