### PR TITLE
fix(ibkr): partial-success sync + inter-query delay

### DIFF
--- a/backend/app/services/investment_sync_service.py
+++ b/backend/app/services/investment_sync_service.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import os
+import time
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Callable
@@ -54,11 +56,11 @@ class InvestmentSyncService:
         conn = self.db.query(BrokerConnection).filter_by(account_id=account.id).one()
         creds = decrypt(conn.credentials_encrypted)
         adapter = self.adapter_factory(creds)
+
+        # Step 1 — positions (fatal if it fails; nothing useful happens without them).
         try:
             ref_positions = adapter.request_statement(creds["query_id_positions"])
             positions_xml = adapter.fetch_statement(ref_positions)
-            ref_trades = adapter.request_statement(creds["query_id_trades"])
-            trades_xml = adapter.fetch_statement(ref_trades)
         except FlexAuthError as e:
             conn.last_sync_status = "needs_reauth"
             conn.last_sync_error = str(e)
@@ -75,14 +77,46 @@ class InvestmentSyncService:
             raise
 
         statement = adapter.parse_positions_xml(positions_xml)
-        trades = adapter.parse_trades_xml(trades_xml)
         self._upsert_positions(account, statement.positions)
         self._upsert_cash(account, statement.cash)
-        self._upsert_trades(account, trades)
+        # Persist positions immediately so a later trades-fetch failure
+        # doesn't roll back the work we already did.
+        self.db.commit()
+
+        # Step 2 — trades (best-effort; IBKR Flex throttles a token to ~1
+        # request per ~10 min per query, so the back-to-back call here is
+        # the most common 1018 trigger). A small delay smooths the bursty
+        # double-call pattern; on failure we keep the sync as "partial"
+        # so positions still surface and trades catch up next cycle.
+        delay = float(os.getenv("IBKR_FLEX_INTER_QUERY_DELAY_SEC", "5"))
+        if delay > 0:
+            time.sleep(delay)
+
+        trades_error: str | None = None
+        try:
+            ref_trades = adapter.request_statement(creds["query_id_trades"])
+            trades_xml = adapter.fetch_statement(ref_trades)
+            trades = adapter.parse_trades_xml(trades_xml)
+            self._upsert_trades(account, trades)
+        except FlexAuthError as e:
+            trades_error = f"trades auth failed: {e}"
+            logger.warning("IBKR trades sync failed (auth) for %s: %s", account.id, e)
+        except FlexStatementNotReady as e:
+            trades_error = f"trades not ready: {e}"
+            logger.info("IBKR trades not ready for %s: %s", account.id, e)
+        except FlexError as e:
+            trades_error = f"trades fetch failed: {e}"
+            logger.warning("IBKR trades sync failed for %s: %s", account.id, e)
+
+        # Re-value either way — positions are saved.
         self.valuation_service.compute(account_id=account.id, on=on)
 
-        conn.last_sync_status = "ok"
-        conn.last_sync_error = None
+        if trades_error:
+            conn.last_sync_status = "partial"
+            conn.last_sync_error = trades_error
+        else:
+            conn.last_sync_status = "ok"
+            conn.last_sync_error = None
         conn.last_sync_at = datetime.utcnow()
         self.db.commit()
 


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in IBKR Flex sync where a 1018 rate-limit on the second query (trades) discards already-fetched positions data.

## Root cause

`_sync_brokerage` wrapped both Flex queries in a single try-block:

```python
try:
    ref_positions = adapter.request_statement(creds["query_id_positions"])
    positions_xml = adapter.fetch_statement(ref_positions)   # ✓ succeeds
    ref_trades = adapter.request_statement(creds["query_id_trades"])  # ✗ 1018
    trades_xml = adapter.fetch_statement(ref_trades)
except FlexError as e:
    conn.last_sync_status = "error"
    raise
```

IBKR Flex Web Service throttles a token to roughly one request per ~10 minutes per query. The two queries fired back-to-back are the most common 1018 trigger, and when it hits, the in-memory positions XML is discarded.

Observed in prod after merging PR #98: `200 OK` on positions SendRequest+GetStatement, then 1018 on trades SendRequest, ending with `last_sync_status='error'` and zero holdings.

## Fix

- Positions fetch + parse + upsert + **commit** happen first.
- Configurable inter-query sleep (`IBKR_FLEX_INTER_QUERY_DELAY_SEC`, default 5s) between the two queries.
- Trades fetch is best-effort: any `FlexError` records `last_sync_status='partial'` with a descriptive `last_sync_error`. Positions stay saved, valuations still compute, trades catch up next sync cycle.

## Test plan

- [ ] Deploy backend
- [ ] Trigger a fresh IBKR sync (UI: Refresh prices, or API: `POST /investments/broker-connections/{id}/sync`)
- [ ] Verify `holdings` populated for the brokerage account even if 1018 hits the trades query
- [ ] Verify `last_sync_status` reflects `ok` / `partial` / `error` correctly
- [ ] Confirm sync now waits ~5s between the positions and trades requests (visible in backend logs as a gap between the two `SendRequest` HTTPX log lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents data loss in IBKR Flex sync by committing positions before fetching trades and adding a small inter-query delay. If the trades request is throttled (1018), the sync now returns partial and preserves holdings and valuations.

- **Bug Fixes**
  - Save positions and cash first, then commit; positions failure remains fatal.
  - Trades fetch is best-effort; on `FlexError`/`FlexStatementNotReady`/`FlexAuthError` set `last_sync_status='partial'` with a clear `last_sync_error`. Status is `ok` only when both queries succeed.
  - Add configurable inter-query delay via `IBKR_FLEX_INTER_QUERY_DELAY_SEC` (default 5s) to reduce 1018 rate limits.

<sup>Written for commit 3930ec22835b849b801ac43c020ad1bf3aee4dde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

