### PR TITLE
fix(eb): backfill account-level IBAN at the start of each EB sync

### DIFF
--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -143,6 +143,38 @@ def sync_bank_connection(self, connection_id: str):
             Account.bank_connection_id == connection.id,
         ).all()
 
+        # Backfill account-level IBAN on synced accounts that don't have it yet.
+        # This is independent of the per-account sync_transactions loop below;
+        # adapter.fetch_accounts() returns the IBAN exposed by EB's session
+        # data, and SyncService._set_account_iban_fields treats IBAN as
+        # immutable (no overwrite once set). Without this hook, the
+        # InternalTransferService can't recognize transfers between two
+        # synced accounts because it won't know which IBANs are the user's.
+        try:
+            account_data_list = adapter.fetch_accounts()
+            account_data_by_uid = {
+                ad.external_id: ad for ad in account_data_list
+            }
+            for acc in accounts:
+                acc_uid = decrypt_with_fallback(
+                    acc.external_id_ciphertext, acc.external_id
+                )
+                if not acc_uid:
+                    continue
+                ad = account_data_by_uid.get(acc_uid)
+                if ad is None:
+                    continue
+                sync_service._set_account_iban_fields(acc, ad.iban)
+            db.commit()
+        except Exception as e:
+            # Don't fail the sync if account-level fetch hiccups — the per-account
+            # transaction sync below has its own error handling, and IBAN backfill
+            # can retry on the next sync.
+            logger.warning(
+                f"[SYNC] IBAN backfill skipped for connection {connection_id}: {e}"
+            )
+            db.rollback()
+
         total_created = 0
         total_updated = 0
         all_created_ids: list[str] = []


### PR DESCRIPTION
## Summary

PR #89 added `SyncService._set_account_iban_fields` to write \`iban_hash\` + \`iban_ciphertext\` on synced accounts, but it's only called from \`SyncService.sync_accounts\` — and the **Enable Banking sync entry point (\`sync_bank_connection\`) never calls that method**. It loops accounts directly from the DB and only runs \`sync_transactions\` per account.

Production confirmed: after the PR #89 deploy and a full ABN sync, the 9 synced accounts still have \`iban_hash=NULL\`, so \`InternalTransferService\` can't recognize transfers between two synced accounts. (Manual-pocket detection works fine — already 16 detections / mirrors against the existing pocket.)

## Fix

At the start of each EB sync, call \`adapter.fetch_accounts()\` once, build a \`{uid → AccountData}\` map, and update \`iban_hash\` on every account that connection owns. The helper treats IBAN as immutable, so re-runs are no-ops once populated.

Errors during the account fetch are logged but don't fail the sync — the per-account transaction loop below has its own error handling.

## Test plan

- [x] All 16 existing transfer-service + sync-encryption tests pass locally
- [ ] Deploy worker → trigger ABN sync → \`accounts.iban_hash\` populated for all 9 synced accounts
- [ ] After backfill, next sync's detection identifies transfers between two synced accounts (e.g. ABN checking → Revo)

## Risk

Low. One DB-write helper per connection per sync, idempotent. Wrapped in try/except so a fetch_accounts failure doesn't break the rest of the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills account-level IBANs at the start of each Enable Banking sync so transfers between synced accounts are detected. The sync now calls `adapter.fetch_accounts()` once, maps by account UID, and updates `iban_hash`/ciphertext for all accounts in the connection.

- **Bug Fixes**
  - `sync_bank_connection` previously skipped `SyncService._set_account_iban_fields`, leaving `iban_hash=NULL`; IBANs are now set once and treated as immutable.
  - Errors during the account fetch are logged and don’t stop per-account transaction sync; writes commit on success and roll back on error.

<sup>Written for commit 7a2f5c1318f2343ad1640ca4b90106a8b160755c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

