### PR TITLE
fix(eb): use per-account /details endpoint for IBAN backfill

### DIFF
--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -245,3 +245,21 @@ class EnableBankingAdapter(BankAdapter):
         """
         resp = self.client.get(f"/accounts/{account_uid}/balances")
         return resp.json()
+
+    def fetch_account_iban(self, account_uid: str) -> Optional[str]:
+        """Fetch the canonical IBAN for a single connected account.
+
+        Why this exists: ``GET /sessions/{session_id}`` returns rich account
+        objects only at OAuth time. On subsequent calls (post-mapping, post-
+        sync) the ``accounts`` field collapses to a list of UID strings, so
+        ``fetch_accounts`` can't be relied on for IBAN. ``GET /accounts/{uid}/
+        details`` is the per-account endpoint that always returns the IBAN.
+
+        Returns the normalized IBAN (spaces stripped, upper-cased) or None if
+        the account doesn't have one (rare — some credit cards don't).
+        """
+        resp = self.client.get(f"/accounts/{account_uid}/details")
+        data = resp.json()
+        if not isinstance(data, dict):
+            return None
+        return _extract_iban(data)

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -145,37 +145,39 @@ def sync_bank_connection(self, connection_id: str):
 
         # Backfill account-level IBAN on synced accounts that don't have it yet.
         # This is independent of the per-account sync_transactions loop below;
-        # adapter.fetch_accounts() returns the IBAN exposed by EB's session
-        # data, and SyncService._set_account_iban_fields treats IBAN as
-        # immutable (no overwrite once set). Without this hook, the
-        # InternalTransferService can't recognize transfers between two
-        # synced accounts because it won't know which IBANs are the user's.
-        try:
-            account_data_list = adapter.fetch_accounts()
-            account_data_by_uid = {
-                ad.external_id: ad for ad in account_data_list
-            }
-            for acc in accounts:
-                acc_uid = decrypt_with_fallback(
-                    acc.external_id_ciphertext, acc.external_id
-                )
-                if not acc_uid:
-                    continue
-                ad = account_data_by_uid.get(acc_uid)
-                if ad is None:
-                    continue
-                sync_service._set_account_iban_fields(acc, ad.iban)
-            db.commit()
-        except Exception as e:
-            # Don't fail the sync if account-level fetch hiccups — the per-account
-            # transaction sync below has its own error handling, and IBAN backfill
-            # can retry on the next sync. Use exc_info=True to surface the full
-            # traceback in worker logs so unexpected failures are diagnosable.
-            logger.warning(
-                "[SYNC] IBAN backfill skipped for connection %s: %s",
-                connection_id, e, exc_info=True,
+        # SyncService._set_account_iban_fields treats IBAN as immutable (no
+        # overwrite once set), so we skip accounts that already have it.
+        # Without this hook, InternalTransferService can't recognize transfers
+        # between two synced accounts because it won't know which IBANs are
+        # the user's.
+        #
+        # NOTE: we cannot use adapter.fetch_accounts() here. EB's GET
+        # /sessions/{uid} returns rich account objects only at OAuth time;
+        # on subsequent calls the "accounts" field collapses to a list of
+        # UID strings. We fetch each account's IBAN individually via
+        # /accounts/{uid}/details which always returns the canonical form.
+        for acc in accounts:
+            if acc.iban_hash is not None:
+                continue  # Skip accounts that already have IBAN persisted
+            acc_uid = decrypt_with_fallback(
+                acc.external_id_ciphertext, acc.external_id
             )
-            db.rollback()
+            if not acc_uid:
+                continue
+            try:
+                iban = adapter.fetch_account_iban(acc_uid)
+                if iban:
+                    sync_service._set_account_iban_fields(acc, iban)
+                    db.commit()
+            except Exception as e:
+                # One account's failure must not block the others, nor the
+                # downstream transaction sync. Skip and move on; backfill
+                # retries on the next sync.
+                logger.warning(
+                    "[SYNC] IBAN backfill skipped for account %s on connection %s: %s",
+                    acc.id, connection_id, e, exc_info=True,
+                )
+                db.rollback()
 
         total_created = 0
         total_updated = 0


### PR DESCRIPTION
## Summary

PR #91's IBAN backfill broke in production with \`TypeError: string indices must be integers, not 'str'\` (surfaced via PR #92's traceback logging). Root cause:

> EB's \`GET /sessions/{uid}\` returns rich account objects **only at OAuth time**. On subsequent calls (post-mapping, post-sync) the \`accounts\` field collapses to a list of UID strings.

The existing \`EnableBankingAdapter.fetch_accounts\` was dead code on the EB sync path until PR #91 wired it up — the bug was latent. With UID strings, \`acc[\"uid\"]\` blows up.

## Fix

1. **New method \`fetch_account_iban(uid)\`** in the EB adapter — calls \`GET /accounts/{uid}/details\` (the symmetric per-account endpoint to \`fetch_balances\` / \`fetch_transactions\`). Always returns the canonical IBAN, normalized via \`_extract_iban\`.

2. **Replaced bulk fetch in \`sync_bank_connection\`** with a per-account loop. Skips accounts that already have \`iban_hash\` (immutable). Per-account \`try/except\` so one bad account doesn't block the others.

## Test plan

- [x] All 31 adapter + transfer-service + sync-encryption tests pass locally
- [ ] Deploy → trigger sync → \`accounts.iban_hash\` populated for all 9 synced accounts
- [ ] Subsequent sync's \`InternalTransferService.detect_for_transactions\` matches transfers between synced accounts

## Risk

Low. Per-account fetch is opt-in (only runs if \`iban_hash\` is NULL), idempotent, and wrapped in try/except so failures don't break the rest of the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken IBAN backfill by fetching each account’s IBAN via the per-account details endpoint, restoring reliable syncs and enabling transfer matching between user accounts.

- **Bug Fixes**
  - Added `EnableBankingAdapter.fetch_account_iban(uid)` that calls `GET /accounts/{uid}/details` and returns a normalized IBAN.
  - Replaced the bulk session fetch with a per-account loop in `sync_bank_connection`; skip accounts with existing `iban_hash`, commit per success, and handle errors per account.
  - Root cause: `GET /sessions/{uid}` only returns rich account objects at OAuth time; subsequent calls return UID strings, which broke the previous approach.

<sup>Written for commit 4b025b9e559a198aa6eedbf44b8d41097d20db93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

