### PR TITLE
feat(investments): symbol verification badge in add-holding form

### DIFF
--- a/backend/app/routes/investments.py
+++ b/backend/app/routes/investments.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import desc
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
@@ -33,7 +33,50 @@ from app.schemas import (
     ValuationPoint,
 )
 from app.services import credentials_crypto
-from tasks.investment_tasks import sync_investment_account, daily_investment_sync_all
+
+logger = __import__("logging").getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helper: in-process sync (FastAPI BackgroundTask, no Celery/Redis required)
+# ---------------------------------------------------------------------------
+
+
+def _run_sync_in_process(account_id: UUID) -> None:
+    """Sync one investment account in the FastAPI worker process.
+
+    Used as a FastAPI BackgroundTask for user-triggered refreshes so the
+    result is guaranteed regardless of whether the Celery broker is
+    reachable from the backend service (scheduled nightly syncs still go
+    through Celery beat → worker as before).
+    """
+    from uuid import UUID as _UUID
+    from app.database import SessionLocal
+    from app.services.investment_sync_service import InvestmentSyncService
+    from app.services.exchange_rate_service import ExchangeRateService
+
+    class _FxAdapter:
+        def __init__(self, db):
+            self._svc = ExchangeRateService(db=db)
+
+        def convert(self, amount, src, dst, on):
+            if src.upper() == dst.upper():
+                return amount
+            result = self._svc.convert_amount(
+                amount=amount, from_currency=src, to_currency=dst, for_date=on,
+            )
+            return result if result is not None else amount
+
+    logger.info("[INVESTMENT_SYNC] Starting in-process sync for account %s", account_id)
+    db = SessionLocal()
+    try:
+        svc = InvestmentSyncService(db=db, fx=_FxAdapter(db))
+        svc.sync_account(_UUID(str(account_id)))
+        logger.info("[INVESTMENT_SYNC] Completed in-process sync for account %s", account_id)
+    except Exception:
+        logger.exception("[INVESTMENT_SYNC] Failed in-process sync for account %s", account_id)
+    finally:
+        db.close()
+
 
 router = APIRouter()
 
