### PR TITLE
fix(investments): correct P&L for non-user-currency holdings

### DIFF
--- a/backend/app/routes/investments.py
+++ b/backend/app/routes/investments.py
@@ -326,6 +326,38 @@ def list_holdings(
     db: Session = Depends(get_db),
 ):
     user_id = get_user_id(user_id)
+    user = db.query(User).filter(User.id == user_id).first()
+    user_currency = (
+        getattr(user, "functional_currency", None) or "EUR"
+    ).upper()
+
+    from app.services.exchange_rate_service import ExchangeRateService
+
+    fx_svc = ExchangeRateService(db=db)
+
+    def _convert_cost_to_user(
+        avg_cost: Optional[Decimal],
+        qty: Decimal,
+        src_currency: str,
+        on: Optional[date],
+    ) -> Optional[Decimal]:
+        if avg_cost is None:
+            return None
+        cost_native = Decimal(avg_cost) * Decimal(qty)
+        src = (src_currency or user_currency).upper()
+        if src == user_currency:
+            return cost_native.quantize(Decimal("0.01"))
+        for_date = on or date.today()
+        converted = fx_svc.convert_amount(
+            amount=cost_native,
+            from_currency=src,
+            to_currency=user_currency,
+            for_date=for_date,
+        )
+        if converted is None:
+            return None
+        return Decimal(converted).quantize(Decimal("0.01"))
+
     query = db.query(Holding).filter(Holding.user_id == user_id)
     if account_id is not None:
         query = query.filter(Holding.account_id == account_id)
@@ -337,6 +369,9 @@ def list_holdings(
             .filter(HoldingValuation.holding_id == h.id)
             .order_by(desc(HoldingValuation.date))
             .first()
+        )
+        cost_basis_user = _convert_cost_to_user(
+            h.avg_cost, h.quantity, h.currency, h.as_of_date
         )
         results.append(
             HoldingResponse(
@@ -355,6 +390,7 @@ def list_holdings(
                 current_value_user_currency=(
                     latest_val.value_user_currency if latest_val else None
                 ),
+                cost_basis_user_currency=cost_basis_user,
                 is_stale=bool(latest_val.is_stale) if latest_val else False,
             )
         )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -294,6 +294,7 @@ class HoldingResponse(BaseModel):
     source: str
     current_price: Optional[Decimal] = None
     current_value_user_currency: Optional[Decimal] = None
+    cost_basis_user_currency: Optional[Decimal] = None
     is_stale: bool = False
 
 

--- a/frontend/components/investments/HoldingDetailView.tsx
+++ b/frontend/components/investments/HoldingDetailView.tsx
@@ -65,8 +65,8 @@ export function HoldingDetailView({
   const totalValue = Number(portfolio.total_value);
   const weight = totalValue > 0 ? (marketValue / totalValue) * 100 : 0;
   const costBasis =
-    holding.avg_cost != null
-      ? Number(holding.avg_cost) * Number(holding.quantity)
+    holding.cost_basis_user_currency != null
+      ? Number(holding.cost_basis_user_currency)
       : null;
   const totalReturn =
     costBasis != null && costBasis > 0

--- a/frontend/components/investments/HoldingsTableHF.tsx
+++ b/frontend/components/investments/HoldingsTableHF.tsx
@@ -97,7 +97,10 @@ export function HoldingsTableHF({
         const qty = Number(h.quantity);
         const price = Number(h.current_price ?? 0);
         const value = Number(h.current_value_user_currency ?? 0);
-        const cost = h.avg_cost != null ? Number(h.avg_cost) * qty : null;
+        const cost =
+          h.cost_basis_user_currency != null
+            ? Number(h.cost_basis_user_currency)
+            : null;
         const pnl = cost != null ? value - cost : null;
         return {
           ...h,

--- a/frontend/lib/api/investments.ts
+++ b/frontend/lib/api/investments.ts
@@ -18,6 +18,7 @@ export type Holding = {
   source: "manual" | "ibkr_flex";
   current_price?: string | null;
   current_value_user_currency?: string | null;
+  cost_basis_user_currency?: string | null;
   is_stale: boolean;
 };
 


### PR DESCRIPTION
## Summary

Fixes a P&L currency-mixing bug in the holdings table and holding detail view (flagged by cubic on #102, pre-existing from #98).

`HoldingsTableHF` and `HoldingDetailView` were computing P&L / total return as:

```
value (in user currency) - avg_cost * quantity (in holding's native currency)
```

For non-user-currency holdings (e.g. a USD stock in a EUR portfolio) this subtracts two amounts in different currencies and produces a meaningless number.

## Fix

- Backend: add `cost_basis_user_currency` to `HoldingResponse`. The route FX-converts `avg_cost * quantity` from the holding's currency to the user's functional currency using `ExchangeRateService` at the holding's `as_of_date` (the rate that was in effect when the avg_cost was set), falling back to today if the date is missing.
- Frontend: `Holding` type gains the new field; both `HoldingsTableHF` (P&L column) and `HoldingDetailView` (total return %) now consume it instead of multiplying native-currency `avg_cost` by quantity.

Using the cost-time FX rate (rather than today's rate, which option (b) in the cubic comment would have implied) is more correct: it preserves the actual return in user-currency terms, including FX gains/losses since the position was opened.

## Test plan

- [ ] Holdings table: USD-priced holding in a EUR portfolio shows non-mixed P&L
- [ ] Holdings table: same-currency holding (EUR holding in EUR portfolio) P&L unchanged
- [ ] Holding detail view: total-return % matches the P&L column in the table
- [ ] Manual holding without `avg_cost`: P&L renders as N/A (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes P&L and total return for non-user-currency holdings by FX-converting cost basis to the user currency. Prevents mixed-currency math in `HoldingsTableHF` and `HoldingDetailView`.

- **Bug Fixes**
  - Backend: add `cost_basis_user_currency` to `HoldingResponse`, converting `avg_cost * quantity` to user currency via `ExchangeRateService` at `as_of_date` (fallback to today).
  - Frontend: use `cost_basis_user_currency` for P&L and total return in `HoldingsTableHF` and `HoldingDetailView`; extend `Holding` type accordingly.

<sup>Written for commit c8a765e504f665728dad9630c70dcebbcd24f076. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

