### PR TITLE
feat(investments): two-step connect wizard + multi-symbol manual add

### DIFF
--- a/backend/app/services/investment_sync_service.py
+++ b/backend/app/services/investment_sync_service.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import os
+import time
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Callable
@@ -54,11 +56,11 @@ class InvestmentSyncService:
         conn = self.db.query(BrokerConnection).filter_by(account_id=account.id).one()
         creds = decrypt(conn.credentials_encrypted)
         adapter = self.adapter_factory(creds)
+
+        # Step 1 — positions (fatal if it fails; nothing useful happens without them).
         try:
             ref_positions = adapter.request_statement(creds["query_id_positions"])
             positions_xml = adapter.fetch_statement(ref_positions)
-            ref_trades = adapter.request_statement(creds["query_id_trades"])
-            trades_xml = adapter.fetch_statement(ref_trades)
         except FlexAuthError as e:
             conn.last_sync_status = "needs_reauth"
             conn.last_sync_error = str(e)
@@ -75,14 +77,46 @@ class InvestmentSyncService:
             raise
 
         statement = adapter.parse_positions_xml(positions_xml)
-        trades = adapter.parse_trades_xml(trades_xml)
         self._upsert_positions(account, statement.positions)
         self._upsert_cash(account, statement.cash)
-        self._upsert_trades(account, trades)
+        # Persist positions immediately so a later trades-fetch failure
+        # doesn't roll back the work we already did.
+        self.db.commit()
+
+        # Step 2 — trades (best-effort; IBKR Flex throttles a token to ~1
+        # request per ~10 min per query, so the back-to-back call here is
+        # the most common 1018 trigger). A small delay smooths the bursty
+        # double-call pattern; on failure we keep the sync as "partial"
+        # so positions still surface and trades catch up next cycle.
+        delay = float(os.getenv("IBKR_FLEX_INTER_QUERY_DELAY_SEC", "5"))
+        if delay > 0:
+            time.sleep(delay)
+
+        trades_error: str | None = None
+        try:
+            ref_trades = adapter.request_statement(creds["query_id_trades"])
+            trades_xml = adapter.fetch_statement(ref_trades)
+            trades = adapter.parse_trades_xml(trades_xml)
+            self._upsert_trades(account, trades)
+        except FlexAuthError as e:
+            trades_error = f"trades auth failed: {e}"
+            logger.warning("IBKR trades sync failed (auth) for %s: %s", account.id, e)
+        except FlexStatementNotReady as e:
+            trades_error = f"trades not ready: {e}"
+            logger.info("IBKR trades not ready for %s: %s", account.id, e)
+        except FlexError as e:
+            trades_error = f"trades fetch failed: {e}"
+            logger.warning("IBKR trades sync failed for %s: %s", account.id, e)
+
+        # Re-value either way — positions are saved.
         self.valuation_service.compute(account_id=account.id, on=on)
 
-        conn.last_sync_status = "ok"
-        conn.last_sync_error = None
+        if trades_error:
+            conn.last_sync_status = "partial"
+            conn.last_sync_error = trades_error
+        else:
+            conn.last_sync_status = "ok"
+            conn.last_sync_error = None
         conn.last_sync_at = datetime.utcnow()
         self.db.commit()
 

--- a/backend/app/services/investment_sync_service.py
+++ b/backend/app/services/investment_sync_service.py
@@ -88,7 +88,15 @@ class InvestmentSyncService:
         # the most common 1018 trigger). A small delay smooths the bursty
         # double-call pattern; on failure we keep the sync as "partial"
         # so positions still surface and trades catch up next cycle.
-        delay = float(os.getenv("IBKR_FLEX_INTER_QUERY_DELAY_SEC", "5"))
+        delay_raw = os.getenv("IBKR_FLEX_INTER_QUERY_DELAY_SEC", "5")
+        try:
+            delay = float(delay_raw)
+        except ValueError:
+            logger.warning(
+                "Invalid IBKR_FLEX_INTER_QUERY_DELAY_SEC=%r; defaulting to 5",
+                delay_raw,
+            )
+            delay = 5.0
         if delay > 0:
             time.sleep(delay)
 