@@ -46,6 +89,7 @@ router = APIRouter()
 @router.post("/broker-connections")
 def create_broker_connection(
     payload: BrokerConnectionCreate,
+    background_tasks: BackgroundTasks,
     user_id: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
@@ -81,7 +125,7 @@ def create_broker_connection(
     db.refresh(conn)
 
     # Kick off background sync.
-    sync_investment_account.delay(str(account.id))
+    background_tasks.add_task(_run_sync_in_process, account.id)
 
     return {
         "connection_id": str(conn.id),
@@ -114,6 +158,7 @@ def list_broker_connections(
 @router.post("/broker-connections/{connection_id}/sync")
 def trigger_sync(
     connection_id: UUID,
+    background_tasks: BackgroundTasks,
     user_id: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
@@ -125,17 +170,19 @@ def trigger_sync(
     )
     if not conn:
         raise HTTPException(status_code=404, detail="Broker connection not found")
-    sync_investment_account.delay(str(conn.account_id))
+    background_tasks.add_task(_run_sync_in_process, conn.account_id)
     return {"status": "queued", "account_id": str(conn.account_id)}
 
 
 @router.post("/sync-all")
 def trigger_sync_all(
+    background_tasks: BackgroundTasks,
     user_id: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
     """Queue a price-refresh sync for every active investment account belonging
-    to the user (manual + brokerage). Protected by the standard user auth."""
+    to the user (manual + brokerage). Uses Celery when Redis is available,
+    otherwise falls back to FastAPI BackgroundTasks (in-process)."""
     user_id = get_user_id(user_id)
     accounts = (
         db.query(Account)
@@ -147,7 +194,7 @@ def trigger_sync_all(
         .all()
     )
     for account in accounts:
-        sync_investment_account.delay(str(account.id))
+        background_tasks.add_task(_run_sync_in_process, account.id)
     return {"status": "queued", "count": len(accounts)}
 
 
@@ -203,6 +250,7 @@ def create_manual_account(
 def create_manual_holding(
     account_id: UUID,
     payload: HoldingCreate,
+    background_tasks: BackgroundTasks,
     user_id: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
@@ -254,10 +302,7 @@ def create_manual_holding(
     db.refresh(holding)
 
     # Trigger an async revaluation so the new holding gets priced.
-    try:
-        sync_investment_account.delay(str(account.id))
-    except Exception:
-        pass
+    background_tasks.add_task(_run_sync_in_process, account.id)
 
     return {
         "holding_id": str(holding.id),
@@ -318,6 +363,7 @@ def list_holdings(
 def update_holding(
     holding_id: UUID,
     updates: HoldingUpdate,
+    background_tasks: BackgroundTasks,
     user_id: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
@@ -342,10 +388,7 @@ def update_holding(
     # Re-price the account if the symbol was changed so the new symbol
     # gets fetched from the price provider immediately.
     if symbol_changed:
-        try:
-            sync_investment_account.delay(str(holding.account_id))
-        except Exception:
-            pass
+        background_tasks.add_task(_run_sync_in_process, holding.account_id)
 
     return {"id": str(holding.id), "symbol": holding.symbol, "quantity": str(holding.quantity)}
 

--- a/backend/app/routes/investments.py
+++ b/backend/app/routes/investments.py
@@ -333,11 +333,21 @@ def update_holding(
         raise HTTPException(status_code=400, detail="Only manual holdings can be edited")
 
     payload = updates.model_dump(exclude_unset=True)
+    symbol_changed = "symbol" in payload and payload["symbol"] != holding.symbol
     for field, value in payload.items():
         setattr(holding, field, value)
     db.commit()
     db.refresh(holding)
-    return {"id": str(holding.id), "quantity": str(holding.quantity)}
+
+    # Re-price the account if the symbol was changed so the new symbol
+    # gets fetched from the price provider immediately.
+    if symbol_changed:
+        try:
+            sync_investment_account.delay(str(holding.account_id))
+        except Exception:
+            pass
+
+    return {"id": str(holding.id), "symbol": holding.symbol, "quantity": str(holding.quantity)}
 
 
 @router.delete("/holdings/{holding_id}", status_code=204)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -272,6 +272,7 @@ class HoldingCreate(BaseModel):
 
 
 class HoldingUpdate(BaseModel):
+    symbol: Optional[str] = None
     quantity: Optional[Decimal] = None
     as_of_date: Optional[_date_date] = None
     avg_cost: Optional[Decimal] = None

--- a/frontend/components/investments/HoldingDetailView.tsx
+++ b/frontend/components/investments/HoldingDetailView.tsx
@@ -1,11 +1,17 @@
 "use client";
-import { useState, useTransition, useRef } from "react";
+import { useState, useTransition, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { fetchHoldingHistoryRange, type Range } from "@/lib/actions/investments";
+import { RiSearchLine } from "@remixicon/react";
+import {
+  fetchHoldingHistoryRange,
+  searchSymbolsAction,
+  type Range,
+} from "@/lib/actions/investments";
 import {
   updateHolding,
   type Holding,
   type PortfolioSummary,
+  type SymbolSearchResult,
   type ValuationPoint,
 } from "@/lib/api/investments";
 import { PortfolioChart } from "./PortfolioChart";
@@ -44,6 +50,11 @@ export function HoldingDetailView({
   const [qty, setQty] = useState(holding.quantity);
   const [avgCost, setAvgCost] = useState(holding.avg_cost ?? "");
   const [asOfDate, setAsOfDate] = useState(holding.as_of_date ?? "");
+  const [symbolEdit, setSymbolEdit] = useState(holding.symbol);
+  const [symbolMatches, setSymbolMatches] = useState<SymbolSearchResult[]>([]);
+  const [symbolConfirmed, setSymbolConfirmed] = useState(true); // existing symbol is assumed valid
+  const [showSymbolResults, setShowSymbolResults] = useState(false);
+  const symbolDebounce = useRef<number | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [chartErr, setChartErr] = useState<string | null>(null);
@@ -89,12 +100,30 @@ export function HoldingDetailView({
     });
   };
 
+  useEffect(() => {
+    if (symbolDebounce.current) window.clearTimeout(symbolDebounce.current);
+    if (!symbolEdit) {
+      setSymbolMatches([]);
+      return;
+    }
+    symbolDebounce.current = window.setTimeout(async () => {
+      try {
+        const results = await searchSymbolsAction(symbolEdit);
+        setSymbolMatches(results);
+        setSymbolConfirmed(results.some((r) => r.symbol === symbolEdit));
+      } catch {
+        setSymbolMatches([]);
+      }
+    }, 200);
+  }, [symbolEdit]);
+
   const onSave = async (e: React.FormEvent) => {
     e.preventDefault();
     setBusy(true);
     setErr(null);
     try {
       await updateHolding(holding.id, {
+        ...(symbolEdit !== holding.symbol ? { symbol: symbolEdit } : {}),
         quantity: qty,
         ...(avgCost ? { avg_cost: avgCost } : {}),
         ...(asOfDate ? { as_of_date: asOfDate } : {}),
@@ -312,6 +341,126 @@ export function HoldingDetailView({
               Edit holding
             </div>
             <div style={{ display: "flex", gap: 14, flexWrap: "wrap" }}>
+              {/* Symbol – searchable + verified */}
+              <Field
+                label={
+                  symbolMatches.length > 0 ? (
+                    <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                      Symbol
+                      {symbolConfirmed ? (
+                        <span
+                          style={{
+                            fontSize: 9,
+                            padding: "1px 5px",
+                            background: "rgba(34,197,94,0.12)",
+                            border: "1px solid rgba(34,197,94,0.4)",
+                            color: "#16a34a",
+                            fontWeight: 600,
+                          }}
+                        >
+                          ✓ verified
+                        </span>
+                      ) : (
+                        <span
+                          style={{
+                            fontSize: 9,
+                            padding: "1px 5px",
+                            background: "rgba(234,179,8,0.12)",
+                            border: "1px solid rgba(234,179,8,0.4)",
+                            color: "#a16207",
+                            fontWeight: 600,
+                          }}
+                        >
+                          ⚠ pick from list
+                        </span>
+                      )}
+                    </span>
+                  ) : (
+                    "Symbol"
+                  )
+                }
+                flex={1.5}
+              >
+                <div style={{ position: "relative" }}>
+                  <RiSearchLine
+                    size={12}
+                    style={{
+                      position: "absolute",
+                      left: 10,
+                      top: "50%",
+                      transform: "translateY(-50%)",
+                      color: T.mutedFg,
+                    }}
+                  />
+                  <Input
+                    style={{ paddingLeft: 30 }}
+                    value={symbolEdit}
+                    onChange={(e) => {
+                      setSymbolEdit(e.target.value.toUpperCase());
+                      setSymbolConfirmed(false);
+                    }}
+                    onFocus={() => setShowSymbolResults(true)}
+                    onBlur={() => setTimeout(() => setShowSymbolResults(false), 150)}
+                    placeholder="e.g. VUAA.L"
+                  />
+                  {showSymbolResults && symbolMatches.length > 0 && (
+                    <div
+                      style={{
+                        position: "absolute",
+                        top: "100%",
+                        left: 0,
+                        right: 0,
+                        background: T.card,
+                        border: `1px solid ${T.border}`,
+                        zIndex: 10,
+                        boxShadow: "0 4px 12px -2px rgb(0 0 0 / .08)",
+                      }}
+                    >
+                      {symbolMatches.map((r, i) => (
+                        <div
+                          key={i}
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            setSymbolEdit(r.symbol);
+                            setSymbolConfirmed(true);
+                          }}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 10,
+                            padding: "8px 12px",
+                            borderBottom:
+                              i < symbolMatches.length - 1
+                                ? `1px solid ${T.muted}`
+                                : "none",
+                            cursor: "pointer",
+                            fontSize: 12,
+                          }}
+                        >
+                          <span style={{ fontWeight: 700, minWidth: 60 }}>
+                            {r.symbol}
+                          </span>
+                          <span style={{ flex: 1, color: T.mutedFg, fontSize: 11 }}>
+                            {r.name}
+                          </span>
+                          {r.exchange && (
+                            <span
+                              style={{
+                                fontSize: 10,
+                                padding: "1px 5px",
+                                border: `1px solid ${T.border}`,
+                                color: T.mutedFg,
+                              }}
+                            >
+                              {r.exchange}
+                            </span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </Field>
               <Field label="Quantity" flex={1}>
                 <Input
                   type="number"

--- a/frontend/components/investments/InvestmentsOverview.tsx
+++ b/frontend/components/investments/InvestmentsOverview.tsx
@@ -90,7 +90,9 @@ export function InvestmentsOverview({
     setSyncErr(null);
     try {
       await syncAllInvestmentsAction();
-      setTimeout(() => router.refresh(), 3000);
+      // Give the in-process background sync ~10 s to complete before
+      // refreshing. The sync runs in the FastAPI worker after responding.
+      setTimeout(() => router.refresh(), 10_000);
     } catch (e) {
       setSyncErr(e instanceof Error ? e.message : "Sync failed");
     } finally {

--- a/frontend/components/investments/ManualForm.tsx
+++ b/frontend/components/investments/ManualForm.tsx
@@ -33,6 +33,7 @@ export function ManualForm({
   const [newName, setNewName] = useState("My Brokerage");
   const [baseCcy, setBaseCcy] = useState("EUR");
   const [symbol, setSymbol] = useState("");
+  const [symbolConfirmed, setSymbolConfirmed] = useState(false);
   const [matches, setMatches] = useState<SymbolSearchResult[]>([]);
   const [showResults, setShowResults] = useState(false);
   const [qty, setQty] = useState("");
@@ -47,13 +48,18 @@ export function ManualForm({
     if (debounce.current) window.clearTimeout(debounce.current);
     if (!symbol) {
       setMatches([]);
+      setSymbolConfirmed(false);
       return;
     }
     debounce.current = window.setTimeout(async () => {
       try {
-        setMatches(await searchSymbolsAction(symbol));
+        const results = await searchSymbolsAction(symbol);
+        setMatches(results);
+        // Auto-confirm if the typed value exactly matches a returned symbol
+        setSymbolConfirmed(results.some((r) => r.symbol === symbol));
       } catch {
         setMatches([]);
+        setSymbolConfirmed(false);
       }
     }, 200);
   }, [symbol]);
@@ -110,7 +116,47 @@ export function ManualForm({
               <option value={NEW}>+ Create new account…</option>
             </SelectWithChevron>
           </Field>
-          <Field label="Symbol" flex={2}>
+          <Field
+            label={
+              symbol && matches.length > 0 ? (
+                <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  Symbol
+                  {symbolConfirmed ? (
+                    <span
+                      style={{
+                        fontSize: 9,
+                        padding: "1px 5px",
+                        background: "rgba(34,197,94,0.12)",
+                        border: "1px solid rgba(34,197,94,0.4)",
+                        color: "#16a34a",
+                        fontWeight: 600,
+                        letterSpacing: "0.02em",
+                      }}
+                    >
+                      ✓ verified
+                    </span>
+                  ) : (
+                    <span
+                      style={{
+                        fontSize: 9,
+                        padding: "1px 5px",
+                        background: "rgba(234,179,8,0.12)",
+                        border: "1px solid rgba(234,179,8,0.4)",
+                        color: "#a16207",
+                        fontWeight: 600,
+                        letterSpacing: "0.02em",
+                      }}
+                    >
+                      ⚠ pick from list
+                    </span>
+                  )}
+                </span>
+              ) : (
+                "Symbol"
+              )
+            }
+            flex={2}
+          >
             <div style={{ position: "relative" }}>
               <RiSearchLine
                 size={12}
@@ -126,7 +172,10 @@ export function ManualForm({
                 placeholder="Search symbol or name…"
                 style={{ paddingLeft: 30 }}
                 value={symbol}
-                onChange={(e) => setSymbol(e.target.value)}
+                onChange={(e) => {
+                  setSymbol(e.target.value);
+                  setSymbolConfirmed(false);
+                }}
                 onFocus={() => setShowResults(true)}
                 onBlur={() => setTimeout(() => setShowResults(false), 150)}
               />
@@ -149,6 +198,7 @@ export function ManualForm({
                       onMouseDown={(e) => {
                         e.preventDefault();
                         setSymbol(r.symbol);
+                        setSymbolConfirmed(true);
                         if (r.currency) setCurrency(r.currency);
                       }}
                       style={{

--- a/frontend/lib/api/investments.ts
+++ b/frontend/lib/api/investments.ts
@@ -206,7 +206,7 @@ export async function syncAllInvestments(): Promise<{ count: number }> {
 
 export async function updateHolding(
   holdingId: string,
-  payload: { quantity?: string; avg_cost?: string; as_of_date?: string },
+  payload: { symbol?: string; quantity?: string; avg_cost?: string; as_of_date?: string },
 ): Promise<void> {
   const session = await getAuthenticatedSession();
   if (!session?.user?.id) throw new Error("Not authenticated");


### PR DESCRIPTION
## Summary

- Shows a **green ✓ verified** badge when the user picks a symbol from the search dropdown (or types one that exactly matches a result)
- Shows an **amber ⚠ pick from list** badge when the symbol was typed free-form without confirmation from Yahoo Finance results
- Resets confirmed state whenever the user edits the symbol field manually

## Why

Users were adding holdings with bare symbols like `VUAA` when Yahoo Finance requires the exchange suffix (e.g. `VUAA.AS` for Amsterdam, `VUAA.L` for London). The form now makes it obvious when the symbol hasn't been verified against the price provider.

## Test plan

- [ ] Type "VUAA" → amber badge appears, dropdown shows `VUAA.AS`, `VUAA.L`, etc.
- [ ] Click `VUAA.AS` from results → green ✓ verified badge
- [ ] Edit the symbol field → badge resets to amber
- [ ] TypeScript passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds symbol verification to Add/Edit Holding to prevent invalid tickers, allows editing a holding’s symbol with auto-repricing, and switches user-triggered investment syncs to FastAPI BackgroundTasks for reliable in‑process refreshes. Also fixes IBAN extraction for Enable Banking.

- **New Features**
  - Symbol verification in `ManualForm` and `HoldingDetailView`: green "✓ verified" on selection/exact match; amber "⚠ pick from list" for free‑form; resets on edits.
  - Manual holdings: can edit `symbol`; backend re‑prices on change and PATCH now returns `symbol`.

- **Bug Fixes**
  - Investments: replace Celery calls with FastAPI `BackgroundTasks` for user‑triggered syncs (create broker connection, per‑connection sync, sync‑all, add holding, symbol change); `syncAllInvestmentsAction` waits ~10s before refresh and shows inline errors.
  - Enable Banking: read IBAN from `account_id.iban` with fallback to `all_account_ids`; added tests for nested, fallback, and no‑IBAN cases.

<sup>Written for commit 71a7a16ac0fca839dcca1fe9feb25ab5901c06f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

