### PR TITLE
chore: bump Railway image pins to v1.0.1

### DIFF
--- a/deploy/railway/docker-compose.yml
+++ b/deploy/railway/docker-compose.yml
@@ -58,7 +58,7 @@ services:
   # ── Backend API (FastAPI) ─────────────────────────────────
   backend:
     # Template maintainers: this tag is auto-bumped by CI on each vX.Y.Z release.
-    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.1
     environment:
       NODE_ENV: production
       PORT: "8080"
@@ -76,7 +76,7 @@ services:
 
   # ── MCP Server (FastMCP) ──────────────────────────────────
   mcp:
-    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.1
     command: uvicorn mcp_server:app --host 0.0.0.0 --port 8001
     healthcheck:
       test:
@@ -100,7 +100,7 @@ services:
 
   # ── Celery Worker ─────────────────────────────────────────
   worker:
-    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.1
     command: celery -A celery_app worker --loglevel=info --concurrency=4
     environment:
       NODE_ENV: production
@@ -117,7 +117,7 @@ services:
 
   # ── Celery Beat (scheduler) ───────────────────────────────
   beat:
-    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.0
+    image: ghcr.io/syllogic-ai/syllogic-backend:v1.0.1
     command: celery -A celery_app beat --loglevel=info
     environment:
       NODE_ENV: production
@@ -136,7 +136,7 @@ services:
   # Migrations run automatically at startup before Next.js boot.
   # Keep PORT=3000 so Railway proxy routes traffic correctly.
   app:
-    image: ghcr.io/syllogic-ai/syllogic-frontend:v1.0.0
+    image: ghcr.io/syllogic-ai/syllogic-frontend:v1.0.1
     command: /bin/sh -lc "mkdir -p /app/public/uploads/profile /app/public/uploads/logos /app/public/uploads/imports && chmod -R u+rwX,g+rwX /app/public/uploads && node scripts/migrate.js && exec node_modules/.bin/next start -p 3000 -H 0.0.0.0"
     healthcheck:
       test:


### PR DESCRIPTION
## Summary

Bumps all Railway service image pins from `v1.0.0` (Feb 28) to `v1.0.1` (today).

This was supposed to be auto-committed by the `release_bundle` CI job on the v1.0.1 tag push, but that step failed. Doing it manually here.

**v1.0.1 includes:**
- Investments feature (holdings, portfolio chart, holding detail page)
- Refresh prices button
- Error feedback on sync failures
- Investment sync via FastAPI BackgroundTasks (fixes silent failures when backend can't reach Celery broker)
- Symbol verification badge in add-holding form
- Symbol editing from holding detail view

## No code changes — image tag bump only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump Railway image pins from v1.0.0 to v1.0.1 across backend, MCP, worker, beat, and app to deploy the latest fixes and features. No code changes; docker-compose image tags only.

<sup>Written for commit e8130b37a4b44879a6c49eebfab00be5a100fd3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