--- a/frontend/components/investments/ConnectPathPicker.tsx
+++ b/frontend/components/investments/ConnectPathPicker.tsx
@@ -1,8 +1,9 @@
 "use client";
 import { useState } from "react";
-import { RiLinksLine, RiPencilLine } from "@remixicon/react";
+import { RiArrowLeftLine, RiLinksLine, RiPencilLine } from "@remixicon/react";
 import type { InvestmentAccount } from "@/lib/api/investments";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { BrokerForm } from "./BrokerForm";
 import { ManualForm } from "./ManualForm";
@@ -44,36 +45,25 @@ export function ConnectPathPicker({
     },
   ];
 
-  return (
-    <div className="flex-1 overflow-auto">
-      <div className="p-8 max-w-3xl space-y-5">
-        <p className="text-sm text-muted-foreground leading-relaxed max-w-xl">
-          Choose how to track your investments. You can use both methods across
-          different accounts — a brokerage account synced from IBKR alongside a
-          manually-managed account for assets held elsewhere.
-        </p>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {paths.map((p) => {
-            const sel = picked === p.id;
-            return (
+  if (picked === null) {
+    return (
+      <div className="flex-1 overflow-auto">
+        <div className="p-8 max-w-3xl space-y-5">
+          <p className="text-sm text-muted-foreground leading-relaxed max-w-xl">
+            Choose how to track your investments. You can use both methods
+            across different accounts — a brokerage account synced from IBKR
+            alongside a manually-managed account for assets held elsewhere.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {paths.map((p) => (
               <Card
                 key={p.id}
                 onClick={() => setPicked(p.id)}
-                className={`cursor-pointer transition-colors ${
-                  sel
-                    ? "border-2 border-primary bg-muted/30"
-                    : "hover:bg-muted/20"
-                }`}
+                className="cursor-pointer transition-colors hover:bg-muted/20 hover:border-primary"
               >
                 <CardContent className="p-6 flex flex-col gap-3.5 h-full">
                   <div className="flex items-start justify-between">
-                    <div
-                      className={`w-9 h-9 border border-border flex items-center justify-center ${
-                        sel
-                          ? "bg-primary text-primary-foreground"
-                          : "text-muted-foreground"
-                      }`}
-                    >
+                    <div className="w-9 h-9 border border-border flex items-center justify-center text-muted-foreground">
                       {p.icon}
                     </div>
                     {p.badge && (
@@ -91,40 +81,36 @@ export function ConnectPathPicker({
                   <div className="text-xs text-muted-foreground border-t border-border pt-3 mt-auto leading-relaxed">
                     {p.detail}
                   </div>
-                  <div className="flex items-center gap-2 mt-1">
-                    <div
-                      className={`w-3.5 h-3.5 border-[1.5px] rounded-full flex items-center justify-center ${
-                        sel ? "border-primary" : "border-border"
-                      }`}
-                    >
-                      {sel && (
-                        <div className="w-1.5 h-1.5 bg-primary rounded-full" />
-                      )}
-                    </div>
-                    <span
-                      className={`text-xs ${
-                        sel
-                          ? "text-foreground font-semibold"
-                          : "text-muted-foreground"
-                      }`}
-                    >
-                      {sel ? "Selected" : "Select this path"}
-                    </span>
-                  </div>
                 </CardContent>
               </Card>
-            );
-          })}
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const pickedTitle = paths.find((p) => p.id === picked)?.title ?? "";
+
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="p-8 max-w-3xl space-y-5">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setPicked(null)}
+          className="-ml-2"
+        >
+          <RiArrowLeftLine className="size-4" />
+          Choose a different path
+        </Button>
+        <div className="text-xs uppercase tracking-wider text-muted-foreground">
+          {pickedTitle}
         </div>
         {picked === "manual" && (
           <ManualForm accounts={accounts} onCancel={() => setPicked(null)} />
         )}
         {picked === "broker" && <BrokerForm onCancel={() => setPicked(null)} />}
-        {!picked && (
-          <div className="text-xs text-muted-foreground text-center pt-1">
-            Select a path above to continue
-          </div>
-        )}
       </div>
     </div>
   );

--- a/frontend/components/investments/ManualForm.tsx
+++ b/frontend/components/investments/ManualForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { RiAddLine, RiCloseLine } from "@remixicon/react";
 import {
   addManualHolding,
   createManualAccount,
@@ -26,6 +27,31 @@ import { Field, Input } from "./_form-bits";
 const NEW = "__new__";
 type Inst = "etf" | "equity" | "cash";
 
+type Row = {
+  id: string;
+  symbol: string;
+  symbolConfirmed: boolean;
+  qty: string;
+  type: Inst;
+  currency: string;
+  avgCost: string;
+  error: string | null;
+};
+
+let _rowSeq = 0;
+function newRow(): Row {
+  return {
+    id: `r${++_rowSeq}`,
+    symbol: "",
+    symbolConfirmed: false,
+    qty: "",
+    type: "etf",
+    currency: "EUR",
+    avgCost: "",
+    error: null,
+  };
+}
+
 export function ManualForm({
   accounts,
   onCancel,
@@ -37,63 +63,95 @@ export function ManualForm({
   const [accountId, setAccountId] = useState<string>(accounts[0]?.id ?? NEW);
   const [newName, setNewName] = useState("My Brokerage");
   const [baseCcy, setBaseCcy] = useState("EUR");
-  const [symbol, setSymbol] = useState("");
-  const [symbolConfirmed, setSymbolConfirmed] = useState(false);
-  const [qty, setQty] = useState("");
-  const [type, setType] = useState<Inst>("etf");
-  const [currency, setCurrency] = useState("EUR");
-  const [avgCost, setAvgCost] = useState("");
-  const [err, setErr] = useState<string | null>(null);
+  const [rows, setRows] = useState<Row[]>([newRow()]);
   const [busy, setBusy] = useState(false);
+  const [topErr, setTopErr] = useState<string | null>(null);
+
+  const updateRow = (id: string, patch: Partial<Row>) =>
+    setRows((rs) => rs.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+  const removeRow = (id: string) =>
+    setRows((rs) => (rs.length === 1 ? rs : rs.filter((r) => r.id !== id)));
+  const addRow = () => setRows((rs) => [...rs, newRow()]);
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
     setBusy(true);
-    setErr(null);
+    setTopErr(null);
+    setRows((rs) => rs.map((r) => ({ ...r, error: null })));
+
+    // Validate at least one row has symbol + qty
+    const valid = rows.filter((r) => r.symbol.trim() && r.qty.trim());
+    if (valid.length === 0) {
+      setTopErr("Add at least one holding with a symbol and quantity.");
+      setBusy(false);
+      return;
+    }
+
     try {
       const target =
         accountId === NEW
           ? (await createManualAccount(newName, baseCcy)).account_id
           : accountId;
-      await addManualHolding(target, {
-        symbol,
-        quantity: qty,
-        instrument_type: type,
-        currency,
-        ...(avgCost ? { avg_cost: avgCost } : {}),
-      });
-      router.push("/investments");
+
+      const results = await Promise.allSettled(
+        valid.map((r) =>
+          addManualHolding(target, {
+            symbol: r.symbol,
+            quantity: r.qty,
+            instrument_type: r.type,
+            currency: r.currency,
+            ...(r.avgCost ? { avg_cost: r.avgCost } : {}),
+          }),
+        ),
+      );
+
+      const failures = results
+        .map((res, i) => ({ res, row: valid[i] }))
+        .filter(({ res }) => res.status === "rejected");
+
+      if (failures.length === 0) {
+        router.push("/investments");
+        return;
+      }
+
+      // Drop rows that succeeded (already saved on the backend); keep
+      // failed rows with their error messages plus any rows that weren't
+      // submitted because they were incomplete.
+      const failedById = new Map(
+        failures.map(({ res, row }) => {
+          const reason = res.status === "rejected" ? res.reason : null;
+          return [
+            row.id,
+            reason instanceof Error ? reason.message : String(reason),
+          ];
+        }),
+      );
+      const submittedIds = new Set(valid.map((r) => r.id));
+      setRows((rs) =>
+        rs
+          .filter((r) => failedById.has(r.id) || !submittedIds.has(r.id))
+          .map((r) =>
+            failedById.has(r.id) ? { ...r, error: failedById.get(r.id)! } : r,
+          ),
+      );
+      setTopErr(
+        `${results.length - failures.length}/${results.length} holdings added. Fix the errors below to retry the rest.`,
+      );
     } catch (e) {
-      setErr(e instanceof Error ? e.message : String(e));
+      setTopErr(e instanceof Error ? e.message : String(e));
     } finally {
       setBusy(false);
     }
   };
 
-  const symbolLabel = symbol ? (
-    <span className="flex items-center gap-1.5">
-      Symbol
-      {symbolConfirmed ? (
-        <span className="rounded border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-px text-[9px] font-semibold tracking-wide text-emerald-700 dark:text-emerald-400">
-          ✓ verified
-        </span>
-      ) : (
-        <span className="rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-px text-[9px] font-semibold tracking-wide text-amber-700 dark:text-amber-400">
-          ⚠ pick from list
-        </span>
-      )}
-    </span>
-  ) : (
-    "Symbol"
-  );
-
   return (
     <Card className="border-t-2 border-t-primary">
       <CardContent className="p-6 space-y-4">
         <form onSubmit={submit} className="space-y-4">
-          <div className="text-sm font-semibold">Add a holding</div>
+          <div className="text-sm font-semibold">Add holdings</div>
+
           <div className="flex gap-3">
-            <Field label="Account" className="flex-[1.2_1_0%]">
+            <Field label="Account" className="flex-1">
               <Select
                 value={accountId}
                 onValueChange={(v) => v && setAccountId(v)}
@@ -111,22 +169,8 @@ export function ManualForm({
                 </SelectContent>
               </Select>
             </Field>
-            <Field label={symbolLabel} className="flex-[2_1_0%]">
-              <SymbolSearchInput
-                value={symbol}
-                onChange={(v) => {
-                  setSymbol(v);
-                  setSymbolConfirmed(false);
-                }}
-                onSelect={(r: SymbolSearchResult) => {
-                  setSymbol(r.symbol);
-                  setSymbolConfirmed(true);
-                  if (r.currency) setCurrency(r.currency);
-                }}
-                placeholder="Search symbol or name…"
-              />
-            </Field>
           </div>
+
           {accountId === NEW && (
             <div className="flex gap-3">
               <Field label="New account name" className="flex-[2_1_0%]">
@@ -152,79 +196,184 @@ export function ManualForm({
               </Field>
             </div>
           )}
-          <div className="flex gap-3">
-            <Field label="Quantity" className="flex-1">
-              <Input
-                type="number"
-                placeholder="0.00"
-                value={qty}
-                onChange={(e) => setQty(e.target.value)}
+
+          <div className="space-y-3">
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">
+              Holdings ({rows.length})
+            </div>
+            {rows.map((r, i) => (
+              <HoldingRow
+                key={r.id}
+                row={r}
+                index={i}
+                canRemove={rows.length > 1}
+                onChange={(patch) => updateRow(r.id, patch)}
+                onRemove={() => removeRow(r.id)}
               />
-            </Field>
-            <Field label="Instrument type" className="flex-1">
-              <ToggleGroup
-                multiple={false}
-                value={[type]}
-                onValueChange={(v) => v[0] && setType(v[0] as Inst)}
-                variant="outline"
-                size="sm"
-              >
-                {(["etf", "equity", "cash"] as Inst[]).map((t) => (
-                  <ToggleGroupItem
-                    key={t}
-                    value={t}
-                    className="capitalize flex-1"
-                  >
-                    {t === "etf" ? "ETF" : t}
-                  </ToggleGroupItem>
-                ))}
-              </ToggleGroup>
-            </Field>
-            <Field label="Currency" className="flex-1">
-              <Select
-                value={currency}
-                onValueChange={(v) => v && setCurrency(v)}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="EUR">EUR</SelectItem>
-                  <SelectItem value="USD">USD</SelectItem>
-                  <SelectItem value="GBP">GBP</SelectItem>
-                </SelectContent>
-              </Select>
-            </Field>
-            <Field
-              label={
-                <>
-                  Avg cost{" "}
-                  <span className="font-normal text-muted-foreground normal-case tracking-normal">
-                    (optional)
-                  </span>
-                </>
-              }
-              className="flex-1"
+            ))}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={addRow}
+              className="w-full"
             >
-              <Input
-                type="number"
-                placeholder="—"
-                value={avgCost}
-                onChange={(e) => setAvgCost(e.target.value)}
-              />
-            </Field>
+              <RiAddLine className="size-4" />
+              Add another holding
+            </Button>
           </div>
-          {err && <div className="text-destructive text-xs">{err}</div>}
+
+          {topErr && <div className="text-destructive text-xs">{topErr}</div>}
+
           <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="outline" onClick={onCancel}>
               Cancel
             </Button>
             <Button type="submit" disabled={busy}>
-              {busy ? "Adding…" : "Add holding"}
+              {busy
+                ? "Adding…"
+                : `Add ${rows.length} holding${rows.length === 1 ? "" : "s"}`}
             </Button>
           </div>
         </form>
       </CardContent>
     </Card>
+  );
+}
+
+function HoldingRow({
+  row,
+  index,
+  canRemove,
+  onChange,
+  onRemove,
+}: {
+  row: Row;
+  index: number;
+  canRemove: boolean;
+  onChange: (patch: Partial<Row>) => void;
+  onRemove: () => void;
+}) {
+  const symbolLabel = row.symbol ? (
+    <span className="flex items-center gap-1.5">
+      Symbol
+      {row.symbolConfirmed ? (
+        <span className="rounded border border-emerald-500/40 bg-emerald-500/10 px-1.5 py-px text-[9px] font-semibold tracking-wide text-emerald-700 dark:text-emerald-400">
+          ✓ verified
+        </span>
+      ) : (
+        <span className="rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-px text-[9px] font-semibold tracking-wide text-amber-700 dark:text-amber-400">
+          ⚠ pick from list
+        </span>
+      )}
+    </span>
+  ) : (
+    "Symbol"
+  );
+
+  return (
+    <div className="rounded border border-border p-3 space-y-3 relative">
+      <div className="flex items-center justify-between">
+        <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          #{index + 1}
+        </div>
+        {canRemove && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onRemove}
+            aria-label="Remove holding"
+          >
+            <RiCloseLine className="size-4" />
+          </Button>
+        )}
+      </div>
+      <div className="flex gap-3">
+        <Field label={symbolLabel} className="flex-[2_1_0%]">
+          <SymbolSearchInput
+            value={row.symbol}
+            onChange={(v) =>
+              onChange({ symbol: v, symbolConfirmed: false })
+            }
+            onSelect={(r: SymbolSearchResult) =>
+              onChange({
+                symbol: r.symbol,
+                symbolConfirmed: true,
+                ...(r.currency ? { currency: r.currency } : {}),
+              })
+            }
+            placeholder="Search symbol or name…"
+          />
+        </Field>
+      </div>
+      <div className="flex gap-3">
+        <Field label="Quantity" className="flex-1">
+          <Input
+            type="number"
+            placeholder="0.00"
+            value={row.qty}
+            onChange={(e) => onChange({ qty: e.target.value })}
+          />
+        </Field>
+        <Field label="Instrument type" className="flex-1">
+          <ToggleGroup
+            multiple={false}
+            value={[row.type]}
+            onValueChange={(v) =>
+              v[0] && onChange({ type: v[0] as Inst })
+            }
+            variant="outline"
+            size="sm"
+          >
+            {(["etf", "equity", "cash"] as Inst[]).map((t) => (
+              <ToggleGroupItem
+                key={t}
+                value={t}
+                className="capitalize flex-1"
+              >
+                {t === "etf" ? "ETF" : t}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+        </Field>
+        <Field label="Currency" className="flex-1">
+          <Select
+            value={row.currency}
+            onValueChange={(v) => v && onChange({ currency: v })}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="EUR">EUR</SelectItem>
+              <SelectItem value="USD">USD</SelectItem>
+              <SelectItem value="GBP">GBP</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field
+          label={
+            <>
+              Avg cost{" "}
+              <span className="font-normal text-muted-foreground normal-case tracking-normal">
+                (optional)
+              </span>
+            </>
+          }
+          className="flex-1"
+        >
+          <Input
+            type="number"
+            placeholder="—"
+            value={row.avgCost}
+            onChange={(e) => onChange({ avgCost: e.target.value })}
+          />
+        </Field>
+      </div>
+      {row.error && (
+        <div className="text-destructive text-xs">{row.error}</div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Two UX improvements to `/investments/connect`:

### 1. Two-step wizard

Before: both route cards (Connect broker / Add manually) AND the corresponding form rendered together, with a redundant radio selector competing with the click-to-pick card affordance.

After:
- **Step 1** — only the two cards. Click a card to advance.
- **Step 2** — only the picked form, full-width, with a "Choose a different path" back button.

### 2. Multi-symbol manual add

Before: `ManualForm` added one holding per submit.

After: row-based editor — add multiple holdings to one account in a single batch. Each row has its own `SymbolSearchInput` with the verified/pick-from-list badge, qty, instrument type, currency, avg cost, and an × to remove (when more than one row exists). `+ Add another holding` appends a fresh row.

**Submit semantics** — `Promise.allSettled`:
- All success → redirect to `/investments`
- Partial failure → successful rows are removed (already saved server-side), failed rows stay visible with their per-row error, and a top status line shows `N/M holdings added`. User fixes errors and re-submits only the remaining rows.

## Test plan

- [ ] Step 1: clicking either card hides them and reveals the corresponding form
- [ ] Back button returns to step 1 with a fresh state
- [ ] Manual: add 3 rows, fill different symbols, submit → all 3 saved, redirect to `/investments`
- [ ] Manual: add 3 rows, give one a bogus symbol that fails server-side validation → other two save, bogus row stays with error message
- [ ] Symbol search still shows verified ✓ / pick-from-list ⚠ badge per row
- [ ] Currency auto-fills from the selected symbol's exchange
- [ ] × button only shows when there's more than one row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-step connect wizard and a multi-row manual add to speed up investment setup, plus makes IBKR sync resilient by saving positions even if trades are throttled.

- **New Features**
  - Two-step wizard: pick “Connect broker” or “Add manually” first, then see only that form with a “Choose a different path” back button.
  - Manual add: add multiple holdings in one submit with per-row symbol search, qty, type, currency, and optional avg cost. Auto-fills currency from symbol. Partial failures keep only failed rows with errors and show an “N/M holdings added” status.

- **Bug Fixes**
  - IBKR sync now commits positions before fetching trades and computes valuations either way.
  - Trades fetch is best-effort: on failure sets `last_sync_status="partial"` and records `last_sync_error` (positions remain visible).
  - Adds a small inter-query delay to reduce Flex 1018 throttling (`IBKR_FLEX_INTER_QUERY_DELAY_SEC`, default 5s; invalid values log a warning and fall back to 5s).

<sup>Written for commit bbe21f16ec46f9ef18f8b43be8219d332e8ccf7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

