### PR TITLE
fix(eb): surface IBAN-backfill traceback for diagnostics

### DIFF
--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -169,9 +169,11 @@ def sync_bank_connection(self, connection_id: str):
         except Exception as e:
             # Don't fail the sync if account-level fetch hiccups — the per-account
             # transaction sync below has its own error handling, and IBAN backfill
-            # can retry on the next sync.
+            # can retry on the next sync. Use exc_info=True to surface the full
+            # traceback in worker logs so unexpected failures are diagnosable.
             logger.warning(
-                f"[SYNC] IBAN backfill skipped for connection {connection_id}: {e}"
+                "[SYNC] IBAN backfill skipped for connection %s: %s",
+                connection_id, e, exc_info=True,
             )
             db.rollback()
 


### PR DESCRIPTION
## Summary

PR #91's IBAN-backfill block silently swallows exceptions with a 1-line warning. In production we see \`[SYNC] IBAN backfill skipped for connection ...: string indices must be integers, not 'str'\` — no traceback, so we can't pinpoint the failing line.

This 2-line change adds \`exc_info=True\` so the traceback lands in the worker log.

Once deployed, the next sync will print a full traceback for the bug, and we can fix it in a follow-up PR.

## Test plan

- [x] No code-path change beyond logging
- [ ] Deploy → trigger sync → grep logs for traceback
- [ ] Open follow-up PR with the actual fix

## Risk

Trivial. Logging-only. No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log full tracebacks for IBAN backfill errors in sync jobs. Adds exc_info=True to the warning so failures are diagnosable in worker logs; runtime behavior unchanged.

<sup>Written for commit 5e054f3dc90b3c252688a3a3088159a9467ee96c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

