### PR TITLE
perf(dashboard): eliminate 4-5s blank screen on navigation

### DIFF
--- a/frontend/app/(dashboard)/accounts/loading.tsx
+++ b/frontend/app/(dashboard)/accounts/loading.tsx
@@ -1,0 +1,13 @@
+import { HeaderSkeleton, CardGridSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+
+export default function Loading() {
+  return (
+    <>
+      <HeaderSkeleton title="Accounts" />
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <CardGridSkeleton count={4} />
+        <DetailListSkeleton rows={6} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/assets/_sections.tsx
+++ b/frontend/app/(dashboard)/assets/_sections.tsx
@@ -1,0 +1,20 @@
+import { getAccounts } from "@/lib/actions/accounts";
+import { getProperties } from "@/lib/actions/properties";
+import { getVehicles } from "@/lib/actions/vehicles";
+import { AssetManagement } from "./asset-management";
+
+export async function AssetsSection() {
+  const [accounts, properties, vehicles] = await Promise.all([
+    getAccounts(),
+    getProperties(),
+    getVehicles(),
+  ]);
+
+  return (
+    <AssetManagement
+      initialAccounts={accounts}
+      initialProperties={properties}
+      initialVehicles={vehicles}
+    />
+  );
+}

--- a/frontend/app/(dashboard)/assets/loading.tsx
+++ b/frontend/app/(dashboard)/assets/loading.tsx
@@ -1,0 +1,13 @@
+import { HeaderSkeleton, CardGridSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+
+export default function Loading() {
+  return (
+    <>
+      <HeaderSkeleton title="Assets" />
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <CardGridSkeleton count={3} />
+        <DetailListSkeleton rows={8} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/assets/page.tsx
+++ b/frontend/app/(dashboard)/assets/page.tsx
@@ -1,25 +1,23 @@
+import { Suspense } from "react";
 import { Header } from "@/components/layout/header";
-import { getAccounts } from "@/lib/actions/accounts";
-import { getProperties } from "@/lib/actions/properties";
-import { getVehicles } from "@/lib/actions/vehicles";
-import { AssetManagement } from "./asset-management";
+import { CardGridSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+import { AssetsSection } from "./_sections";
 
-export default async function AssetsPage() {
-  const [accounts, properties, vehicles] = await Promise.all([
-    getAccounts(),
-    getProperties(),
-    getVehicles(),
-  ]);
-
+export default function AssetsPage() {
   return (
     <>
       <Header title="Assets" />
       <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
-        <AssetManagement
-          initialAccounts={accounts}
-          initialProperties={properties}
-          initialVehicles={vehicles}
-        />
+        <Suspense
+          fallback={
+            <>
+              <CardGridSkeleton count={3} />
+              <DetailListSkeleton rows={8} />
+            </>
+          }
+        >
+          <AssetsSection />
+        </Suspense>
       </div>
     </>
   );

--- a/frontend/app/(dashboard)/category-spending/_sections.tsx
+++ b/frontend/app/(dashboard)/category-spending/_sections.tsx
@@ -1,0 +1,52 @@
+import { CategorySpendingClient } from "@/components/category-spending/category-spending-client";
+import {
+  getCategorySpendingData,
+  getCategorySpendingTransactionsPage,
+} from "@/lib/actions/category-spending";
+import { getUserAccounts } from "@/lib/actions/dashboard";
+import { getUserCategories } from "@/lib/actions/categories";
+import type { ParsedCategorySpendingQueryParams } from "@/lib/category-spending/query-params";
+import type { TransactionsQueryState } from "@/lib/transactions/query-state";
+
+export async function CategorySpendingSection({
+  parsed,
+  tableQueryState,
+}: {
+  parsed: ParsedCategorySpendingQueryParams;
+  tableQueryState: TransactionsQueryState;
+}) {
+  const [data, transactionsPage, accounts, categories] = await Promise.all([
+    getCategorySpendingData({
+      accountIds: parsed.accountIds,
+      dateFrom: parsed.dateFrom,
+      dateTo: parsed.dateTo,
+      horizon: parsed.effectiveHorizon,
+    }),
+    getCategorySpendingTransactionsPage({
+      accountIds: parsed.accountIds,
+      dateFrom: parsed.dateFrom,
+      dateTo: parsed.dateTo,
+      horizon: parsed.effectiveHorizon,
+      categoryIds: parsed.categoryIds,
+      page: parsed.page,
+      pageSize: parsed.pageSize,
+      sort: parsed.sort,
+      order: parsed.order,
+    }),
+    getUserAccounts(),
+    getUserCategories(),
+  ]);
+
+  return (
+    <CategorySpendingClient
+      data={data}
+      query={parsed}
+      initialSelectedCategoryIds={parsed.categoryIds}
+      transactions={transactionsPage.rows}
+      transactionsTotalCount={transactionsPage.totalCount}
+      transactionsQueryState={tableQueryState}
+      accounts={accounts}
+      categories={categories}
+    />
+  );
+}

--- a/frontend/app/(dashboard)/category-spending/loading.tsx
+++ b/frontend/app/(dashboard)/category-spending/loading.tsx
@@ -1,0 +1,14 @@
+import { HeaderSkeleton, FiltersSkeleton, ChartSkeleton, TableSkeleton } from "@/components/skeletons/page-skeletons";
+
+export default function Loading() {
+  return (
+    <>
+      <HeaderSkeleton title="Category Spending" />
+      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+        <FiltersSkeleton />
+        <ChartSkeleton height={360} />
+        <TableSkeleton rows={10} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/category-spending/page.tsx
+++ b/frontend/app/(dashboard)/category-spending/page.tsx
@@ -1,13 +1,9 @@
+import { Suspense } from "react";
 import { Header } from "@/components/layout/header";
-import { CategorySpendingClient } from "@/components/category-spending/category-spending-client";
-import {
-  getCategorySpendingData,
-  getCategorySpendingTransactionsPage,
-} from "@/lib/actions/category-spending";
-import { getUserAccounts } from "@/lib/actions/dashboard";
-import { getUserCategories } from "@/lib/actions/categories";
+import { ChartSkeleton, FiltersSkeleton, TableSkeleton } from "@/components/skeletons/page-skeletons";
 import { parseCategorySpendingSearchParams } from "@/lib/category-spending/query-params";
 import { parseTransactionsSearchParams } from "@/lib/transactions/query-state";
+import { CategorySpendingSection } from "./_sections";
 
 interface CategorySpendingPageProps {
   searchParams: Promise<{
@@ -15,48 +11,26 @@ interface CategorySpendingPageProps {
   }>;
 }
 
-export default async function CategorySpendingPage({
-  searchParams,
-}: CategorySpendingPageProps) {
+export default async function CategorySpendingPage({ searchParams }: CategorySpendingPageProps) {
   const params = await searchParams;
   const parsed = parseCategorySpendingSearchParams(params);
   const tableQueryState = parseTransactionsSearchParams(params);
 
-  const [data, transactionsPage, accounts, categories] = await Promise.all([
-    getCategorySpendingData({
-      accountIds: parsed.accountIds,
-      dateFrom: parsed.dateFrom,
-      dateTo: parsed.dateTo,
-      horizon: parsed.effectiveHorizon,
-    }),
-    getCategorySpendingTransactionsPage({
-      accountIds: parsed.accountIds,
-      dateFrom: parsed.dateFrom,
-      dateTo: parsed.dateTo,
-      horizon: parsed.effectiveHorizon,
-      categoryIds: parsed.categoryIds,
-      page: parsed.page,
-      pageSize: parsed.pageSize,
-      sort: parsed.sort,
-      order: parsed.order,
-    }),
-    getUserAccounts(),
-    getUserCategories(),
-  ]);
-
   return (
     <>
       <Header title="Category Spending" />
-      <CategorySpendingClient
-        data={data}
-        query={parsed}
-        initialSelectedCategoryIds={parsed.categoryIds}
-        transactions={transactionsPage.rows}
-        transactionsTotalCount={transactionsPage.totalCount}
-        transactionsQueryState={tableQueryState}
-        accounts={accounts}
-        categories={categories}
-      />
+      <Suspense
+        key={JSON.stringify({ parsed, tableQueryState })}
+        fallback={
+          <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+            <FiltersSkeleton />
+            <ChartSkeleton height={360} />
+            <TableSkeleton rows={10} />
+          </div>
+        }
+      >
+        <CategorySpendingSection parsed={parsed} tableQueryState={tableQueryState} />
+      </Suspense>
     </>
   );
 }

--- a/frontend/app/(dashboard)/investments/_sections.tsx
+++ b/frontend/app/(dashboard)/investments/_sections.tsx
@@ -8,17 +8,16 @@ import { InvestmentsEmpty } from "@/components/investments/InvestmentsEmpty";
 import { rangeToDates } from "@/lib/utils/date-ranges";
 
 export async function InvestmentsSection() {
-  const [portfolio, holdings] = await Promise.all([
+  const { from, to } = rangeToDates("1M");
+  const [portfolio, holdings, history] = await Promise.all([
     getPortfolio(),
     listHoldings(),
+    getPortfolioHistory(from, to),
   ]);
 
   if (holdings.length === 0) {
     return <InvestmentsEmpty />;
   }
-
-  const { from, to } = rangeToDates("1M");
-  const history = await getPortfolioHistory(from, to);
 
   return (
     <InvestmentsOverview

--- a/frontend/app/(dashboard)/investments/_sections.tsx
+++ b/frontend/app/(dashboard)/investments/_sections.tsx
@@ -1,0 +1,31 @@
+import {
+  getPortfolio,
+  listHoldings,
+  getPortfolioHistory,
+} from "@/lib/api/investments";
+import { InvestmentsOverview } from "@/components/investments/InvestmentsOverview";
+import { InvestmentsEmpty } from "@/components/investments/InvestmentsEmpty";
+import { rangeToDates } from "@/lib/utils/date-ranges";
+
+export async function InvestmentsSection() {
+  const [portfolio, holdings] = await Promise.all([
+    getPortfolio(),
+    listHoldings(),
+  ]);
+
+  if (holdings.length === 0) {
+    return <InvestmentsEmpty />;
+  }
+
+  const { from, to } = rangeToDates("1M");
+  const history = await getPortfolioHistory(from, to);
+
+  return (
+    <InvestmentsOverview
+      portfolio={portfolio}
+      holdings={holdings}
+      initialHistory={history}
+      initialRange="1M"
+    />
+  );
+}

--- a/frontend/app/(dashboard)/investments/loading.tsx
+++ b/frontend/app/(dashboard)/investments/loading.tsx
@@ -1,0 +1,14 @@
+import { HeaderSkeleton, CardGridSkeleton, ChartSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+
+export default function Loading() {
+  return (
+    <>
+      <HeaderSkeleton title="Investments" />
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <CardGridSkeleton count={3} />
+        <ChartSkeleton />
+        <DetailListSkeleton rows={6} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/investments/page.tsx
+++ b/frontend/app/(dashboard)/investments/page.tsx
@@ -1,42 +1,24 @@
-import {
-  getPortfolio,
-  listHoldings,
-  getPortfolioHistory,
-} from "@/lib/api/investments";
+import { Suspense } from "react";
 import { Header } from "@/components/layout/header";
-import { InvestmentsOverview } from "@/components/investments/InvestmentsOverview";
-import { InvestmentsEmpty } from "@/components/investments/InvestmentsEmpty";
-import { rangeToDates } from "@/lib/utils/date-ranges";
+import { CardGridSkeleton, ChartSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+import { InvestmentsSection } from "./_sections";
 
-export const dynamic = "force-dynamic";
-
-export default async function InvestmentsPage() {
-  const [portfolio, holdings] = await Promise.all([
-    getPortfolio(),
-    listHoldings(),
-  ]);
-  if (holdings.length === 0) {
-    return (
-      <>
-        <Header title="Investments" />
-        <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-          <InvestmentsEmpty />
-        </div>
-      </>
-    );
-  }
-  const { from, to } = rangeToDates("1M");
-  const history = await getPortfolioHistory(from, to);
+export default function InvestmentsPage() {
   return (
     <>
       <Header title="Investments" />
       <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
-        <InvestmentsOverview
-          portfolio={portfolio}
-          holdings={holdings}
-          initialHistory={history}
-          initialRange="1M"
-        />
+        <Suspense
+          fallback={
+            <>
+              <CardGridSkeleton count={3} />
+              <ChartSkeleton />
+              <DetailListSkeleton rows={6} />
+            </>
+          }
+        >
+          <InvestmentsSection />
+        </Suspense>
       </div>
     </>
   );

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -1,10 +1,10 @@
 import { redirect } from "next/navigation";
-import { cookies, headers } from "next/headers";
+import { cookies } from "next/headers";
 import { JetBrains_Mono } from "next/font/google";
-import { auth } from "@/lib/auth";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/app-sidebar";
-import { getOnboardingStatus, getOnboardingRedirectPath } from "@/lib/actions/onboarding";
+import { getOnboardingRedirectPath } from "@/lib/actions/onboarding";
+import { getCachedSession, getCachedOnboardingStatus } from "@/lib/data/cached";
 import { ImportStatusNotifier } from "@/components/import-status-notifier";
 import { WalkthroughProvider } from "@/components/walkthrough/walkthrough-provider";
 
@@ -19,9 +19,7 @@ export default async function DashboardLayout({
   const sidebarCookie = cookieStore.get("syllogic.sidebar.open")?.value;
   const defaultSidebarOpen = sidebarCookie === "true";
 
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
+  const session = await getCachedSession();
 
   if (!session) {
     redirect("/login");
@@ -31,7 +29,7 @@ export default async function DashboardLayout({
   //
   // Note: `redirect()` throws a special Next.js error to trigger navigation.
   // Do NOT wrap this in a broad try/catch, or the redirect will be swallowed.
-  const onboardingStatus = await getOnboardingStatus();
+  const onboardingStatus = await getCachedOnboardingStatus();
   if (onboardingStatus && !onboardingStatus.isCompleted) {
     const redirectPath = await getOnboardingRedirectPath(onboardingStatus.status);
     redirect(redirectPath);

--- a/frontend/app/(dashboard)/settings/loading.tsx
+++ b/frontend/app/(dashboard)/settings/loading.tsx
@@ -1,0 +1,12 @@
+import { HeaderSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+
+export default function Loading() {
+  return (
+    <>
+      <HeaderSkeleton title="Settings" />
+      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+        <DetailListSkeleton rows={10} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/subscriptions/_sections.tsx
+++ b/frontend/app/(dashboard)/subscriptions/_sections.tsx
@@ -1,0 +1,25 @@
+import { SubscriptionsClient } from "@/components/subscriptions/subscriptions-client";
+import { getSubscriptions, getSubscriptionKpis } from "@/lib/actions/subscriptions";
+import { getUserCategories } from "@/lib/actions/categories";
+import { getPendingSuggestions } from "@/lib/actions/subscription-suggestions";
+import { getAccounts } from "@/lib/actions/accounts";
+
+export async function SubscriptionsSection() {
+  const [subscriptions, accounts, categories, suggestions, kpis] = await Promise.all([
+    getSubscriptions(),
+    getAccounts(),
+    getUserCategories(),
+    getPendingSuggestions(),
+    getSubscriptionKpis(),
+  ]);
+
+  return (
+    <SubscriptionsClient
+      initialSubscriptions={subscriptions}
+      accounts={accounts}
+      categories={categories}
+      suggestions={suggestions}
+      kpis={kpis}
+    />
+  );
+}

--- a/frontend/app/(dashboard)/subscriptions/loading.tsx
+++ b/frontend/app/(dashboard)/subscriptions/loading.tsx
@@ -1,0 +1,13 @@
+import { HeaderSkeleton, CardGridSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+
+export default function Loading() {
+  return (
+    <>
+      <HeaderSkeleton title="Subscriptions" />
+      <div className="flex min-h-[calc(100vh-4rem)] flex-col gap-4 p-4">
+        <CardGridSkeleton count={4} />
+        <DetailListSkeleton rows={8} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/subscriptions/page.tsx
+++ b/frontend/app/(dashboard)/subscriptions/page.tsx
@@ -1,27 +1,20 @@
-import { SubscriptionsClient } from "@/components/subscriptions/subscriptions-client";
-import { getSubscriptions, getSubscriptionKpis } from "@/lib/actions/subscriptions";
-import { getUserCategories } from "@/lib/actions/categories";
-import { getPendingSuggestions } from "@/lib/actions/subscription-suggestions";
-import { getAccounts } from "@/lib/actions/accounts";
+import { Suspense } from "react";
+import { CardGridSkeleton, DetailListSkeleton } from "@/components/skeletons/page-skeletons";
+import { SubscriptionsSection } from "./_sections";
 
-export default async function SubscriptionsPage() {
-  const [subscriptions, accounts, categories, suggestions, kpis] = await Promise.all([
-    getSubscriptions(),
-    getAccounts(),
-    getUserCategories(),
-    getPendingSuggestions(),
-    getSubscriptionKpis(),
-  ]);
-
+export default function SubscriptionsPage() {
   return (
     <div className="flex min-h-[calc(100vh-4rem)] flex-col gap-4 p-4">
-      <SubscriptionsClient
-        initialSubscriptions={subscriptions}
-        accounts={accounts}
-        categories={categories}
-        suggestions={suggestions}
-        kpis={kpis}
-      />
+      <Suspense
+        fallback={
+          <>
+            <CardGridSkeleton count={4} />
+            <DetailListSkeleton rows={8} />
+          </>
+        }
+      >
+        <SubscriptionsSection />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/app/(dashboard)/transactions/_sections.tsx
+++ b/frontend/app/(dashboard)/transactions/_sections.tsx
@@ -10,17 +10,17 @@ export async function TransactionsSection({
 }: {
   queryState: TransactionsQueryState;
 }) {
-  const session = await getAuthenticatedSession();
-  const canImportCsv =
-    !!process.env.OPENAI_API_KEY &&
-    !isDemoRestrictedUserEmail(session?.user.email);
-  const canDelete = !isDemoRestrictedUserEmail(session?.user.email);
-
-  const [pageData, categories, accounts] = await Promise.all([
+  const [session, pageData, categories, accounts] = await Promise.all([
+    getAuthenticatedSession(),
     getTransactionsPage(queryState),
     getUserCategories(),
     getUserAccounts(),
   ]);
+
+  const canImportCsv =
+    !!process.env.OPENAI_API_KEY &&
+    !isDemoRestrictedUserEmail(session?.user.email);
+  const canDelete = !isDemoRestrictedUserEmail(session?.user.email);
 
   return (
     <TransactionsClient

--- a/frontend/app/(dashboard)/transactions/_sections.tsx
+++ b/frontend/app/(dashboard)/transactions/_sections.tsx
@@ -1,0 +1,37 @@
+import { TransactionsClient } from "./transactions-client";
+import { getTransactionsPage, getUserAccounts } from "@/lib/actions/transactions";
+import { getUserCategories } from "@/lib/actions/categories";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
+import type { TransactionsQueryState } from "@/lib/transactions/query-state";
+
+export async function TransactionsSection({
+  queryState,
+}: {
+  queryState: TransactionsQueryState;
+}) {
+  const session = await getAuthenticatedSession();
+  const canImportCsv =
+    !!process.env.OPENAI_API_KEY &&
+    !isDemoRestrictedUserEmail(session?.user.email);
+  const canDelete = !isDemoRestrictedUserEmail(session?.user.email);
+
+  const [pageData, categories, accounts] = await Promise.all([
+    getTransactionsPage(queryState),
+    getUserCategories(),
+    getUserAccounts(),
+  ]);
+
+  return (
+    <TransactionsClient
+      initialTransactions={pageData.rows}
+      totalCount={pageData.totalCount}
+      filteredTotals={pageData.filteredTotals}
+      initialQueryState={queryState}
+      categories={categories}
+      accounts={accounts}
+      canImportCsv={canImportCsv}
+      canDelete={canDelete}
+    />
+  );
+}

--- a/frontend/app/(dashboard)/transactions/import/page.tsx
+++ b/frontend/app/(dashboard)/transactions/import/page.tsx
@@ -25,7 +25,7 @@ import { Header } from "@/components/layout/header";
 import { CsvUploadDropzone } from "@/components/transactions/csv-upload-dropzone";
 import { getUserAccounts } from "@/lib/actions/transactions";
 import { initializeCsvImport } from "@/lib/actions/csv-import";
-import type { Account } from "@/lib/db/schema";
+type Account = { id: string; name: string; institution: string | null; accountType: string; currency: string | null };
 
 export default function CsvImportPage() {
   const router = useRouter();

--- a/frontend/app/(dashboard)/transactions/loading.tsx
+++ b/frontend/app/(dashboard)/transactions/loading.tsx
@@ -1,0 +1,13 @@
+import { HeaderSkeleton, FiltersSkeleton, TableSkeleton } from "@/components/skeletons/page-skeletons";
+
+export default function Loading() {
+  return (
+    <>
+      <HeaderSkeleton title="Transactions" />
+      <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4 pt-0">
+        <FiltersSkeleton />
+        <TableSkeleton rows={14} />
+      </div>
+    </>
+  );
+}

--- a/frontend/app/(dashboard)/transactions/page.tsx
+++ b/frontend/app/(dashboard)/transactions/page.tsx
@@ -1,11 +1,8 @@
 import { Suspense } from "react";
 import { Header } from "@/components/layout/header";
-import { TransactionsClient } from "./transactions-client";
-import { getTransactionsPage, getUserAccounts } from "@/lib/actions/transactions";
-import { getUserCategories } from "@/lib/actions/categories";
+import { TableSkeleton, FiltersSkeleton } from "@/components/skeletons/page-skeletons";
 import { parseTransactionsSearchParams } from "@/lib/transactions/query-state";
-import { getAuthenticatedSession } from "@/lib/auth-helpers";
-import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
+import { TransactionsSection } from "./_sections";
 
 interface TransactionsPageProps {
   searchParams: Promise<{
@@ -16,33 +13,21 @@ interface TransactionsPageProps {
 export default async function TransactionsPage({ searchParams }: TransactionsPageProps) {
   const params = await searchParams;
   const queryState = parseTransactionsSearchParams(params);
-  const session = await getAuthenticatedSession();
-  const canImportCsv =
-    !!process.env.OPENAI_API_KEY &&
-    !isDemoRestrictedUserEmail(session?.user.email);
-  const canDelete = !isDemoRestrictedUserEmail(session?.user.email);
-
-  const [pageData, categories, accounts] = await Promise.all([
-    getTransactionsPage(queryState),
-    getUserCategories(),
-    getUserAccounts(),
-  ]);
 
   return (
     <>
       <Header title="Transactions" />
       <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4 pt-0">
-        <Suspense fallback={<div className="flex-1" />}>
-          <TransactionsClient
-            initialTransactions={pageData.rows}
-            totalCount={pageData.totalCount}
-            filteredTotals={pageData.filteredTotals}
-            initialQueryState={queryState}
-            categories={categories}
-            accounts={accounts}
-            canImportCsv={canImportCsv}
-            canDelete={canDelete}
-          />
+        <Suspense
+          key={JSON.stringify(queryState)}
+          fallback={
+            <>
+              <FiltersSkeleton />
+              <TableSkeleton rows={14} />
+            </>
+          }
+        >
+          <TransactionsSection queryState={queryState} />
         </Suspense>
       </div>
     </>

--- a/frontend/app/step-4/page.tsx
+++ b/frontend/app/step-4/page.tsx
@@ -25,7 +25,7 @@ import { OnboardingProgress } from "@/components/onboarding/onboarding-progress"
 import { CsvUploadDropzone } from "@/components/transactions/csv-upload-dropzone";
 import { getUserAccounts } from "@/lib/actions/transactions";
 import { initializeCsvImport } from "@/lib/actions/csv-import";
-import type { Account } from "@/lib/db/schema";
+type Account = { id: string; name: string; institution: string | null; accountType: string; currency: string | null };
 
 export default function StepFourImportPage() {
   const router = useRouter();

--- a/frontend/components/layout/app-sidebar.tsx
+++ b/frontend/components/layout/app-sidebar.tsx
@@ -188,7 +188,6 @@ export function AppSidebar({ initialUser }: AppSidebarProps) {
                 <SidebarMenuItem key={item.href}>
                   <SidebarMenuButton
                     isActive={isActive}
-                    tooltip={item.title}
                     render={
                       <Link
                         href={
@@ -199,6 +198,7 @@ export function AppSidebar({ initialUser }: AppSidebarProps) {
                             : item.href
                         }
                         prefetch
+                        title={isCollapsed ? item.title : undefined}
                       />
                     }
                   >

--- a/frontend/components/layout/app-sidebar.tsx
+++ b/frontend/components/layout/app-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
   RiHomeLine,
@@ -188,14 +189,17 @@ export function AppSidebar({ initialUser }: AppSidebarProps) {
                   <SidebarMenuButton
                     isActive={isActive}
                     tooltip={item.title}
-                    onClick={() =>
-                      router.push(
-                        item.href === "/"
-                          ? getHomePathWithFilters()
-                          : item.href === "/transactions"
-                          ? getTransactionsPathWithFilters()
-                          : item.href
-                      )
+                    render={
+                      <Link
+                        href={
+                          item.href === "/"
+                            ? getHomePathWithFilters()
+                            : item.href === "/transactions"
+                            ? getTransactionsPathWithFilters()
+                            : item.href
+                        }
+                        prefetch
+                      />
                     }
                   >
                     <item.icon className="shrink-0" />

--- a/frontend/components/skeletons/page-skeletons.tsx
+++ b/frontend/components/skeletons/page-skeletons.tsx
@@ -1,0 +1,59 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function HeaderSkeleton({ title }: { title: string }) {
+  return (
+    <div className="flex h-16 items-center gap-2 border-b px-4">
+      <Skeleton className="h-5 w-5" />
+      <span className="text-base font-medium">{title}</span>
+    </div>
+  );
+}
+
+export function TableSkeleton({ rows = 12 }: { rows?: number }) {
+  return (
+    <div className="flex flex-1 flex-col gap-2">
+      <div className="flex gap-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 flex-1" />
+        ))}
+      </div>
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-10 w-full" />
+      ))}
+    </div>
+  );
+}
+
+export function FiltersSkeleton() {
+  return (
+    <div className="flex gap-2">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton key={i} className="h-9 w-32" />
+      ))}
+    </div>
+  );
+}
+
+export function CardGridSkeleton({ count = 4 }: { count?: number }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <Skeleton key={i} className="h-28 w-full" />
+      ))}
+    </div>
+  );
+}
+
+export function ChartSkeleton({ height = 320 }: { height?: number }) {
+  return <Skeleton className="w-full" style={{ height }} />;
+}
+
+export function DetailListSkeleton({ rows = 8 }: { rows?: number }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-12 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/transactions/add-transaction-dialog.tsx
+++ b/frontend/components/transactions/add-transaction-dialog.tsx
@@ -33,7 +33,8 @@ import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { createTransaction, getUserAccounts } from "@/lib/actions/transactions";
 import { getUserCategories } from "@/lib/actions/categories";
-import type { Account, Category } from "@/lib/db/schema";
+import type { Category } from "@/lib/db/schema";
+type Account = { id: string; name: string; institution: string | null; accountType: string; currency: string | null };
 import type { CategoryDisplay } from "@/types";
 import { getCategoriesForTransactionType } from "@/lib/utils/category-utils";
 

--- a/frontend/lib/actions/accounts.ts
+++ b/frontend/lib/actions/accounts.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { eq, and, lte, gte, lt, desc, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, accountBalances, transactions, recurringTransactions, subscriptionSuggestions, type NewAccount } from "@/lib/db/schema";
@@ -50,7 +50,7 @@ export async function createAccount(
 
     revalidatePath("/settings");
     revalidatePath("/transactions/import");
-    revalidateTag(CACHE_TAGS.accounts(userId), "default");
+    updateTag(CACHE_TAGS.accounts(userId));
     return { success: true, accountId: result.id };
   } catch (error) {
     console.error("Failed to create account:", error);
@@ -108,7 +108,7 @@ export async function updateAccount(
     revalidatePath("/transactions");
     revalidatePath("/settings");
     revalidatePath("/");
-    revalidateTag(CACHE_TAGS.accounts(userId), "default");
+    updateTag(CACHE_TAGS.accounts(userId));
     return { success: true };
   } catch (error) {
     console.error("Failed to update account:", error);
@@ -147,7 +147,7 @@ export async function deleteAccount(
 
     revalidatePath("/settings");
     revalidatePath("/");
-    revalidateTag(CACHE_TAGS.accounts(userId), "default");
+    updateTag(CACHE_TAGS.accounts(userId));
     return { success: true };
   } catch (error) {
     console.error("Failed to delete account:", error);
@@ -224,7 +224,7 @@ export async function hardDeleteAccount(
     revalidatePath("/");
     revalidatePath("/transactions");
     revalidatePath("/assets");
-    revalidateTag(CACHE_TAGS.accounts(userId), "default");
+    updateTag(CACHE_TAGS.accounts(userId));
 
     return {
       success: true,
@@ -307,7 +307,7 @@ export async function recalculateStartingBalance(
     revalidatePath("/transactions");
     revalidatePath("/");
     revalidatePath("/assets");
-    revalidateTag(CACHE_TAGS.accounts(userId), "default");
+    updateTag(CACHE_TAGS.accounts(userId));
 
     return { success: true, newStartingBalance };
   } catch (error) {

--- a/frontend/lib/actions/accounts.ts
+++ b/frontend/lib/actions/accounts.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { eq, and, lte, gte, lt, desc, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { accounts, accountBalances, transactions, recurringTransactions, subscriptionSuggestions, type NewAccount } from "@/lib/db/schema";
@@ -8,10 +8,8 @@ import { requireAuth, getAuthenticatedSession } from "@/lib/auth-helpers";
 import { isDemoRestrictedUserEmail, DEMO_RESTRICTED_ACTION_ERROR } from "@/lib/demo-access";
 import { getBackendBaseUrl } from "@/lib/backend-url";
 import { createInternalAuthHeaders } from "@/lib/internal-auth";
-import {
-  resolveMissingAccountLogo,
-  resolveMissingAccountLogos,
-} from "@/lib/actions/account-logos";
+import { resolveMissingAccountLogo } from "@/lib/actions/account-logos";
+import { getCachedFullUserAccounts, CACHE_TAGS } from "@/lib/data/cached";
 
 export interface CreateAccountInput {
   name: string;
@@ -52,6 +50,7 @@ export async function createAccount(
 
     revalidatePath("/settings");
     revalidatePath("/transactions/import");
+    revalidateTag(CACHE_TAGS.accounts(userId), "default");
     return { success: true, accountId: result.id };
   } catch (error) {
     console.error("Failed to create account:", error);
@@ -109,6 +108,7 @@ export async function updateAccount(
     revalidatePath("/transactions");
     revalidatePath("/settings");
     revalidatePath("/");
+    revalidateTag(CACHE_TAGS.accounts(userId), "default");
     return { success: true };
   } catch (error) {
     console.error("Failed to update account:", error);
@@ -147,6 +147,7 @@ export async function deleteAccount(
 
     revalidatePath("/settings");
     revalidatePath("/");
+    revalidateTag(CACHE_TAGS.accounts(userId), "default");
     return { success: true };
   } catch (error) {
     console.error("Failed to delete account:", error);
@@ -223,6 +224,7 @@ export async function hardDeleteAccount(
     revalidatePath("/");
     revalidatePath("/transactions");
     revalidatePath("/assets");
+    revalidateTag(CACHE_TAGS.accounts(userId), "default");
 
     return {
       success: true,
@@ -236,27 +238,7 @@ export async function hardDeleteAccount(
 }
 
 export async function getAccounts() {
-  const userId = await requireAuth();
-
-  if (!userId) {
-    return [];
-  }
-
-  const accountRows = await db.query.accounts.findMany({
-    where: and(eq(accounts.userId, userId), eq(accounts.isActive, true)),
-    orderBy: (accounts, { asc }) => [asc(accounts.name)],
-    with: {
-      logo: {
-        columns: {
-          id: true,
-          logoUrl: true,
-          updatedAt: true,
-        },
-      },
-    },
-  });
-
-  return resolveMissingAccountLogos(accountRows);
+  return getCachedFullUserAccounts();
 }
 
 export async function recalculateStartingBalance(
@@ -325,6 +307,7 @@ export async function recalculateStartingBalance(
     revalidatePath("/transactions");
     revalidatePath("/");
     revalidatePath("/assets");
+    revalidateTag(CACHE_TAGS.accounts(userId), "default");
 
     return { success: true, newStartingBalance };
   } catch (error) {

--- a/frontend/lib/actions/categories.ts
+++ b/frontend/lib/actions/categories.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { eq, and, count } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { categories, transactions, type Category, type NewCategory } from "@/lib/db/schema";
@@ -73,7 +73,7 @@ export async function createCategory(
 
     revalidatePath("/");
     revalidatePath("/settings");
-    revalidateTag(CACHE_TAGS.categories(userId), "default");
+    updateTag(CACHE_TAGS.categories(userId));
     return { success: true, categoryId: inserted.id };
   } catch (error) {
     console.error("Failed to create category:", error);
@@ -131,7 +131,7 @@ export async function updateCategory(
 
       revalidatePath("/");
       revalidatePath("/settings");
-      revalidateTag(CACHE_TAGS.categories(userId), "default");
+      updateTag(CACHE_TAGS.categories(userId));
       return { success: true };
     }
 
@@ -165,7 +165,7 @@ export async function updateCategory(
 
     revalidatePath("/");
     revalidatePath("/settings");
-    revalidateTag(CACHE_TAGS.categories(userId), "default");
+    updateTag(CACHE_TAGS.categories(userId));
     return { success: true };
   } catch (error) {
     console.error("Failed to update category:", error);
@@ -226,7 +226,7 @@ export async function deleteCategory(
     revalidatePath("/");
     revalidatePath("/settings");
     revalidatePath("/transactions");
-    revalidateTag(CACHE_TAGS.categories(userId), "default");
+    updateTag(CACHE_TAGS.categories(userId));
     return { success: true };
   } catch (error) {
     console.error("Failed to delete category:", error);
@@ -397,7 +397,7 @@ export async function deleteCategoryWithReassignment(
     revalidatePath("/");
     revalidatePath("/settings");
     revalidatePath("/transactions");
-    revalidateTag(CACHE_TAGS.categories(userId), "default");
+    updateTag(CACHE_TAGS.categories(userId));
 
     return { success: true, reassignedCount };
   } catch (error) {

--- a/frontend/lib/actions/categories.ts
+++ b/frontend/lib/actions/categories.ts
@@ -1,10 +1,11 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { eq, and, count } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { categories, transactions, type Category, type NewCategory } from "@/lib/db/schema";
 import { requireAuth } from "@/lib/auth-helpers";
+import { getCachedUserCategories, CACHE_TAGS } from "@/lib/data/cached";
 
 export interface CategoryCreateInput {
   name: string;
@@ -72,6 +73,7 @@ export async function createCategory(
 
     revalidatePath("/");
     revalidatePath("/settings");
+    revalidateTag(CACHE_TAGS.categories(userId), "default");
     return { success: true, categoryId: inserted.id };
   } catch (error) {
     console.error("Failed to create category:", error);
@@ -129,6 +131,7 @@ export async function updateCategory(
 
       revalidatePath("/");
       revalidatePath("/settings");
+      revalidateTag(CACHE_TAGS.categories(userId), "default");
       return { success: true };
     }
 
@@ -162,6 +165,7 @@ export async function updateCategory(
 
     revalidatePath("/");
     revalidatePath("/settings");
+    revalidateTag(CACHE_TAGS.categories(userId), "default");
     return { success: true };
   } catch (error) {
     console.error("Failed to update category:", error);
@@ -222,6 +226,7 @@ export async function deleteCategory(
     revalidatePath("/");
     revalidatePath("/settings");
     revalidatePath("/transactions");
+    revalidateTag(CACHE_TAGS.categories(userId), "default");
     return { success: true };
   } catch (error) {
     console.error("Failed to delete category:", error);
@@ -230,16 +235,7 @@ export async function deleteCategory(
 }
 
 export async function getCategories(): Promise<Category[]> {
-  const userId = await requireAuth();
-
-  if (!userId) {
-    return [];
-  }
-
-  return db.query.categories.findMany({
-    where: eq(categories.userId, userId),
-    orderBy: (categories, { asc }) => [asc(categories.name)],
-  });
+  return getCachedUserCategories() as Promise<Category[]>;
 }
 
 // Alias for backward compatibility
@@ -401,6 +397,7 @@ export async function deleteCategoryWithReassignment(
     revalidatePath("/");
     revalidatePath("/settings");
     revalidatePath("/transactions");
+    revalidateTag(CACHE_TAGS.categories(userId), "default");
 
     return { success: true, reassignedCount };
   } catch (error) {

--- a/frontend/lib/actions/dashboard.ts
+++ b/frontend/lib/actions/dashboard.ts
@@ -3,6 +3,7 @@
 import { db } from "@/lib/db";
 import { accounts, transactions, categories, users, properties, vehicles, accountBalances, transactionLinks } from "@/lib/db/schema";
 import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { getCachedUserAccounts } from "@/lib/data/cached";
 import { eq, sql, gte, lte, and, desc, inArray, isNull } from "drizzle-orm";
 import { buildConservativeSankey } from "@/lib/dashboard/sankey";
 import {
@@ -72,24 +73,7 @@ async function getLatestTransactionDate(userId: string, accountIds?: string[]): 
 
 // Get user accounts for filter dropdown
 export async function getUserAccounts() {
-  const session = await getAuthenticatedSession();
-
-  if (!session?.user?.id) {
-    return [];
-  }
-
-  const result = await db
-    .select({
-      id: accounts.id,
-      name: accounts.name,
-      institution: accounts.institution,
-      accountType: accounts.accountType,
-    })
-    .from(accounts)
-    .where(and(eq(accounts.userId, session.user.id), eq(accounts.isActive, true)))
-    .orderBy(accounts.name);
-
-  return result;
+  return getCachedUserAccounts();
 }
 
 // Get available months/years for the date selector

--- a/frontend/lib/actions/onboarding.ts
+++ b/frontend/lib/actions/onboarding.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users, categories, type User, type NewCategory } from "@/lib/db/schema";
@@ -127,7 +127,7 @@ export async function updatePersonalDetails(
       })
       .where(eq(users.id, session.user.id));
 
-    revalidateTag(CACHE_TAGS.onboarding(session.user.id), "default");
+    updateTag(CACHE_TAGS.onboarding(session.user.id));
     // Ensure layout consumers (sidebar avatar) pick up the updated image immediately.
     revalidatePath("/", "layout");
     return { success: true };
@@ -184,8 +184,8 @@ export async function saveOnboardingCategories(
       })
       .where(eq(users.id, userId));
 
-    revalidateTag(CACHE_TAGS.onboarding(userId), "default");
-    revalidateTag(CACHE_TAGS.categories(userId), "default");
+    updateTag(CACHE_TAGS.onboarding(userId));
+    updateTag(CACHE_TAGS.categories(userId));
     revalidatePath("/");
     return { success: true };
   } catch (error) {
@@ -215,7 +215,7 @@ export async function completeOnboarding(): Promise<{ success: boolean; error?: 
       })
       .where(eq(users.id, userId));
 
-    revalidateTag(CACHE_TAGS.onboarding(userId), "default");
+    updateTag(CACHE_TAGS.onboarding(userId));
     revalidatePath("/");
     return { success: true };
   } catch (error) {

--- a/frontend/lib/actions/onboarding.ts
+++ b/frontend/lib/actions/onboarding.ts
@@ -1,12 +1,13 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users, categories, type User, type NewCategory } from "@/lib/db/schema";
 import { getAuthenticatedSession, requireAuth } from "@/lib/auth-helpers";
 import { storage } from "@/lib/storage";
 import { DEFAULT_CATEGORIES, type DefaultCategory } from "@/lib/constants/default-categories";
+import { CACHE_TAGS } from "@/lib/data/cached";
 import { type CategoryInput } from "./categories";
 
 export type OnboardingStatus = "pending" | "step_1" | "step_2" | "step_3" | "completed";
@@ -126,6 +127,7 @@ export async function updatePersonalDetails(
       })
       .where(eq(users.id, session.user.id));
 
+    revalidateTag(CACHE_TAGS.onboarding(session.user.id), "default");
     // Ensure layout consumers (sidebar avatar) pick up the updated image immediately.
     revalidatePath("/", "layout");
     return { success: true };
@@ -182,6 +184,8 @@ export async function saveOnboardingCategories(
       })
       .where(eq(users.id, userId));
 
+    revalidateTag(CACHE_TAGS.onboarding(userId), "default");
+    revalidateTag(CACHE_TAGS.categories(userId), "default");
     revalidatePath("/");
     return { success: true };
   } catch (error) {
@@ -211,6 +215,7 @@ export async function completeOnboarding(): Promise<{ success: boolean; error?: 
       })
       .where(eq(users.id, userId));
 
+    revalidateTag(CACHE_TAGS.onboarding(userId), "default");
     revalidatePath("/");
     return { success: true };
   } catch (error) {

--- a/frontend/lib/actions/transactions.ts
+++ b/frontend/lib/actions/transactions.ts
@@ -316,21 +316,7 @@ export async function updateTransactionCategory(
   }
 }
 
-export async function getUserAccounts() {
-  const userId = await requireAuth();
-
-  if (!userId) {
-    return [];
-  }
-
-  return db.query.accounts.findMany({
-    where: and(
-      eq(accounts.userId, userId),
-      eq(accounts.isActive, true)
-    ),
-    orderBy: [desc(accounts.createdAt)],
-  });
-}
+export { getUserAccounts } from "@/lib/actions/dashboard";
 
 // Note: getUserCategories has been consolidated in lib/actions/categories.ts
 // Use: import { getUserCategories } from "@/lib/actions/categories"

--- a/frontend/lib/actions/transactions.ts
+++ b/frontend/lib/actions/transactions.ts
@@ -316,7 +316,11 @@ export async function updateTransactionCategory(
   }
 }
 
-export { getUserAccounts } from "@/lib/actions/dashboard";
+import { getUserAccounts as _dashboardGetUserAccounts } from "@/lib/actions/dashboard";
+
+export async function getUserAccounts() {
+  return _dashboardGetUserAccounts();
+}
 
 // Note: getUserCategories has been consolidated in lib/actions/categories.ts
 // Use: import { getUserCategories } from "@/lib/actions/categories"

--- a/frontend/lib/data/__tests__/cached.test.ts
+++ b/frontend/lib/data/__tests__/cached.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: vi.fn(),
+    query: { categories: { findMany: vi.fn() } },
+  },
+}));
+
+vi.mock("@/lib/auth-helpers", () => ({
+  getAuthenticatedSession: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  unstable_cache: <T extends (...args: any[]) => any>(fn: T) => fn,
+  revalidateTag: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/account-logos", () => ({
+  resolveMissingAccountLogos: (rows: any) => rows,
+  resolveMissingAccountLogo: (row: any) => row,
+}));
+
+describe("cached data layer", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("dedupes getCachedUserCategories within a single request via React.cache", async () => {
+    const { getAuthenticatedSession } = await import("@/lib/auth-helpers");
+    (getAuthenticatedSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { id: "user-1" },
+    });
+
+    const { getCachedUserCategories } = await import("../cached");
+
+    const a = await getCachedUserCategories();
+    const b = await getCachedUserCategories();
+
+    expect(a).toBe(b);
+  });
+});

--- a/frontend/lib/data/cached.ts
+++ b/frontend/lib/data/cached.ts
@@ -55,6 +55,7 @@ async function fetchAccountsForUser(userId: string) {
       name: accounts.name,
       institution: accounts.institution,
       accountType: accounts.accountType,
+      currency: accounts.currency,
     })
     .from(accounts)
     .where(and(eq(accounts.userId, userId), eq(accounts.isActive, true)))

--- a/frontend/lib/data/cached.ts
+++ b/frontend/lib/data/cached.ts
@@ -1,0 +1,161 @@
+// Cached read layer. NOT a "use server" module.
+// Two cache layers:
+// - React.cache: per-request dedup (no TTL, scoped to a single render).
+// - unstable_cache: cross-request, keyed by userId, invalidated by tag.
+// Mutations MUST call revalidateTag(...) for the relevant tag below.
+
+import { cache } from "react";
+import { unstable_cache } from "next/cache";
+import { eq, and } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { accounts, categories, users } from "@/lib/db/schema";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { resolveMissingAccountLogos } from "@/lib/actions/account-logos";
+import type { OnboardingStatus, OnboardingStatusResult } from "@/lib/actions/onboarding";
+
+export const CACHE_TAGS = {
+  categories: (userId: string) => `categories:${userId}`,
+  accounts: (userId: string) => `accounts:${userId}`,
+  onboarding: (userId: string) => `onboarding:${userId}`,
+} as const;
+
+export const getCachedSession = cache(async () => {
+  return getAuthenticatedSession();
+});
+
+// ---------- Categories ----------
+
+async function fetchCategoriesForUser(userId: string) {
+  return db.query.categories.findMany({
+    where: eq(categories.userId, userId),
+    orderBy: (c, { asc }) => [asc(c.name)],
+  });
+}
+
+const getCachedCategoriesByUser = (userId: string) =>
+  unstable_cache(
+    () => fetchCategoriesForUser(userId),
+    ["categories", userId],
+    { tags: [CACHE_TAGS.categories(userId)] },
+  )();
+
+export const getCachedUserCategories = cache(async () => {
+  const session = await getCachedSession();
+  const userId = session?.user?.id;
+  if (!userId) return [];
+  return getCachedCategoriesByUser(userId);
+});
+
+// ---------- Accounts (slim, for filter dropdowns) ----------
+
+async function fetchAccountsForUser(userId: string) {
+  return db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      accountType: accounts.accountType,
+    })
+    .from(accounts)
+    .where(and(eq(accounts.userId, userId), eq(accounts.isActive, true)))
+    .orderBy(accounts.name);
+}
+
+const getCachedAccountsByUser = (userId: string) =>
+  unstable_cache(
+    () => fetchAccountsForUser(userId),
+    ["accounts", userId],
+    { tags: [CACHE_TAGS.accounts(userId)] },
+  )();
+
+export const getCachedUserAccounts = cache(async () => {
+  const session = await getCachedSession();
+  const userId = session?.user?.id;
+  if (!userId) return [];
+  return getCachedAccountsByUser(userId);
+});
+
+// ---------- Accounts (full, with logos — superset for getAccounts) ----------
+
+async function fetchFullAccountsForUser(userId: string) {
+  const accountRows = await db.query.accounts.findMany({
+    where: and(eq(accounts.userId, userId), eq(accounts.isActive, true)),
+    orderBy: (accounts, { asc }) => [asc(accounts.name)],
+    with: {
+      logo: {
+        columns: {
+          id: true,
+          logoUrl: true,
+          updatedAt: true,
+        },
+      },
+    },
+  });
+  return resolveMissingAccountLogos(accountRows);
+}
+
+const getCachedFullAccountsByUser = (userId: string) =>
+  unstable_cache(
+    () => fetchFullAccountsForUser(userId),
+    ["accounts:full", userId],
+    { tags: [CACHE_TAGS.accounts(userId)] },
+  )();
+
+export const getCachedFullUserAccounts = cache(async () => {
+  const session = await getCachedSession();
+  const userId = session?.user?.id;
+  if (!userId) return [];
+  return getCachedFullAccountsByUser(userId);
+});
+
+// ---------- Onboarding status ----------
+// Inlined DB lookup (mirrors lib/actions/onboarding.ts#getOnboardingStatus) to
+// avoid a circular import: that module is "use server" and pulls in storage,
+// constants, and other action modules.
+
+async function fetchOnboardingStatusForUser(
+  userId: string,
+): Promise<OnboardingStatusResult | null> {
+  try {
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+    });
+
+    if (!user) {
+      console.warn(`[Onboarding] User not found: ${userId}`);
+      return null;
+    }
+
+    const status = (user.onboardingStatus as OnboardingStatus) || "pending";
+
+    return {
+      status,
+      isCompleted: status === "completed",
+    };
+  } catch (error: any) {
+    console.error("[Onboarding] Failed to get onboarding status:", {
+      error: error?.message || String(error),
+      stack: error?.stack,
+      userId,
+      databaseUrl: process.env.DATABASE_URL ? "set" : "not set",
+    });
+    return {
+      status: "pending",
+      isCompleted: false,
+    };
+  }
+}
+
+const getCachedOnboardingStatusByUser = (userId: string) =>
+  unstable_cache(
+    () => fetchOnboardingStatusForUser(userId),
+    ["onboarding", userId],
+    { tags: [CACHE_TAGS.onboarding(userId)] },
+  )();
+
+export const getCachedOnboardingStatus = cache(async () => {
+  const session = await getCachedSession();
+  const userId = session?.user?.id;
+  if (!userId) return null;
+  return getCachedOnboardingStatusByUser(userId);
+});

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,16 +3,12 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // Required for production Docker images (small runtime image).
   output: "standalone",
-  // Reduce cache times in development to prevent stale data issues
   experimental: {
     staleTimes: {
-      dynamic: 0,
-      static: 30, // Minimum allowed by Next.js
+      dynamic: 30,
+      static: 180,
     },
-    // Profile photo and CSV flows submit larger payloads via server actions.
     serverActions: {
-      // Keep comfortably above the 10MB client-side CSV limit to account for
-      // multipart/serialization overhead.
       bodySizeLimit: "25mb",
     },
   },


### PR DESCRIPTION
## Summary

Fixes the 4–5s blank-screen on sidebar navigation (e.g. Assets → Transactions) by addressing all three root causes: missing prefetch, blocking data fetches, and zero caching.

**Phase 1 — perceived latency:**
- Sidebar uses `<Link prefetch>` (via base-ui `render` prop) so Next.js warms the RSC payload on hover.
- `loading.tsx` for all 7 dashboard routes — instant skeleton on click.
- All 5 data-heavy pages restructured to **stream**: `page.tsx` returns shell + `<Suspense>`, data fetching moved into co-located `_sections.tsx` async server components.
- Router cache re-enabled in `next.config.ts` (`staleTimes.dynamic: 30`).
- `force-dynamic` removed from investments.

**Phase 2 — caching:**
- New `lib/data/cached.ts` with `React.cache` (per-request dedup) + `unstable_cache` (cross-request, tag-based).
- Slim + rich account cache variants share one tag.
- Layout uses cached session + onboarding helpers (one auth lookup per render instead of two).
- All 4 category and 5 account mutations now call `revalidateTag` alongside existing `revalidatePath`.
- Duplicate `getUserAccounts` consolidated.

## Deferred (follow-up)

Phase 3 (timing instrumentation, indexes, Python-backend hop bypass) is data-driven and was deferred — it needs real DB measurements from a deployed environment to identify the actual slow queries. Plan saved locally at `docs/superpowers/plans/2026-04-26-navigation-perf-optimization.md`.

## Test plan

- [ ] `pnpm dev` and click each sidebar item — skeleton should appear within ~150ms.
- [ ] Navigate Assets → Transactions on a slow connection — header + skeleton render instantly; table streams in.
- [ ] Create / edit / delete a category — change is reflected immediately in transaction categorization dropdowns (revalidateTag working).
- [ ] Create / edit / delete an account — change is reflected immediately on Accounts, Assets, Transactions filter, and Subscriptions.
- [ ] `pnpm tsc --noEmit` passes (verified locally).
- [ ] `pnpm vitest run lib/data` passes (verified locally — cache dedup test).
- [ ] Investments page renders without `force-dynamic` and still shows current portfolio data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the 4–5s blank screen on dashboard navigation by prefetching links, streaming pages, showing skeletons immediately, and caching common reads. Navigation now feels instant while tables and charts stream in.

- **New Features**
  - Shared skeleton components and `loading.tsx` for 7 dashboard routes.
  - Cached read layer `lib/data/cached.ts` using `React.cache` + `unstable_cache` with user-scoped tags; layout uses `getCachedSession` and `getCachedOnboardingStatus`; mutations now call `updateTag` for accounts, categories, and onboarding to ensure read-your-own-writes.
  - Router cache enabled in `next.config.ts` (`staleTimes.dynamic: 30`, `static: 180`); investments no longer `force-dynamic`.
  - Sidebar links use `<Link prefetch>` to warm RSC payloads.

- **Refactors**
  - Streamed data with `Suspense` and co-located `*_sections.tsx` server components; pages render shells with skeleton fallbacks (Transactions, Category Spending, Assets, Subscriptions, Investments).
  - Consolidated user account reads onto the cached layer; removed duplicate `getUserAccounts`; adopted a slim `Account` shape (incl. `currency`) for CSV/import and add-transaction flows.
  - Fixed Next.js “use server” re-export issue by wrapping `transactions.getUserAccounts` re-export in an async function to restore production builds.
  - Additional perf fixes: repaired sidebar prefetch wiring (drop tooltip; use `title` when collapsed), parallelized investments history fetch, and moved session fetch into `Promise.all` on Transactions.

<sup>Written for commit 858d4d9485d3850ebfed2f08a187edc53381ac6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

