### PR TITLE
feat(investments): Refresh Prices button + sync-all endpoint

### DIFF
--- a/backend/app/integrations/enable_banking_adapter.py
+++ b/backend/app/integrations/enable_banking_adapter.py
@@ -245,3 +245,21 @@ class EnableBankingAdapter(BankAdapter):
         """
         resp = self.client.get(f"/accounts/{account_uid}/balances")
         return resp.json()
+
+    def fetch_account_iban(self, account_uid: str) -> Optional[str]:
+        """Fetch the canonical IBAN for a single connected account.
+
+        Why this exists: ``GET /sessions/{session_id}`` returns rich account
+        objects only at OAuth time. On subsequent calls (post-mapping, post-
+        sync) the ``accounts`` field collapses to a list of UID strings, so
+        ``fetch_accounts`` can't be relied on for IBAN. ``GET /accounts/{uid}/
+        details`` is the per-account endpoint that always returns the IBAN.
+
+        Returns the normalized IBAN (spaces stripped, upper-cased) or None if
+        the account doesn't have one (rare — some credit cards don't).
+        """
+        resp = self.client.get(f"/accounts/{account_uid}/details")
+        data = resp.json()
+        if not isinstance(data, dict):
+            return None
+        return _extract_iban(data)

--- a/backend/app/routes/investments.py
+++ b/backend/app/routes/investments.py
@@ -33,7 +33,7 @@ from app.schemas import (
     ValuationPoint,
 )
 from app.services import credentials_crypto
-from tasks.investment_tasks import sync_investment_account
+from tasks.investment_tasks import sync_investment_account, daily_investment_sync_all
 
 router = APIRouter()
 
@@ -127,6 +127,28 @@ def trigger_sync(
         raise HTTPException(status_code=404, detail="Broker connection not found")
     sync_investment_account.delay(str(conn.account_id))
     return {"status": "queued", "account_id": str(conn.account_id)}
+
+
+@router.post("/sync-all")
+def trigger_sync_all(
+    user_id: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    """Queue a price-refresh sync for every active investment account belonging
+    to the user (manual + brokerage). Protected by the standard user auth."""
+    user_id = get_user_id(user_id)
+    accounts = (
+        db.query(Account)
+        .filter(
+            Account.user_id == user_id,
+            Account.is_active.is_(True),
+            Account.account_type.in_(["investment_manual", "investment_brokerage"]),
+        )
+        .all()
+    )
+    for account in accounts:
+        sync_investment_account.delay(str(account.id))
+    return {"status": "queued", "count": len(accounts)}
 
 
 @router.delete("/broker-connections/{connection_id}", status_code=204)

--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -145,37 +145,39 @@ def sync_bank_connection(self, connection_id: str):
 
         # Backfill account-level IBAN on synced accounts that don't have it yet.
         # This is independent of the per-account sync_transactions loop below;
-        # adapter.fetch_accounts() returns the IBAN exposed by EB's session
-        # data, and SyncService._set_account_iban_fields treats IBAN as
-        # immutable (no overwrite once set). Without this hook, the
-        # InternalTransferService can't recognize transfers between two
-        # synced accounts because it won't know which IBANs are the user's.
-        try:
-            account_data_list = adapter.fetch_accounts()
-            account_data_by_uid = {
-                ad.external_id: ad for ad in account_data_list
-            }
-            for acc in accounts:
-                acc_uid = decrypt_with_fallback(
-                    acc.external_id_ciphertext, acc.external_id
-                )
-                if not acc_uid:
-                    continue
-                ad = account_data_by_uid.get(acc_uid)
-                if ad is None:
-                    continue
-                sync_service._set_account_iban_fields(acc, ad.iban)
-            db.commit()
-        except Exception as e:
-            # Don't fail the sync if account-level fetch hiccups — the per-account
-            # transaction sync below has its own error handling, and IBAN backfill
-            # can retry on the next sync. Use exc_info=True to surface the full
-            # traceback in worker logs so unexpected failures are diagnosable.
-            logger.warning(
-                "[SYNC] IBAN backfill skipped for connection %s: %s",
-                connection_id, e, exc_info=True,
+        # SyncService._set_account_iban_fields treats IBAN as immutable (no
+        # overwrite once set), so we skip accounts that already have it.
+        # Without this hook, InternalTransferService can't recognize transfers
+        # between two synced accounts because it won't know which IBANs are
+        # the user's.
+        #
+        # NOTE: we cannot use adapter.fetch_accounts() here. EB's GET
+        # /sessions/{uid} returns rich account objects only at OAuth time;
+        # on subsequent calls the "accounts" field collapses to a list of
+        # UID strings. We fetch each account's IBAN individually via
+        # /accounts/{uid}/details which always returns the canonical form.
+        for acc in accounts:
+            if acc.iban_hash is not None:
+                continue  # Skip accounts that already have IBAN persisted
+            acc_uid = decrypt_with_fallback(
+                acc.external_id_ciphertext, acc.external_id
             )
-            db.rollback()
+            if not acc_uid:
+                continue
+            try:
+                iban = adapter.fetch_account_iban(acc_uid)
+                if iban:
+                    sync_service._set_account_iban_fields(acc, iban)
+                    db.commit()
+            except Exception as e:
+                # One account's failure must not block the others, nor the
+                # downstream transaction sync. Skip and move on; backfill
+                # retries on the next sync.
+                logger.warning(
+                    "[SYNC] IBAN backfill skipped for account %s on connection %s: %s",
+                    acc.id, connection_id, e, exc_info=True,
+                )
+                db.rollback()
 
         total_created = 0
         total_updated = 0

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -148,3 +148,8 @@
   color: var(--app-foreground);
 }
 .syllogic-surface * { box-sizing: border-box; }
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}

--- a/frontend/components/investments/InvestmentsOverview.tsx
+++ b/frontend/components/investments/InvestmentsOverview.tsx
@@ -4,10 +4,12 @@ import { useRouter } from "next/navigation";
 import { fetchHistoryRange, type Range } from "@/lib/actions/investments";
 import {
   deleteHolding,
+  syncAllInvestments,
   type Holding,
   type PortfolioSummary,
   type ValuationPoint,
 } from "@/lib/api/investments";
+import { RiRefreshLine } from "@remixicon/react";
 import { PortfolioHero } from "./PortfolioHero";
 import { PortfolioChart } from "./PortfolioChart";
 import { PortfolioStatsStrip, computeBestDay } from "./PortfolioStatsStrip";
@@ -31,6 +33,7 @@ export function InvestmentsOverview({
   const [history, setHistory] = useState<ValuationPoint[]>(initialHistory);
   const [pending, startTransition] = useTransition();
   const activeRangeRef = useRef<Range>(initialRange);
+  const [syncing, setSyncing] = useState(false);
 
   const series = useMemo(
     () =>
@@ -78,6 +81,16 @@ export function InvestmentsOverview({
     router.refresh();
   };
 
+  const onSync = async () => {
+    setSyncing(true);
+    try {
+      await syncAllInvestments();
+      setTimeout(() => router.refresh(), 3000);
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   const sym =
     portfolio.currency === "USD"
       ? "$"
@@ -95,16 +108,44 @@ export function InvestmentsOverview({
           gap: 16,
         }}
       >
-        <PortfolioHero
-          totalValue={totalValue}
-          currency={portfolio.currency}
-          absChange={absChange}
-          pctChange={pctChange}
-          range={range}
-          onRangeChange={onRangeChange}
-          asOf="moments ago"
-          staleCount={staleCount}
-        />
+        <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <PortfolioHero
+              totalValue={totalValue}
+              currency={portfolio.currency}
+              absChange={absChange}
+              pctChange={pctChange}
+              range={range}
+              onRangeChange={onRangeChange}
+              asOf="moments ago"
+              staleCount={staleCount}
+            />
+          </div>
+          <button
+            onClick={onSync}
+            disabled={syncing}
+            title="Refresh prices"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "5px 12px",
+              background: "transparent",
+              border: `1px solid ${T.border}`,
+              color: T.mutedFg,
+              cursor: syncing ? "default" : "pointer",
+              fontSize: 11,
+              fontFamily: "inherit",
+              opacity: syncing ? 0.5 : 1,
+            }}
+          >
+            <RiRefreshLine
+              size={12}
+              style={{ animation: syncing ? "spin 1s linear infinite" : "none" }}
+            />
+            {syncing ? "Syncing…" : "Refresh prices"}
+          </button>
+        </div>
         <div
           style={{
             background: T.card,

--- a/frontend/lib/api/investments.ts
+++ b/frontend/lib/api/investments.ts
@@ -199,6 +199,11 @@ export async function deleteHolding(holdingId: string): Promise<void> {
   await signedFetch("DELETE", `/api/investments/holdings/${holdingId}`);
 }
 
+export async function syncAllInvestments(): Promise<{ count: number }> {
+  const resp = await signedFetch("POST", "/api/investments/sync-all");
+  return readJsonOrThrow<{ count: number }>(resp);
+}
+
 export async function updateHolding(
   holdingId: string,
   payload: { quantity?: string; avg_cost?: string; as_of_date?: string },


### PR DESCRIPTION
## Summary
- **Backend**: `POST /api/investments/sync-all` — queues a price-refresh sync for all of the authenticated user's active investment accounts (manual + brokerage) via Celery
- **Frontend**: `syncAllInvestments()` API helper + **Refresh prices** button in the investments hero row, with a spinning icon while in-flight and auto-refresh after 3 s

## Why
No way to manually trigger a price refresh from the UI — the only option was waiting for the daily cron or SSHing into Railway. This unblocks manual testing and gives users on-demand price updates.

## Test plan
- [ ] Click "Refresh prices" on `/investments` — button shows spinner, prices update within a few seconds
- [ ] Verify `POST /api/investments/sync-all` returns `{"status":"queued","count":N}`
- [ ] Button disabled while syncing, re-enables after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Refresh prices” button on the Investments page and a `POST /api/investments/sync-all` endpoint that queues price updates for all of a user’s active investment accounts. Also fixes IBAN backfill by using Enable Banking’s per‑account details endpoint to keep transfer matching accurate.

- **New Features**
  - `POST /api/investments/sync-all` queues Celery syncs for the authenticated user’s active manual and brokerage accounts.
  - `syncAllInvestments()` API helper and a “Refresh prices” button with a spinning icon; auto-refreshes the page after 3 seconds and disables while syncing.

- **Bug Fixes**
  - Replaced broken bulk IBAN fetch with per-account `fetch_account_iban()` via `/accounts/{uid}/details`.
  - Skips accounts that already have an IBAN and isolates errors per account to avoid blocking other syncs.

<sup>Written for commit 6c988cb76a1e62505f980230248e80e1252ad777. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

