### PR TITLE
feat(assets): per-account investments + grouped holdings

### DIFF
--- a/frontend/components/assets/assets-table.tsx
+++ b/frontend/components/assets/assets-table.tsx
@@ -19,14 +19,19 @@ function AccountRow({
   currency,
   color,
   isLinkable = false,
+  categoryKey,
 }: {
   account: AssetAccount;
   currency: string;
   color: string;
   isLinkable?: boolean;
+  categoryKey?: AssetCategoryKey;
 }) {
   const handleClick = () => {
-    if (isLinkable) {
+    if (!isLinkable) return;
+    if (categoryKey === "investment") {
+      window.location.href = `/investments`;
+    } else {
       window.location.href = `/accounts/${account.id}`;
     }
   };
@@ -136,6 +141,7 @@ function CategoryRow({
               currency={currency}
               color={category.color}
               isLinkable={ACCOUNT_CATEGORY_KEYS.includes(category.key)}
+              categoryKey={category.key}
             />
           ))}
         </div>

--- a/frontend/components/investments/HoldingsTableHF.tsx
+++ b/frontend/components/investments/HoldingsTableHF.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   RiAddLine,
@@ -9,54 +9,63 @@ import {
   RiMore2Fill,
 } from "@remixicon/react";
 import type { Holding } from "@/lib/api/investments";
-import { T } from "./_tokens";
+import { currencySymbol } from "@/lib/utils/currency";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/components/ui/toggle-group";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { EditHoldingDialog } from "./EditHoldingDialog";
 
 type Filter = "All" | "ETF" | "Equity" | "Cash";
 type SortKey = "sym" | "acct" | "type" | "qty" | "price" | "value" | "pnl";
 
 export function TypeBadge({ type }: { type: "etf" | "equity" | "cash" }) {
-  const s = {
-    etf: {
-      background: T.primary,
-      color: T.primaryFg,
-      border: `1px solid ${T.primary}`,
-    },
-    equity: {
-      background: T.muted,
-      color: T.fg,
-      border: `1px solid ${T.border}`,
-    },
-    cash: {
-      background: "transparent",
-      color: T.mutedFg,
-      border: `1px solid ${T.border}`,
-    },
-  }[type];
-  return (
-    <span
-      style={{
-        display: "inline-flex",
-        padding: "1px 6px",
-        fontSize: 10,
-        letterSpacing: ".04em",
-        ...s,
-      }}
-    >
-      {type === "etf" ? "ETF" : type === "equity" ? "Equity" : "Cash"}
-    </span>
-  );
+  if (type === "etf") return <Badge>ETF</Badge>;
+  if (type === "equity") return <Badge variant="secondary">Equity</Badge>;
+  return <Badge variant="outline">Cash</Badge>;
 }
 
 export function HoldingsTableHF({
   holdings,
   accountNames,
   accountsCount,
+  portfolioCurrencySymbol,
   onAddClick,
   onDelete,
 }: {
   holdings: Holding[];
   accountNames: Record<string, string>;
   accountsCount: number;
+  portfolioCurrencySymbol: string;
   onAddClick?: () => void;
   onDelete?: (id: string) => void;
 }) {
@@ -64,6 +73,8 @@ export function HoldingsTableHF({
   const [filter, setFilter] = useState<Filter>("All");
   const [sortKey, setSortKey] = useState<SortKey>("value");
   const [sortDir, setSortDir] = useState<-1 | 1>(-1);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const handleSort = (k: SortKey) => {
     if (k === sortKey) setSortDir((d) => (d * -1) as -1 | 1);
@@ -73,338 +84,322 @@ export function HoldingsTableHF({
     }
   };
 
-  const rows = holdings
-    .filter(
-      (h) =>
-        filter === "All" ||
-        (filter === "ETF" && h.instrument_type === "etf") ||
-        (filter === "Equity" && h.instrument_type === "equity") ||
-        (filter === "Cash" && h.instrument_type === "cash"),
-    )
-    .map((h) => ({
-      ...h,
-      _qty: Number(h.quantity),
-      _price: Number(h.current_price ?? 0),
-      _value: Number(h.current_value_user_currency ?? 0),
-      _acct: accountNames[h.account_id] ?? h.account_id,
-    }))
-    .sort((a, b) => {
-      const get = (r: typeof a) =>
-        ({
-          sym: r.symbol,
-          acct: r._acct,
-          type: r.instrument_type,
-          qty: r._qty,
-          price: r._price,
-          value: r._value,
-          pnl: 0,
-        })[sortKey];
-      const av = get(a) ?? 0;
-      const bv = get(b) ?? 0;
-      return typeof av === "string"
-        ? av.localeCompare(bv as string) * sortDir
-        : ((av as number) - (bv as number)) * sortDir;
-    });
+  const rows = useMemo(() => {
+    return holdings
+      .filter(
+        (h) =>
+          filter === "All" ||
+          (filter === "ETF" && h.instrument_type === "etf") ||
+          (filter === "Equity" && h.instrument_type === "equity") ||
+          (filter === "Cash" && h.instrument_type === "cash"),
+      )
+      .map((h) => {
+        const qty = Number(h.quantity);
+        const price = Number(h.current_price ?? 0);
+        const value = Number(h.current_value_user_currency ?? 0);
+        const cost = h.avg_cost != null ? Number(h.avg_cost) * qty : null;
+        const pnl = cost != null ? value - cost : null;
+        return {
+          ...h,
+          _qty: qty,
+          _price: price,
+          _value: value,
+          _pnl: pnl,
+          _acct: accountNames[h.account_id] ?? h.account_id,
+        };
+      })
+      .sort((a, b) => {
+        if (sortKey === "pnl") {
+          if (a._pnl == null && b._pnl == null) return 0;
+          if (a._pnl == null) return 1;
+          if (b._pnl == null) return -1;
+          return (a._pnl - b._pnl) * sortDir;
+        }
+        const get = (r: typeof a) =>
+          ({
+            sym: r.symbol,
+            acct: r._acct,
+            type: r.instrument_type,
+            qty: r._qty,
+            price: r._price,
+            value: r._value,
+          })[sortKey as Exclude<SortKey, "pnl">];
+        const av = get(a) ?? 0;
+        const bv = get(b) ?? 0;
+        return typeof av === "string"
+          ? (av as string).localeCompare(bv as string) * sortDir
+          : ((av as number) - (bv as number)) * sortDir;
+      });
+  }, [holdings, accountNames, filter, sortKey, sortDir]);
 
   const SortIcon = ({ k }: { k: SortKey }) =>
     sortKey === k ? (
       sortDir === -1 ? (
-        <RiArrowDownSLine size={11} />
+        <RiArrowDownSLine className="size-3" />
       ) : (
-        <RiArrowUpSLine size={11} />
+        <RiArrowUpSLine className="size-3" />
       )
     ) : (
-      <RiArrowUpDownLine size={10} style={{ opacity: 0.3 }} />
+      <RiArrowUpDownLine className="size-3 opacity-30" />
     );
 
   const totalValue = rows.reduce((s, r) => s + r._value, 0);
+  const editingHolding = editingId ? holdings.find((h) => h.id === editingId) : null;
 
   return (
-    <div style={{ background: T.card, border: `1px solid ${T.border}` }}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          padding: "12px 18px",
-          gap: 12,
-          borderBottom: `1px solid ${T.border}`,
-          flexWrap: "wrap",
-        }}
-      >
-        <span style={{ fontWeight: 600, fontSize: 13 }}>All holdings</span>
-        <span style={{ fontSize: 11, color: T.mutedFg }}>
-          {holdings.length} positions · {accountsCount} account
-          {accountsCount !== 1 ? "s" : ""}
-        </span>
-        <div style={{ flex: 1 }} />
-        <div style={{ display: "flex", gap: 0 }}>
-          {(["All", "ETF", "Equity", "Cash"] as Filter[]).map((t) => {
-            const active = filter === t;
-            return (
-              <button
-                key={t}
-                onClick={() => setFilter(t)}
-                style={{
-                  padding: "4px 10px",
-                  fontSize: 11,
-                  fontFamily: "inherit",
-                  border: `1px solid ${active ? T.primary : T.border}`,
-                  background: active ? T.primary : T.card,
-                  color: active ? T.primaryFg : T.mutedFg,
-                  cursor: "pointer",
-                  marginLeft: -1,
-                }}
-              >
-                {t}
-              </button>
-            );
-          })}
+    <Card>
+      <CardHeader className="flex flex-row flex-wrap items-center gap-3">
+        <div>
+          <h2 className="text-sm font-semibold">All holdings</h2>
+          <p className="text-xs text-muted-foreground">
+            {holdings.length} positions · {accountsCount} account
+            {accountsCount !== 1 ? "s" : ""}
+          </p>
         </div>
+        <div className="flex-1" />
+        <ToggleGroup
+          multiple={false}
+          value={[filter]}
+          onValueChange={(v) => {
+            const next = v[0] as Filter | undefined;
+            if (next) setFilter(next);
+          }}
+          variant="outline"
+          size="sm"
+        >
+          {(["All", "ETF", "Equity", "Cash"] as Filter[]).map((t) => (
+            <ToggleGroupItem key={t} value={t} aria-label={`Filter ${t}`}>
+              {t}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
         {onAddClick && (
-          <button
-            onClick={onAddClick}
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 6,
-              padding: "5px 12px",
-              background: T.primary,
-              color: T.primaryFg,
-              border: "none",
-              cursor: "pointer",
-              fontSize: 11,
-            }}
-          >
-            <RiAddLine size={12} /> Add holding
-          </button>
+          <Button size="sm" onClick={onAddClick}>
+            <RiAddLine className="size-4" />
+            Add holding
+          </Button>
         )}
-      </div>
-      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
-        <thead>
-          <tr style={{ borderBottom: `1px solid ${T.border}` }}>
-            {(
-              [
-                ["sym", "Symbol", "left"],
-                ["acct", "Account", "left"],
-                ["type", "Type", "left"],
-                ["qty", "Qty", "right"],
-                ["price", "Price", "right"],
-                ["value", "Value", "right"],
-              ] as const
-            ).map(([k, label, align]) => (
-              <th
-                key={k}
-                onClick={() => handleSort(k as SortKey)}
-                style={{
-                  textAlign: align,
-                  padding: "9px 18px",
-                  fontSize: 10,
-                  color: T.mutedFg,
-                  fontWeight: 500,
-                  textTransform: "uppercase",
-                  letterSpacing: ".08em",
-                  cursor: "pointer",
-                  userSelect: "none",
-                }}
-              >
-                <span
-                  style={{ display: "inline-flex", alignItems: "center", gap: 2 }}
+      </CardHeader>
+      <CardContent className="p-0">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {(
+                [
+                  ["sym", "Symbol", "left"],
+                  ["acct", "Account", "left"],
+                  ["type", "Type", "left"],
+                  ["qty", "Qty", "right"],
+                  ["price", "Price", "right"],
+                  ["value", "Value", "right"],
+                  ["pnl", "P&L", "right"],
+                ] as const
+              ).map(([k, label, align]) => (
+                <TableHead
+                  key={k}
+                  onClick={() => handleSort(k as SortKey)}
+                  className={`cursor-pointer select-none uppercase tracking-wider text-[10px] ${
+                    align === "right" ? "text-right" : "text-left"
+                  }`}
                 >
-                  {label}
-                  <SortIcon k={k as SortKey} />
-                </span>
-              </th>
-            ))}
-            <th style={{ width: 36 }} />
-          </tr>
-        </thead>
-        <tbody>
-          {(["etf", "equity", "cash"] as const).flatMap((groupType) => {
-            const groupRows = rows.filter((r) => r.instrument_type === groupType);
-            if (groupRows.length === 0) return [];
-            const groupTotal = groupRows.reduce((s, r) => s + r._value, 0);
-            const groupLabel =
-              groupType === "etf" ? "ETF" : groupType === "equity" ? "Equity" : "Cash";
-            return [
-              <tr key={`group-${groupType}`} style={{ background: T.bg }}>
-                <td
-                  colSpan={5}
-                  style={{
-                    padding: "8px 18px",
-                    fontSize: 10,
-                    fontWeight: 600,
-                    color: T.mutedFg,
-                    textTransform: "uppercase",
-                    letterSpacing: ".08em",
-                    borderTop: `1px solid ${T.border}`,
-                    borderBottom: `1px solid ${T.border}`,
+                  <span className={`inline-flex items-center gap-1 ${
+                    align === "right" ? "justify-end w-full" : ""
+                  }`}>
+                    {label}
+                    <SortIcon k={k as SortKey} />
+                  </span>
+                </TableHead>
+              ))}
+              <TableHead className="w-10" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {(["etf", "equity", "cash"] as const).flatMap((groupType) => {
+              const groupRows = rows.filter((r) => r.instrument_type === groupType);
+              if (groupRows.length === 0) return [];
+              const groupTotal = groupRows.reduce((s, r) => s + r._value, 0);
+              const groupLabel =
+                groupType === "etf" ? "ETF" : groupType === "equity" ? "Equity" : "Cash";
+              return [
+                <TableRow key={`group-${groupType}`} className="bg-muted/40 hover:bg-muted/40">
+                  <TableCell
+                    colSpan={5}
+                    className="uppercase tracking-wider text-[10px] font-semibold text-muted-foreground"
+                  >
+                    {groupLabel} · {groupRows.length}
+                  </TableCell>
+                  <TableCell
+                    colSpan={3}
+                    className="text-right tabular-nums text-xs font-semibold text-muted-foreground"
+                  >
+                    {portfolioCurrencySymbol} {groupTotal.toLocaleString("en", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
+                  </TableCell>
+                </TableRow>,
+                ...groupRows.map((h) => {
+              const sym = currencySymbol(h.currency);
+              return (
+                <TableRow
+                  key={h.id}
+                  tabIndex={0}
+                  aria-label={`View details for ${h.symbol}`}
+                  onClick={() => router.push(`/investments/${h.id}`)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      router.push(`/investments/${h.id}`);
+                    }
                   }}
+                  className={`cursor-pointer ${
+                    h.is_stale ? "bg-amber-50 dark:bg-amber-950/30" : ""
+                  }`}
                 >
-                  {groupLabel} · {groupRows.length}
-                </td>
-                <td
-                  colSpan={2}
-                  style={{
-                    padding: "8px 18px",
-                    fontSize: 11,
-                    textAlign: "right",
-                    fontVariantNumeric: "tabular-nums",
-                    fontWeight: 600,
-                    color: T.mutedFg,
-                    borderTop: `1px solid ${T.border}`,
-                    borderBottom: `1px solid ${T.border}`,
-                  }}
-                >
-                  €{" "}
-                  {groupTotal.toLocaleString("en", {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 2,
-                  })}
-                </td>
-              </tr>,
-              ...groupRows.map((h) => (
-            <tr
-              key={h.id}
-              className={h.is_stale ? "stale" : ""}
-              tabIndex={0}
-              aria-label={`View details for ${h.symbol}`}
-              onClick={() => router.push(`/investments/${h.id}`)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" || e.key === " ") {
-                  e.preventDefault();
-                  router.push(`/investments/${h.id}`);
-                }
-              }}
-              style={{
-                borderBottom: `1px solid ${T.muted}`,
-                background: h.is_stale ? T.staleBg : undefined,
-                cursor: "pointer",
-              }}
-            >
-              <td style={{ padding: "11px 18px" }}>
-                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                  <span style={{ fontWeight: 700, fontSize: 13 }}>{h.symbol}</span>
-                  {h.is_stale && (
-                    <span
-                      title="Price may be stale"
-                      style={{
-                        width: 6,
-                        height: 6,
-                        background: T.stale,
-                        borderRadius: "50%",
-                      }}
-                    />
-                  )}
-                </div>
-                <div style={{ fontSize: 10, color: T.mutedFg, marginTop: 1 }}>
-                  {h.name ?? ""}
-                </div>
-              </td>
-              <td style={{ padding: "11px 18px" }}>
-                <span
-                  style={{
-                    padding: "2px 6px",
-                    border: `1px solid ${T.border}`,
-                    fontSize: 10,
-                    color: T.mutedFg,
-                    background: T.muted,
-                  }}
-                >
-                  {h._acct}
-                </span>
-              </td>
-              <td style={{ padding: "11px 18px" }}>
-                <TypeBadge type={h.instrument_type} />
-              </td>
-              <td
-                style={{
-                  padding: "11px 18px",
-                  textAlign: "right",
-                  fontVariantNumeric: "tabular-nums",
-                }}
-              >
-                {h._qty.toLocaleString()}
-              </td>
-              <td
-                style={{
-                  padding: "11px 18px",
-                  textAlign: "right",
-                  fontVariantNumeric: "tabular-nums",
-                  color: T.mutedFg,
-                }}
-              >
-                {h.current_price
-                  ? `${h.currency === "USD" ? "$" : "€"} ${h._price.toFixed(2)}`
-                  : "—"}
-              </td>
-              <td
-                style={{
-                  padding: "11px 18px",
-                  textAlign: "right",
-                  fontVariantNumeric: "tabular-nums",
-                  fontWeight: 600,
-                }}
-              >
-                €{" "}
-                {h._value.toLocaleString("en", {
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <span className="font-bold">{h.symbol}</span>
+                      {h.is_stale && (
+                        <span
+                          title="Price may be stale"
+                          className="size-1.5 rounded-full bg-amber-500"
+                        />
+                      )}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground">
+                      {h.name ?? ""}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="outline">{h._acct}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <TypeBadge type={h.instrument_type} />
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {h._qty.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                    {h.current_price ? `${sym} ${h._price.toFixed(2)}` : "—"}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums font-semibold">
+                    {portfolioCurrencySymbol} {h._value.toLocaleString("en", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })}
+                  </TableCell>
+                  <TableCell className={`text-right tabular-nums ${
+                    h._pnl == null
+                      ? "text-muted-foreground"
+                      : h._pnl >= 0
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : "text-destructive"
+                  }`}>
+                    {h._pnl == null
+                      ? "—"
+                      : `${h._pnl >= 0 ? "+" : ""}${portfolioCurrencySymbol} ${h._pnl.toLocaleString("en", {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}`}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          aria-label="Row actions"
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+                          }}
+                        >
+                          <RiMore2Fill className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent
+                        align="end"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <DropdownMenuItem
+                          onClick={() => router.push(`/investments/${h.id}`)}
+                        >
+                          View details
+                        </DropdownMenuItem>
+                        {h.source === "manual" && (
+                          <>
+                            <DropdownMenuItem onClick={() => setEditingId(h.id)}>
+                              Edit
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onClick={() => setDeletingId(h.id)}
+                              className="text-destructive focus:text-destructive"
+                            >
+                              Delete
+                            </DropdownMenuItem>
+                          </>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              );
+                }),
+              ];
+            })}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableCell colSpan={6} className="font-semibold text-muted-foreground">
+                Total
+              </TableCell>
+              <TableCell className="text-right tabular-nums font-bold">
+                {portfolioCurrencySymbol} {totalValue.toLocaleString("en", {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
                 })}
-              </td>
-              <td style={{ padding: "11px 10px", textAlign: "center" }}>
-                {onDelete && h.source === "manual" && (
-                  <button
-                    onClick={(e) => { e.stopPropagation(); onDelete(h.id); }}
-                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") e.stopPropagation(); }}
-                    title="Delete"
-                    style={{
-                      background: "transparent",
-                      border: "none",
-                      cursor: "pointer",
-                      color: T.mutedFg,
-                    }}
-                  >
-                    <RiMore2Fill size={14} />
-                  </button>
-                )}
-              </td>
-            </tr>
-              )),
-            ];
-          })}
-        </tbody>
-        <tfoot>
-          <tr style={{ borderTop: `1px solid ${T.border}`, background: T.bg }}>
-            <td
-              colSpan={5}
-              style={{
-                padding: "10px 18px",
-                fontSize: 11,
-                fontWeight: 600,
-                color: T.mutedFg,
+              </TableCell>
+              <TableCell />
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </CardContent>
+
+      {editingHolding && (
+        <EditHoldingDialog
+          open={true}
+          onOpenChange={(o) => !o && setEditingId(null)}
+          holding={editingHolding}
+        />
+      )}
+
+      <AlertDialog
+        open={deletingId !== null}
+        onOpenChange={(o) => !o && setDeletingId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this holding?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes the manual position. Price history is retained but the
+              position will no longer count toward your portfolio.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deletingId && onDelete) onDelete(deletingId);
+                setDeletingId(null);
               }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Total
-            </td>
-            <td
-              style={{
-                padding: "10px 18px",
-                textAlign: "right",
-                fontWeight: 700,
-                fontVariantNumeric: "tabular-nums",
-                fontSize: 13,
-              }}
-            >
-              €{" "}
-              {totalValue.toLocaleString("en", {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              })}
-            </td>
-            <td />
-          </tr>
-        </tfoot>
-      </table>
-    </div>
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
   );
 }

--- a/frontend/components/investments/HoldingsTableHF.tsx
+++ b/frontend/components/investments/HoldingsTableHF.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   RiAddLine,
@@ -9,63 +9,54 @@ import {
   RiMore2Fill,
 } from "@remixicon/react";
 import type { Holding } from "@/lib/api/investments";
-import { currencySymbol } from "@/lib/utils/currency";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from "@/components/ui/toggle-group";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { EditHoldingDialog } from "./EditHoldingDialog";
+import { T } from "./_tokens";
 
 type Filter = "All" | "ETF" | "Equity" | "Cash";
 type SortKey = "sym" | "acct" | "type" | "qty" | "price" | "value" | "pnl";
 
 export function TypeBadge({ type }: { type: "etf" | "equity" | "cash" }) {
-  if (type === "etf") return <Badge>ETF</Badge>;
-  if (type === "equity") return <Badge variant="secondary">Equity</Badge>;
-  return <Badge variant="outline">Cash</Badge>;
+  const s = {
+    etf: {
+      background: T.primary,
+      color: T.primaryFg,
+      border: `1px solid ${T.primary}`,
+    },
+    equity: {
+      background: T.muted,
+      color: T.fg,
+      border: `1px solid ${T.border}`,
+    },
+    cash: {
+      background: "transparent",
+      color: T.mutedFg,
+      border: `1px solid ${T.border}`,
+    },
+  }[type];
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        padding: "1px 6px",
+        fontSize: 10,
+        letterSpacing: ".04em",
+        ...s,
+      }}
+    >
+      {type === "etf" ? "ETF" : type === "equity" ? "Equity" : "Cash"}
+    </span>
+  );
 }
 
 export function HoldingsTableHF({
   holdings,
   accountNames,
   accountsCount,
-  portfolioCurrencySymbol,
   onAddClick,
   onDelete,
 }: {
   holdings: Holding[];
   accountNames: Record<string, string>;
   accountsCount: number;
-  portfolioCurrencySymbol: string;
   onAddClick?: () => void;
   onDelete?: (id: string) => void;
 }) {
@@ -73,8 +64,6 @@ export function HoldingsTableHF({
   const [filter, setFilter] = useState<Filter>("All");
   const [sortKey, setSortKey] = useState<SortKey>("value");
   const [sortDir, setSortDir] = useState<-1 | 1>(-1);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const handleSort = (k: SortKey) => {
     if (k === sortKey) setSortDir((d) => (d * -1) as -1 | 1);
@@ -84,296 +73,338 @@ export function HoldingsTableHF({
     }
   };
 
-  const rows = useMemo(() => {
-    return holdings
-      .filter(
-        (h) =>
-          filter === "All" ||
-          (filter === "ETF" && h.instrument_type === "etf") ||
-          (filter === "Equity" && h.instrument_type === "equity") ||
-          (filter === "Cash" && h.instrument_type === "cash"),
-      )
-      .map((h) => {
-        const qty = Number(h.quantity);
-        const price = Number(h.current_price ?? 0);
-        const value = Number(h.current_value_user_currency ?? 0);
-        const cost = h.avg_cost != null ? Number(h.avg_cost) * qty : null;
-        const pnl = cost != null ? value - cost : null;
-        return {
-          ...h,
-          _qty: qty,
-          _price: price,
-          _value: value,
-          _pnl: pnl,
-          _acct: accountNames[h.account_id] ?? h.account_id,
-        };
-      })
-      .sort((a, b) => {
-        if (sortKey === "pnl") {
-          if (a._pnl == null && b._pnl == null) return 0;
-          if (a._pnl == null) return 1;
-          if (b._pnl == null) return -1;
-          return (a._pnl - b._pnl) * sortDir;
-        }
-        const get = (r: typeof a) =>
-          ({
-            sym: r.symbol,
-            acct: r._acct,
-            type: r.instrument_type,
-            qty: r._qty,
-            price: r._price,
-            value: r._value,
-          })[sortKey as Exclude<SortKey, "pnl">];
-        const av = get(a) ?? 0;
-        const bv = get(b) ?? 0;
-        return typeof av === "string"
-          ? (av as string).localeCompare(bv as string) * sortDir
-          : ((av as number) - (bv as number)) * sortDir;
-      });
-  }, [holdings, accountNames, filter, sortKey, sortDir]);
+  const rows = holdings
+    .filter(
+      (h) =>
+        filter === "All" ||
+        (filter === "ETF" && h.instrument_type === "etf") ||
+        (filter === "Equity" && h.instrument_type === "equity") ||
+        (filter === "Cash" && h.instrument_type === "cash"),
+    )
+    .map((h) => ({
+      ...h,
+      _qty: Number(h.quantity),
+      _price: Number(h.current_price ?? 0),
+      _value: Number(h.current_value_user_currency ?? 0),
+      _acct: accountNames[h.account_id] ?? h.account_id,
+    }))
+    .sort((a, b) => {
+      const get = (r: typeof a) =>
+        ({
+          sym: r.symbol,
+          acct: r._acct,
+          type: r.instrument_type,
+          qty: r._qty,
+          price: r._price,
+          value: r._value,
+          pnl: 0,
+        })[sortKey];
+      const av = get(a) ?? 0;
+      const bv = get(b) ?? 0;
+      return typeof av === "string"
+        ? av.localeCompare(bv as string) * sortDir
+        : ((av as number) - (bv as number)) * sortDir;
+    });
 
   const SortIcon = ({ k }: { k: SortKey }) =>
     sortKey === k ? (
       sortDir === -1 ? (
-        <RiArrowDownSLine className="size-3" />
+        <RiArrowDownSLine size={11} />
       ) : (
-        <RiArrowUpSLine className="size-3" />
+        <RiArrowUpSLine size={11} />
       )
     ) : (
-      <RiArrowUpDownLine className="size-3 opacity-30" />
+      <RiArrowUpDownLine size={10} style={{ opacity: 0.3 }} />
     );
 
   const totalValue = rows.reduce((s, r) => s + r._value, 0);
-  const editingHolding = editingId ? holdings.find((h) => h.id === editingId) : null;
 
   return (
-    <Card>
-      <CardHeader className="flex flex-row flex-wrap items-center gap-3">
-        <div>
-          <h2 className="text-sm font-semibold">All holdings</h2>
-          <p className="text-xs text-muted-foreground">
-            {holdings.length} positions · {accountsCount} account
-            {accountsCount !== 1 ? "s" : ""}
-          </p>
+    <div style={{ background: T.card, border: `1px solid ${T.border}` }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          padding: "12px 18px",
+          gap: 12,
+          borderBottom: `1px solid ${T.border}`,
+          flexWrap: "wrap",
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: 13 }}>All holdings</span>
+        <span style={{ fontSize: 11, color: T.mutedFg }}>
+          {holdings.length} positions · {accountsCount} account
+          {accountsCount !== 1 ? "s" : ""}
+        </span>
+        <div style={{ flex: 1 }} />
+        <div style={{ display: "flex", gap: 0 }}>
+          {(["All", "ETF", "Equity", "Cash"] as Filter[]).map((t) => {
+            const active = filter === t;
+            return (
+              <button
+                key={t}
+                onClick={() => setFilter(t)}
+                style={{
+                  padding: "4px 10px",
+                  fontSize: 11,
+                  fontFamily: "inherit",
+                  border: `1px solid ${active ? T.primary : T.border}`,
+                  background: active ? T.primary : T.card,
+                  color: active ? T.primaryFg : T.mutedFg,
+                  cursor: "pointer",
+                  marginLeft: -1,
+                }}
+              >
+                {t}
+              </button>
+            );
+          })}
         </div>
-        <div className="flex-1" />
-        <ToggleGroup
-          multiple={false}
-          value={[filter]}
-          onValueChange={(v) => {
-            const next = v[0] as Filter | undefined;
-            if (next) setFilter(next);
-          }}
-          variant="outline"
-          size="sm"
-        >
-          {(["All", "ETF", "Equity", "Cash"] as Filter[]).map((t) => (
-            <ToggleGroupItem key={t} value={t} aria-label={`Filter ${t}`}>
-              {t}
-            </ToggleGroupItem>
-          ))}
-        </ToggleGroup>
         {onAddClick && (
-          <Button size="sm" onClick={onAddClick}>
-            <RiAddLine className="size-4" />
-            Add holding
-          </Button>
+          <button
+            onClick={onAddClick}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              padding: "5px 12px",
+              background: T.primary,
+              color: T.primaryFg,
+              border: "none",
+              cursor: "pointer",
+              fontSize: 11,
+            }}
+          >
+            <RiAddLine size={12} /> Add holding
+          </button>
         )}
-      </CardHeader>
-      <CardContent className="p-0">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              {(
-                [
-                  ["sym", "Symbol", "left"],
-                  ["acct", "Account", "left"],
-                  ["type", "Type", "left"],
-                  ["qty", "Qty", "right"],
-                  ["price", "Price", "right"],
-                  ["value", "Value", "right"],
-                  ["pnl", "P&L", "right"],
-                ] as const
-              ).map(([k, label, align]) => (
-                <TableHead
-                  key={k}
-                  onClick={() => handleSort(k as SortKey)}
-                  className={`cursor-pointer select-none uppercase tracking-wider text-[10px] ${
-                    align === "right" ? "text-right" : "text-left"
-                  }`}
+      </div>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+        <thead>
+          <tr style={{ borderBottom: `1px solid ${T.border}` }}>
+            {(
+              [
+                ["sym", "Symbol", "left"],
+                ["acct", "Account", "left"],
+                ["type", "Type", "left"],
+                ["qty", "Qty", "right"],
+                ["price", "Price", "right"],
+                ["value", "Value", "right"],
+              ] as const
+            ).map(([k, label, align]) => (
+              <th
+                key={k}
+                onClick={() => handleSort(k as SortKey)}
+                style={{
+                  textAlign: align,
+                  padding: "9px 18px",
+                  fontSize: 10,
+                  color: T.mutedFg,
+                  fontWeight: 500,
+                  textTransform: "uppercase",
+                  letterSpacing: ".08em",
+                  cursor: "pointer",
+                  userSelect: "none",
+                }}
+              >
+                <span
+                  style={{ display: "inline-flex", alignItems: "center", gap: 2 }}
                 >
-                  <span className={`inline-flex items-center gap-1 ${
-                    align === "right" ? "justify-end w-full" : ""
-                  }`}>
-                    {label}
-                    <SortIcon k={k as SortKey} />
-                  </span>
-                </TableHead>
-              ))}
-              <TableHead className="w-10" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {rows.map((h) => {
-              const sym = currencySymbol(h.currency);
-              return (
-                <TableRow
-                  key={h.id}
-                  tabIndex={0}
-                  aria-label={`View details for ${h.symbol}`}
-                  onClick={() => router.push(`/investments/${h.id}`)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      router.push(`/investments/${h.id}`);
-                    }
+                  {label}
+                  <SortIcon k={k as SortKey} />
+                </span>
+              </th>
+            ))}
+            <th style={{ width: 36 }} />
+          </tr>
+        </thead>
+        <tbody>
+          {(["etf", "equity", "cash"] as const).flatMap((groupType) => {
+            const groupRows = rows.filter((r) => r.instrument_type === groupType);
+            if (groupRows.length === 0) return [];
+            const groupTotal = groupRows.reduce((s, r) => s + r._value, 0);
+            const groupLabel =
+              groupType === "etf" ? "ETF" : groupType === "equity" ? "Equity" : "Cash";
+            return [
+              <tr key={`group-${groupType}`} style={{ background: T.bg }}>
+                <td
+                  colSpan={5}
+                  style={{
+                    padding: "8px 18px",
+                    fontSize: 10,
+                    fontWeight: 600,
+                    color: T.mutedFg,
+                    textTransform: "uppercase",
+                    letterSpacing: ".08em",
+                    borderTop: `1px solid ${T.border}`,
+                    borderBottom: `1px solid ${T.border}`,
                   }}
-                  className={`cursor-pointer ${
-                    h.is_stale ? "bg-amber-50 dark:bg-amber-950/30" : ""
-                  }`}
                 >
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <span className="font-bold">{h.symbol}</span>
-                      {h.is_stale && (
-                        <span
-                          title="Price may be stale"
-                          className="size-1.5 rounded-full bg-amber-500"
-                        />
-                      )}
-                    </div>
-                    <div className="text-[10px] text-muted-foreground">
-                      {h.name ?? ""}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="outline">{h._acct}</Badge>
-                  </TableCell>
-                  <TableCell>
-                    <TypeBadge type={h.instrument_type} />
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums">
-                    {h._qty.toLocaleString()}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums text-muted-foreground">
-                    {h.current_price ? `${sym} ${h._price.toFixed(2)}` : "—"}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums font-semibold">
-                    {portfolioCurrencySymbol} {h._value.toLocaleString("en", {
-                      minimumFractionDigits: 2,
-                      maximumFractionDigits: 2,
-                    })}
-                  </TableCell>
-                  <TableCell className={`text-right tabular-nums ${
-                    h._pnl == null
-                      ? "text-muted-foreground"
-                      : h._pnl >= 0
-                        ? "text-emerald-600 dark:text-emerald-400"
-                        : "text-destructive"
-                  }`}>
-                    {h._pnl == null
-                      ? "—"
-                      : `${h._pnl >= 0 ? "+" : ""}${portfolioCurrencySymbol} ${h._pnl.toLocaleString("en", {
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}`}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          aria-label="Row actions"
-                          onClick={(e) => e.stopPropagation()}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" || e.key === " ") e.stopPropagation();
-                          }}
-                        >
-                          <RiMore2Fill className="size-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent
-                        align="end"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <DropdownMenuItem
-                          onClick={() => router.push(`/investments/${h.id}`)}
-                        >
-                          View details
-                        </DropdownMenuItem>
-                        {h.source === "manual" && (
-                          <>
-                            <DropdownMenuItem onClick={() => setEditingId(h.id)}>
-                              Edit
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              onClick={() => setDeletingId(h.id)}
-                              className="text-destructive focus:text-destructive"
-                            >
-                              Delete
-                            </DropdownMenuItem>
-                          </>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-          <TableFooter>
-            <TableRow>
-              <TableCell colSpan={6} className="font-semibold text-muted-foreground">
-                Total
-              </TableCell>
-              <TableCell className="text-right tabular-nums font-bold">
-                {portfolioCurrencySymbol} {totalValue.toLocaleString("en", {
+                  {groupLabel} · {groupRows.length}
+                </td>
+                <td
+                  colSpan={2}
+                  style={{
+                    padding: "8px 18px",
+                    fontSize: 11,
+                    textAlign: "right",
+                    fontVariantNumeric: "tabular-nums",
+                    fontWeight: 600,
+                    color: T.mutedFg,
+                    borderTop: `1px solid ${T.border}`,
+                    borderBottom: `1px solid ${T.border}`,
+                  }}
+                >
+                  €{" "}
+                  {groupTotal.toLocaleString("en", {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                </td>
+              </tr>,
+              ...groupRows.map((h) => (
+            <tr
+              key={h.id}
+              className={h.is_stale ? "stale" : ""}
+              tabIndex={0}
+              aria-label={`View details for ${h.symbol}`}
+              onClick={() => router.push(`/investments/${h.id}`)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  router.push(`/investments/${h.id}`);
+                }
+              }}
+              style={{
+                borderBottom: `1px solid ${T.muted}`,
+                background: h.is_stale ? T.staleBg : undefined,
+                cursor: "pointer",
+              }}
+            >
+              <td style={{ padding: "11px 18px" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  <span style={{ fontWeight: 700, fontSize: 13 }}>{h.symbol}</span>
+                  {h.is_stale && (
+                    <span
+                      title="Price may be stale"
+                      style={{
+                        width: 6,
+                        height: 6,
+                        background: T.stale,
+                        borderRadius: "50%",
+                      }}
+                    />
+                  )}
+                </div>
+                <div style={{ fontSize: 10, color: T.mutedFg, marginTop: 1 }}>
+                  {h.name ?? ""}
+                </div>
+              </td>
+              <td style={{ padding: "11px 18px" }}>
+                <span
+                  style={{
+                    padding: "2px 6px",
+                    border: `1px solid ${T.border}`,
+                    fontSize: 10,
+                    color: T.mutedFg,
+                    background: T.muted,
+                  }}
+                >
+                  {h._acct}
+                </span>
+              </td>
+              <td style={{ padding: "11px 18px" }}>
+                <TypeBadge type={h.instrument_type} />
+              </td>
+              <td
+                style={{
+                  padding: "11px 18px",
+                  textAlign: "right",
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {h._qty.toLocaleString()}
+              </td>
+              <td
+                style={{
+                  padding: "11px 18px",
+                  textAlign: "right",
+                  fontVariantNumeric: "tabular-nums",
+                  color: T.mutedFg,
+                }}
+              >
+                {h.current_price
+                  ? `${h.currency === "USD" ? "$" : "€"} ${h._price.toFixed(2)}`
+                  : "—"}
+              </td>
+              <td
+                style={{
+                  padding: "11px 18px",
+                  textAlign: "right",
+                  fontVariantNumeric: "tabular-nums",
+                  fontWeight: 600,
+                }}
+              >
+                €{" "}
+                {h._value.toLocaleString("en", {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
                 })}
-              </TableCell>
-              <TableCell />
-            </TableRow>
-          </TableFooter>
-        </Table>
-      </CardContent>
-
-      {editingHolding && (
-        <EditHoldingDialog
-          open={true}
-          onOpenChange={(o) => !o && setEditingId(null)}
-          holding={editingHolding}
-        />
-      )}
-
-      <AlertDialog
-        open={deletingId !== null}
-        onOpenChange={(o) => !o && setDeletingId(null)}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete this holding?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This removes the manual position. Price history is retained but the
-              position will no longer count toward your portfolio.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (deletingId && onDelete) onDelete(deletingId);
-                setDeletingId(null);
+              </td>
+              <td style={{ padding: "11px 10px", textAlign: "center" }}>
+                {onDelete && h.source === "manual" && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onDelete(h.id); }}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") e.stopPropagation(); }}
+                    title="Delete"
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      cursor: "pointer",
+                      color: T.mutedFg,
+                    }}
+                  >
+                    <RiMore2Fill size={14} />
+                  </button>
+                )}
+              </td>
+            </tr>
+              )),
+            ];
+          })}
+        </tbody>
+        <tfoot>
+          <tr style={{ borderTop: `1px solid ${T.border}`, background: T.bg }}>
+            <td
+              colSpan={5}
+              style={{
+                padding: "10px 18px",
+                fontSize: 11,
+                fontWeight: 600,
+                color: T.mutedFg,
               }}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </Card>
+              Total
+            </td>
+            <td
+              style={{
+                padding: "10px 18px",
+                textAlign: "right",
+                fontWeight: 700,
+                fontVariantNumeric: "tabular-nums",
+                fontSize: 13,
+              }}
+            >
+              €{" "}
+              {totalValue.toLocaleString("en", {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </td>
+            <td />
+          </tr>
+        </tfoot>
+      </table>
+    </div>
   );
 }

--- a/frontend/lib/actions/dashboard.ts
+++ b/frontend/lib/actions/dashboard.ts
@@ -3,6 +3,7 @@
 import { db } from "@/lib/db";
 import { accounts, transactions, categories, users, properties, vehicles, accountBalances, transactionLinks } from "@/lib/db/schema";
 import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { getCachedUserAccounts } from "@/lib/data/cached";
 import { eq, sql, gte, lte, and, desc, inArray, isNull } from "drizzle-orm";
 import { buildConservativeSankey } from "@/lib/dashboard/sankey";
 import {
@@ -73,24 +74,7 @@ async function getLatestTransactionDate(userId: string, accountIds?: string[]): 
 
 // Get user accounts for filter dropdown
 export async function getUserAccounts() {
-  const session = await getAuthenticatedSession();
-
-  if (!session?.user?.id) {
-    return [];
-  }
-
-  const result = await db
-    .select({
-      id: accounts.id,
-      name: accounts.name,
-      institution: accounts.institution,
-      accountType: accounts.accountType,
-    })
-    .from(accounts)
-    .where(and(eq(accounts.userId, session.user.id), eq(accounts.isActive, true)))
-    .orderBy(accounts.name);
-
-  return result;
+  return getCachedUserAccounts();
 }
 
 // Get available months/years for the date selector

--- a/frontend/lib/actions/dashboard.ts
+++ b/frontend/lib/actions/dashboard.ts
@@ -3,7 +3,6 @@
 import { db } from "@/lib/db";
 import { accounts, transactions, categories, users, properties, vehicles, accountBalances, transactionLinks } from "@/lib/db/schema";
 import { getAuthenticatedSession } from "@/lib/auth-helpers";
-import { getCachedUserAccounts } from "@/lib/data/cached";
 import { eq, sql, gte, lte, and, desc, inArray, isNull } from "drizzle-orm";
 import { buildConservativeSankey } from "@/lib/dashboard/sankey";
 import {
@@ -18,6 +17,7 @@ import {
   ASSET_CATEGORY_ORDER,
   getAssetCategory,
 } from "@/lib/assets/asset-category";
+import { getPortfolio } from "@/lib/api/investments";
 
 async function getUserCurrency(userId: string): Promise<string> {
   const result = await db
@@ -73,7 +73,24 @@ async function getLatestTransactionDate(userId: string, accountIds?: string[]): 
 
 // Get user accounts for filter dropdown
 export async function getUserAccounts() {
-  return getCachedUserAccounts();
+  const session = await getAuthenticatedSession();
+
+  if (!session?.user?.id) {
+    return [];
+  }
+
+  const result = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      institution: accounts.institution,
+      accountType: accounts.accountType,
+    })
+    .from(accounts)
+    .where(and(eq(accounts.userId, session.user.id), eq(accounts.isActive, true)))
+    .orderBy(accounts.name);
+
+  return result;
 }
 
 // Get available months/years for the date selector
@@ -782,7 +799,7 @@ export async function getAssetsOverview(): Promise<AssetsOverviewData> {
     };
   }
 
-  const [userAccounts, userProperties, userVehicles, currency] = await Promise.all([
+  const [userAccounts, userProperties, userVehicles, currency, portfolio] = await Promise.all([
     db
       .select({
         id: accounts.id,
@@ -819,6 +836,7 @@ export async function getAssetsOverview(): Promise<AssetsOverviewData> {
       .from(vehicles)
       .where(and(eq(vehicles.userId, session.user.id), eq(vehicles.isActive, true))),
     getUserCurrency(session.user.id),
+    getPortfolio().catch(() => null),
   ]);
 
   // Group accounts by asset category
@@ -900,6 +918,33 @@ export async function getAssetsOverview(): Promise<AssetsOverviewData> {
         currency: vehicle.currency || currency,
         initial: vehicle.name.charAt(0).toUpperCase(),
       });
+    }
+  }
+
+  // Process investment accounts from portfolio
+  if (portfolio?.accounts?.length) {
+    for (const invAccount of portfolio.accounts) {
+      const value = typeof invAccount.balance === "number"
+        ? invAccount.balance
+        : parseFloat(String(invAccount.balance) || "0");
+
+      if (value > 0) {
+        total += value;
+
+        if (!categoryMap.has("investment")) {
+          categoryMap.set("investment", []);
+        }
+
+        categoryMap.get("investment")!.push({
+          id: invAccount.id,
+          name: invAccount.name,
+          institution: invAccount.type || null,
+          value,
+          percentage: 0,
+          currency: portfolio.currency || currency,
+          initial: invAccount.name.charAt(0).toUpperCase(),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- **Assets Overview**: the Investment row now expands into per-account rows (one per portfolio account), matching the Cash/Savings UX. Data sourced from `getPortfolio()`.
- **Investment row navigation**: clicking an investment account row navigates to `/investments` instead of `/accounts/{id}` (portfolio account IDs aren't bank-account IDs).
- **Holdings table**: rows are now grouped by `ETF / Equity / Cash` with per-group counts and subtotals. Existing filter and column sort still work within each group.

## Test plan
- [ ] Dashboard renders Investment category with per-account breakdown
- [ ] Clicking an investment account row routes to `/investments`
- [ ] Cash / Savings rows still link to `/accounts/{id}`
- [ ] Holdings page shows ETF / Equity / Cash group headers with subtotals
- [ ] Holdings filter (All/ETF/Equity/Cash) and column sort still work
- [ ] Dashboard still renders if investments backend is down (failure swallowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show per-account investments in Assets and group holdings by type for faster scanning. Investment rows now open the Investments page, and the dashboard still renders if the portfolio API fails.

- **New Features**
  - Assets Overview: Investment expands into per-account rows from `getPortfolio()`, matching Cash/Savings; investment rows route to `/investments`, others to `/accounts/{id}`.
  - Holdings: Grouped by ETF/Equity/Cash with per‑group counts and subtotals; sort and filter still work; total footer retained.

- **Bug Fixes**
  - Rebased Holdings table to the current shadcn version and restored dashboard changes, removing stale pre‑shadcn imports to fix build issues.

<sup>Written for commit ad3f2929bcb48bf9ee762f357ecc85fa5d6860b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

