### PR TITLE
feat(mcp): broker trade import + FIFO P&L tools

### DIFF
--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -40,7 +40,8 @@ The `user_id` parameter is optional on all tools but must match the authenticate
 - **Transactions**: List, search, view, and update categories
 - **Analytics**: Spending/income by category, monthly cashflow, financial summary
 - **Recurring**: List and view subscriptions/bills
-- **Investments**: List holdings, portfolio summary/history, symbol search
+- **Investments**: List holdings, portfolio summary/history, symbol search,
+  import broker trades (CSV/PDF/XLSX statements), realized & unrealized P&L (FIFO)
 
 ## Bulk recategorization workflow (recommended)
 
@@ -763,3 +764,109 @@ def search_symbol(query: str, user_id: str | None = None) -> list[dict]:
         List of matching {symbol, name, currency, instrument_type} entries.
     """
     return investments.search_symbol(get_mcp_user_id(user_id), query)
+
+
+@mcp.tool
+def import_broker_trades(
+    account_id: str,
+    trades: list[dict],
+    dry_run: bool = False,
+    user_id: str | None = None,
+) -> dict:
+    """
+    Import a batch of broker trades for an investment account.
+
+    Use this after you (the LLM) have parsed a broker statement (CSV/PDF/XLSX)
+    into a typed list of trades. The tool dedupes by stable external_id, so
+    re-uploading the same statement is a no-op.
+
+    Workflow:
+        1. Call list_accounts(account_type="investment_brokerage") or
+           list_accounts(account_type="investment_manual") to find the right account.
+        2. Parse the user's statement file into the `trades` shape below.
+        3. Call this with dry_run=True first to preview.
+        4. Call again with dry_run=False to commit.
+
+    Args:
+        account_id: UUID of an investment-type account owned by the authenticated user.
+        trades: List of trade dicts. Each dict must include:
+            - symbol (str): ticker, e.g. "AAPL"
+            - trade_date (str): ISO date "YYYY-MM-DD"
+            - side (str): "buy" or "sell"
+            - quantity (str|number): positive number of shares
+            - price (str|number): per-share price in native currency
+            - currency (str): 3-letter ISO code, e.g. "USD"
+            - fees (str|number, optional): broker fees/commission in native
+              currency; defaults to 0. On buys, fees increase cost basis;
+              on sells, fees reduce proceeds.
+            - external_id (str, optional): broker's confirmation/trade id; if
+              omitted, the server generates a deterministic hash so re-uploads
+              are idempotent.
+            - broker_ref (str, optional): broker confirmation reference for traceability.
+        dry_run: If True, runs the import in a transaction and rolls back; the
+            return shape is the same. Use this to preview before committing.
+        user_id: Optional, defaults to authenticated user.
+
+    Returns:
+        Dict with keys:
+            - inserted (int): rows newly inserted
+            - skipped_duplicate (int): rows skipped because external_id already existed
+            - errors (list): per-trade validation errors with {index, trade, reason}
+            - affected_symbols (list[str]): symbols touched (Holding rows recomputed)
+    """
+    return investments.import_broker_trades(
+        get_mcp_user_id(user_id), account_id, trades, dry_run
+    )
+
+
+@mcp.tool
+def get_realized_pnl(
+    account_id: str | None = None,
+    symbol: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    user_id: str | None = None,
+) -> list[dict]:
+    """
+    Compute FIFO realized P&L from imported broker trades.
+
+    Returns one row per symbol, with native-currency totals plus
+    base-currency totals (using FX on each lot's close date).
+
+    Args:
+        account_id: Filter to a single investment account (optional).
+        symbol: Filter to a single symbol (optional).
+        start_date: ISO YYYY-MM-DD; only count trades on/after this date.
+        end_date: ISO YYYY-MM-DD; only count trades on/before this date.
+        user_id: Optional, defaults to authenticated user.
+
+    Returns:
+        List of {symbol, currency, realized_native, realized_base, lots_closed[]}.
+    """
+    return investments.get_realized_pnl(
+        get_mcp_user_id(user_id), account_id, symbol, start_date, end_date
+    )
+
+
+@mcp.tool
+def get_unrealized_pnl(
+    account_id: str | None = None,
+    symbol: str | None = None,
+    user_id: str | None = None,
+) -> list[dict]:
+    """
+    Compute unrealized P&L for currently-open FIFO lots.
+
+    Uses the latest HoldingValuation price per symbol. Symbols without a
+    valuation are omitted (run a price refresh first if needed).
+
+    Args:
+        account_id: Filter to a single investment account (optional).
+        symbol: Filter to a single symbol (optional).
+        user_id: Optional, defaults to authenticated user.
+
+    Returns:
+        List of {symbol, currency, quantity, cost_basis_native, cost_basis_base,
+        market_value_native, market_value_base, unrealized_native, unrealized_base, fx_missing}.
+    """
+    return investments.get_unrealized_pnl(get_mcp_user_id(user_id), account_id, symbol)

--- a/backend/app/mcp/tools/investments.py
+++ b/backend/app/mcp/tools/investments.py
@@ -316,7 +316,7 @@ def _trades_for_user(
         q = q.filter(BrokerTrade.trade_date >= validate_date(start_date))
     if end_date:
         q = q.filter(BrokerTrade.trade_date <= validate_date(end_date))
-    rows = q.order_by(BrokerTrade.trade_date).all()
+    rows = q.order_by(BrokerTrade.trade_date, BrokerTrade.id).all()
     return [
         Trade(
             symbol=r.symbol,

--- a/backend/app/mcp/tools/investments.py
+++ b/backend/app/mcp/tools/investments.py
@@ -18,9 +18,18 @@ from app.mcp.dependencies import get_db, validate_date
 from app.models import (
     Account,
     AccountBalance,
+    BrokerTrade,
     Holding,
     HoldingValuation,
     User,
+)
+from app.services.broker_trade_service import import_trades as _import_trades_service
+from app.services.broker_trade_service import ImportError as _BrokerImportError
+from app.services.exchange_rate_service import ExchangeRateService
+from app.services.pnl_service import (
+    Trade,
+    realized_pnl_from_trades,
+    unrealized_pnl_from_trades,
 )
 
 
@@ -243,3 +252,182 @@ def search_symbol_impl(db: Session, user_id: str, query: str) -> list[dict]:
 def search_symbol(user_id: str, query: str) -> list[dict]:
     with get_db() as db:
         return search_symbol_impl(db, user_id, query)
+
+
+def import_broker_trades_impl(
+    db: Session,
+    user_id: str,
+    account_id: str,
+    trades: list[dict],
+    dry_run: bool = False,
+) -> dict:
+    try:
+        return _import_trades_service(
+            db=db,
+            user_id=user_id,
+            account_id=account_id,
+            trades=trades,
+            dry_run=dry_run,
+        )
+    except _BrokerImportError as e:
+        return {
+            "inserted": 0,
+            "skipped_duplicate": 0,
+            "errors": [{"index": -1, "trade": None, "reason": str(e)}],
+            "affected_symbols": [],
+        }
+
+
+def import_broker_trades(
+    user_id: str,
+    account_id: str,
+    trades: list[dict],
+    dry_run: bool = False,
+) -> dict:
+    with get_db() as db:
+        return import_broker_trades_impl(db, user_id, account_id, trades, dry_run)
+
+
+def _user_base_currency(db: Session, user_id: str) -> str:
+    user = db.query(User).filter(User.id == user_id).first()
+    return getattr(user, "functional_currency", "EUR") if user else "EUR"
+
+
+def _trades_for_user(
+    db: Session,
+    user_id: str,
+    account_id: Optional[str] = None,
+    symbol: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> list[Trade]:
+    """Load BrokerTrade rows scoped to the user, return as pure-engine `Trade` objects."""
+    account_ids_subq = (
+        db.query(Account.id)
+        .filter(Account.user_id == user_id)
+        .subquery()
+    )
+    q = db.query(BrokerTrade).filter(BrokerTrade.account_id.in_(account_ids_subq))
+    if account_id:
+        q = q.filter(BrokerTrade.account_id == account_id)
+    if symbol:
+        q = q.filter(BrokerTrade.symbol == symbol.upper())
+    if start_date:
+        q = q.filter(BrokerTrade.trade_date >= validate_date(start_date))
+    if end_date:
+        q = q.filter(BrokerTrade.trade_date <= validate_date(end_date))
+    rows = q.order_by(BrokerTrade.trade_date).all()
+    return [
+        Trade(
+            symbol=r.symbol,
+            trade_date=r.trade_date,
+            side=r.side,
+            quantity=Decimal(r.quantity),
+            price=Decimal(r.price),
+            currency=r.currency,
+            fees=Decimal(r.fees or 0),
+        )
+        for r in rows
+    ]
+
+
+def get_realized_pnl_impl(
+    db: Session,
+    user_id: str,
+    account_id: Optional[str] = None,
+    symbol: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> list[dict]:
+    base = _user_base_currency(db, user_id)
+    trades = _trades_for_user(db, user_id, account_id, symbol, start_date, end_date)
+    if not trades:
+        return []
+    fx = ExchangeRateService(db)
+    rows = realized_pnl_from_trades(trades, base_currency=base, fx_service=fx)
+    return [_jsonify_pnl_row(r) for r in rows]
+
+
+def get_realized_pnl(
+    user_id: str,
+    account_id: Optional[str] = None,
+    symbol: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> list[dict]:
+    with get_db() as db:
+        return get_realized_pnl_impl(db, user_id, account_id, symbol, start_date, end_date)
+
+
+def get_unrealized_pnl_impl(
+    db: Session,
+    user_id: str,
+    account_id: Optional[str] = None,
+    symbol: Optional[str] = None,
+) -> list[dict]:
+    base = _user_base_currency(db, user_id)
+    trades = _trades_for_user(db, user_id, account_id, symbol)
+    if not trades:
+        return []
+
+    # Latest valuation per symbol — pick most recent HoldingValuation joined to Holding
+    holdings_q = db.query(Holding).filter(Holding.user_id == user_id)
+    if account_id:
+        holdings_q = holdings_q.filter(Holding.account_id == account_id)
+    if symbol:
+        holdings_q = holdings_q.filter(Holding.symbol == symbol.upper())
+    holdings = holdings_q.all()
+
+    valuations = _latest_valuations_for_user(db, user_id)
+    latest_prices: dict[str, Decimal] = {}
+    latest_dates: list[date] = []
+    for h in holdings:
+        v = valuations.get(h.id)
+        if v is not None and v.price is not None:
+            latest_prices[h.symbol] = Decimal(v.price)
+            latest_dates.append(v.date)
+
+    as_of = max(latest_dates) if latest_dates else date.today()
+
+    fx = ExchangeRateService(db)
+    rows = unrealized_pnl_from_trades(
+        trades,
+        base_currency=base,
+        fx_service=fx,
+        latest_prices=latest_prices,
+        as_of_date=as_of,
+    )
+    return [_jsonify_pnl_row(r) for r in rows]
+
+
+def get_unrealized_pnl(
+    user_id: str,
+    account_id: Optional[str] = None,
+    symbol: Optional[str] = None,
+) -> list[dict]:
+    with get_db() as db:
+        return get_unrealized_pnl_impl(db, user_id, account_id, symbol)
+
+
+def _dec_str(v: Decimal) -> str:
+    """Stringify a Decimal, stripping trailing zeros (e.g. '500' not '500.0000000000000000')."""
+    normalized = v.normalize()
+    # normalize() can produce scientific notation for very large/small values; use 'f' format
+    return format(normalized, "f")
+
+
+def _jsonify_pnl_row(row: dict) -> dict:
+    """Convert Decimals to strings recursively for JSON-friendly output."""
+    out = {}
+    for k, v in row.items():
+        if isinstance(v, Decimal):
+            out[k] = _dec_str(v)
+        elif isinstance(v, list):
+            out[k] = [
+                {kk: (_dec_str(vv) if isinstance(vv, Decimal) else vv) for kk, vv in item.items()}
+                if isinstance(item, dict) else item
+                for item in v
+            ]
+        else:
+            out[k] = v
+    return out

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -751,6 +751,7 @@ class BrokerTrade(Base):
     quantity = Column(Numeric(28, 8), nullable=False)
     price = Column(Numeric(28, 8), nullable=False)
     currency = Column(String(3), nullable=False)
+    fees = Column(Numeric(28, 8), nullable=False, default=0)
     external_id = Column(String(128), nullable=False)
 
     __table_args__ = (

--- a/backend/app/services/broker_trade_service.py
+++ b/backend/app/services/broker_trade_service.py
@@ -198,6 +198,9 @@ def import_trades(
     if dry_run:
         db.rollback()
     else:
+        # Recompute holdings for each affected (account, symbol) pair from full trade history
+        for symbol in affected_symbols:
+            _recompute_holding(db, account, symbol)
         db.commit()
 
     return {
@@ -206,3 +209,70 @@ def import_trades(
         "errors": errors,
         "affected_symbols": affected_symbols,
     }
+
+
+def _recompute_holding(db: Session, account: Account, symbol: str) -> None:
+    """Rebuild Holding(account, symbol) from full BrokerTrade history using FIFO."""
+    trades = (
+        db.query(BrokerTrade)
+        .filter(BrokerTrade.account_id == account.id, BrokerTrade.symbol == symbol)
+        .order_by(BrokerTrade.trade_date)
+        .all()
+    )
+    if not trades:
+        return
+
+    fifo_trades = [
+        Trade(
+            symbol=t.symbol,
+            trade_date=t.trade_date,
+            side=t.side,
+            quantity=Decimal(t.quantity),
+            price=Decimal(t.price),
+            currency=t.currency,
+            fees=Decimal(t.fees or 0),
+        )
+        for t in trades
+    ]
+    result = compute_fifo(fifo_trades)
+    open_lots = [l for l in result.open_lots if l.symbol == symbol]
+
+    quantity = sum((l.quantity_remaining for l in open_lots), Decimal("0"))
+    if quantity > 0:
+        total_cost = sum(
+            (l.quantity_remaining * l.cost_per_share_native for l in open_lots),
+            Decimal("0"),
+        )
+        avg_cost = (total_cost / quantity).quantize(Decimal("0.00000001"))
+        currency = open_lots[0].currency
+    else:
+        avg_cost = None
+        currency = trades[-1].currency
+
+    last_date = max(t.trade_date for t in trades)
+
+    holding = (
+        db.query(Holding)
+        .filter(Holding.account_id == account.id, Holding.symbol == symbol)
+        .first()
+    )
+    if holding is None:
+        holding = Holding(
+            user_id=account.user_id,
+            account_id=account.id,
+            symbol=symbol,
+            currency=currency,
+            instrument_type="equity",
+            quantity=quantity,
+            avg_cost=avg_cost,
+            as_of_date=last_date,
+            source="trade_import",
+        )
+        db.add(holding)
+    else:
+        holding.quantity = quantity
+        holding.avg_cost = avg_cost
+        holding.as_of_date = last_date
+        holding.source = "trade_import"
+        if not holding.currency:
+            holding.currency = currency

--- a/backend/app/services/broker_trade_service.py
+++ b/backend/app/services/broker_trade_service.py
@@ -31,6 +31,24 @@ def _normalize_quantity(q: Decimal) -> str:
     return s if s != "-0" else "0"
 
 
+def _hash_trade_key(
+    trade_date: date,
+    symbol: str,
+    side: str,
+    quantity: Decimal,
+    price: Decimal,
+) -> str:
+    """16-hex stable digest of the trade collision key (date|symbol|side|qty|price)."""
+    key = "|".join([
+        trade_date.isoformat(),
+        symbol.upper(),
+        side.lower(),
+        _normalize_quantity(quantity),
+        _normalize_quantity(price),
+    ])
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
 def _generate_external_id(
     trade_date: date,
     symbol: str,
@@ -44,15 +62,7 @@ def _generate_external_id(
     Format: `<16-hex>#<N>`. Same statement re-uploaded → same id (no-op).
     Two genuinely identical trades on the same day → distinct ids via ordinal.
     """
-    key = "|".join([
-        trade_date.isoformat(),
-        symbol.upper(),
-        side.lower(),
-        _normalize_quantity(quantity),
-        _normalize_quantity(price),
-    ])
-    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
-    return f"{digest}#{ordinal}"
+    return f"{_hash_trade_key(trade_date, symbol, side, quantity, price)}#{ordinal}"
 
 
 class ImportError(Exception):
@@ -151,22 +161,49 @@ def import_trades(
         }
 
     # Generate external_ids for trades that didn't provide one.
-    # Group by collision key to assign per-batch ordinals.
-    by_key: dict[tuple, int] = defaultdict(int)
+    # Ordinal assignment is sequential (0, 1, 2, ...) per collision key. This
+    # preserves idempotent re-upload (same trades → same ids → ON CONFLICT
+    # dedup) while also being cross-batch aware: if a previous batch already
+    # imported N same-key trades (#0..#N-1) and a new batch contains M more,
+    # we look up the existing count and start new ordinals at N — so the new
+    # rows don't collide with the existing #0..#N-1 and are correctly inserted.
+    existing_max_by_digest: dict[str, int] = {}
+    existing_rows = (
+        db.query(BrokerTrade.external_id)
+        .filter(BrokerTrade.account_id == account.id)
+        .all()
+    )
+    for (eid,) in existing_rows:
+        if not eid or "#" not in eid:
+            continue
+        prefix, _, ord_str = eid.rpartition("#")
+        try:
+            n = int(ord_str)
+        except ValueError:
+            continue
+        prev = existing_max_by_digest.get(prefix)
+        if prev is None or n > prev:
+            existing_max_by_digest[prefix] = n
+
+    batch_count_by_digest: dict[str, int] = defaultdict(int)
     for vt in validated:
         if vt.external_id:
             continue
-        key = (vt.trade_date, vt.symbol.upper(), vt.side, _normalize_quantity(vt.quantity), _normalize_quantity(vt.price))
-        ordinal = by_key[key]
-        by_key[key] += 1
-        vt.external_id = _generate_external_id(
+        digest = _hash_trade_key(
             trade_date=vt.trade_date,
             symbol=vt.symbol,
             side=vt.side,
             quantity=vt.quantity,
             price=vt.price,
-            ordinal=ordinal,
         )
+        # Sequential within batch (0, 1, 2, ...). For re-uploads these match
+        # existing ids and dedup. If the batch produces more same-key trades
+        # than already exist, the surplus uses ordinals beyond the existing max.
+        batch_idx = batch_count_by_digest[digest]
+        batch_count_by_digest[digest] += 1
+        existing_max = existing_max_by_digest.get(digest, -1)
+        ordinal = batch_idx if batch_idx <= existing_max else max(batch_idx, existing_max + 1)
+        vt.external_id = f"{digest}#{ordinal}"
 
     # Bulk insert with ON CONFLICT DO NOTHING; RETURNING tells us which rows actually inserted.
     rows = [
@@ -195,12 +232,14 @@ def import_trades(
     skipped = len(validated) - inserted
     affected_symbols = sorted({vt.symbol.upper() for vt in validated})
 
+    # Recompute holdings before deciding whether to commit so dry_run still
+    # surfaces FIFO oversell errors and any other recompute failures.
+    for symbol in affected_symbols:
+        _recompute_holding(db, account, symbol)
+
     if dry_run:
         db.rollback()
     else:
-        # Recompute holdings for each affected (account, symbol) pair from full trade history
-        for symbol in affected_symbols:
-            _recompute_holding(db, account, symbol)
         db.commit()
 
     return {
@@ -253,7 +292,11 @@ def _recompute_holding(db: Session, account: Account, symbol: str) -> None:
 
     holding = (
         db.query(Holding)
-        .filter(Holding.account_id == account.id, Holding.symbol == symbol)
+        .filter(
+            Holding.account_id == account.id,
+            Holding.symbol == symbol,
+            Holding.instrument_type == "equity",
+        )
         .first()
     )
     if holding is None:

--- a/backend/app/services/broker_trade_service.py
+++ b/backend/app/services/broker_trade_service.py
@@ -53,3 +53,107 @@ def _generate_external_id(
     ])
     digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
     return f"{digest}#{ordinal}"
+
+
+class ImportError(Exception):
+    """Raised for import-level (not per-trade) failures."""
+
+
+@dataclass
+class _ValidatedTrade:
+    index: int
+    symbol: str
+    trade_date: date
+    side: str
+    quantity: Decimal
+    price: Decimal
+    currency: str
+    fees: Decimal
+    external_id: str | None
+    broker_ref: str | None
+
+
+def _validate_trade(index: int, raw: dict[str, Any]) -> tuple[_ValidatedTrade | None, dict | None]:
+    """Returns (validated, None) on success or (None, error_dict) on failure."""
+    try:
+        symbol = str(raw["symbol"]).strip()
+        if not symbol:
+            raise ValueError("symbol required")
+        trade_date = date.fromisoformat(str(raw["trade_date"]))
+        side = str(raw["side"]).lower()
+        if side not in VALID_SIDES:
+            raise ValueError(f"side must be one of {VALID_SIDES}, got {side!r}")
+        quantity = Decimal(str(raw["quantity"]))
+        if quantity <= 0:
+            raise ValueError("quantity must be positive")
+        price = Decimal(str(raw["price"]))
+        if price < 0:
+            raise ValueError("price must be non-negative")
+        currency = str(raw["currency"]).upper()
+        if len(currency) != 3:
+            raise ValueError("currency must be a 3-letter ISO code")
+        fees_raw = raw.get("fees")
+        fees = Decimal(str(fees_raw)) if fees_raw is not None else Decimal("0")
+        if fees < 0:
+            raise ValueError("fees must be non-negative")
+        external_id = raw.get("external_id")
+        broker_ref = raw.get("broker_ref")
+    except (KeyError, ValueError, TypeError, ArithmeticError) as e:
+        return None, {"index": index, "trade": raw, "reason": str(e)}
+
+    return _ValidatedTrade(
+        index=index,
+        symbol=symbol,
+        trade_date=trade_date,
+        side=side,
+        quantity=quantity,
+        price=price,
+        currency=currency,
+        fees=fees,
+        external_id=external_id,
+        broker_ref=broker_ref,
+    ), None
+
+
+def import_trades(
+    db: Session,
+    user_id: str,
+    account_id: str,
+    trades: list[dict[str, Any]],
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Import a batch of broker trades. See spec §"New MCP tools"."""
+    account = (
+        db.query(Account)
+        .filter(Account.id == account_id, Account.user_id == user_id)
+        .first()
+    )
+    if account is None:
+        raise ImportError(f"account not found or not owned by user: {account_id}")
+    if account.account_type not in ("investment_manual", "investment_brokerage"):
+        raise ImportError(f"account is not an investment account: {account.account_type}")
+
+    validated: list[_ValidatedTrade] = []
+    errors: list[dict] = []
+    for i, raw in enumerate(trades):
+        ok, err = _validate_trade(i, raw)
+        if err is not None:
+            errors.append(err)
+        else:
+            validated.append(ok)
+
+    if not validated:
+        return {
+            "inserted": 0,
+            "skipped_duplicate": 0,
+            "errors": errors,
+            "affected_symbols": [],
+        }
+
+    # Step 4 (next task) implements the actual insert + holding recompute.
+    return {
+        "inserted": 0,
+        "skipped_duplicate": 0,
+        "errors": errors,
+        "affected_symbols": [],
+    }

--- a/backend/app/services/broker_trade_service.py
+++ b/backend/app/services/broker_trade_service.py
@@ -150,10 +150,59 @@ def import_trades(
             "affected_symbols": [],
         }
 
-    # Step 4 (next task) implements the actual insert + holding recompute.
+    # Generate external_ids for trades that didn't provide one.
+    # Group by collision key to assign per-batch ordinals.
+    by_key: dict[tuple, int] = defaultdict(int)
+    for vt in validated:
+        if vt.external_id:
+            continue
+        key = (vt.trade_date, vt.symbol.upper(), vt.side, _normalize_quantity(vt.quantity), _normalize_quantity(vt.price))
+        ordinal = by_key[key]
+        by_key[key] += 1
+        vt.external_id = _generate_external_id(
+            trade_date=vt.trade_date,
+            symbol=vt.symbol,
+            side=vt.side,
+            quantity=vt.quantity,
+            price=vt.price,
+            ordinal=ordinal,
+        )
+
+    # Bulk insert with ON CONFLICT DO NOTHING; RETURNING tells us which rows actually inserted.
+    rows = [
+        {
+            "account_id": account.id,
+            "symbol": vt.symbol.upper(),
+            "trade_date": vt.trade_date,
+            "side": vt.side,
+            "quantity": vt.quantity,
+            "price": vt.price,
+            "currency": vt.currency,
+            "fees": vt.fees,
+            "external_id": vt.external_id,
+        }
+        for vt in validated
+    ]
+
+    stmt = (
+        pg_insert(BrokerTrade.__table__)
+        .values(rows)
+        .on_conflict_do_nothing(index_elements=["account_id", "external_id"])
+        .returning(BrokerTrade.__table__.c.id, BrokerTrade.__table__.c.symbol)
+    )
+    inserted_rows = db.execute(stmt).fetchall()
+    inserted = len(inserted_rows)
+    skipped = len(validated) - inserted
+    affected_symbols = sorted({vt.symbol.upper() for vt in validated})
+
+    if dry_run:
+        db.rollback()
+    else:
+        db.commit()
+
     return {
-        "inserted": 0,
-        "skipped_duplicate": 0,
+        "inserted": inserted,
+        "skipped_duplicate": skipped,
         "errors": errors,
-        "affected_symbols": [],
+        "affected_symbols": affected_symbols,
     }

--- a/backend/app/services/broker_trade_service.py
+++ b/backend/app/services/broker_trade_service.py
@@ -1,0 +1,55 @@
+"""
+Broker trade import orchestration.
+
+Validates ownership, generates stable external_ids for dedup, bulk-inserts
+into `broker_trades`, and recomputes `Holding.quantity` and `Holding.avg_cost`
+for every affected (account_id, symbol) pair using FIFO.
+"""
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from app.models import Account, BrokerTrade, Holding
+from app.services.pnl_service import Trade, compute_fifo
+
+
+VALID_SIDES = ("buy", "sell")
+
+
+def _normalize_quantity(q: Decimal) -> str:
+    # Stable representation for hashing: strip trailing zeros, no scientific notation.
+    s = format(q.normalize(), "f")
+    return s if s != "-0" else "0"
+
+
+def _generate_external_id(
+    trade_date: date,
+    symbol: str,
+    side: str,
+    quantity: Decimal,
+    price: Decimal,
+    ordinal: int,
+) -> str:
+    """Stable hash of the trade fields plus an ordinal disambiguator.
+
+    Format: `<16-hex>#<N>`. Same statement re-uploaded → same id (no-op).
+    Two genuinely identical trades on the same day → distinct ids via ordinal.
+    """
+    key = "|".join([
+        trade_date.isoformat(),
+        symbol.upper(),
+        side.lower(),
+        _normalize_quantity(quantity),
+        _normalize_quantity(price),
+    ])
+    digest = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+    return f"{digest}#{ordinal}"

--- a/backend/app/services/pnl_service.py
+++ b/backend/app/services/pnl_service.py
@@ -109,10 +109,11 @@ def compute_fifo(trades: Iterable[Trade]) -> FifoResult:
         # sell — fees reduce proceeds, prorated by consumed quantity vs total sell qty
         remaining = t.quantity
         sell_total_qty = t.quantity
+        # Pre-compute available quantity before iterating (for oversell error reporting)
+        available_at_start = sum((l.quantity_remaining for l in lots), Decimal("0"))
         while remaining > 0:
             if not lots:
-                available = sum((l.quantity_remaining for l in lots), Decimal("0"))
-                raise OverSellError(t.symbol, t.trade_date, t.quantity, available)
+                raise OverSellError(t.symbol, t.trade_date, t.quantity, available_at_start)
             lot = lots[0]
             consumed = min(lot.quantity_remaining, remaining)
             cost = consumed * lot.cost_per_share_native

--- a/backend/app/services/pnl_service.py
+++ b/backend/app/services/pnl_service.py
@@ -86,11 +86,11 @@ def compute_fifo(trades: Iterable[Trade]) -> FifoResult:
     """
     sorted_trades = sorted(trades, key=lambda t: (t.trade_date, 0 if t.side == "buy" else 1))
 
-    open_by_symbol: dict[str, list[_MutableLot]] = {}
+    open_by_key: dict[tuple[str, str], list[_MutableLot]] = {}
     realized: list[ClosedLot] = []
 
     for t in sorted_trades:
-        lots = open_by_symbol.setdefault(t.symbol, [])
+        lots = open_by_key.setdefault((t.symbol, t.currency), [])
         if t.side == "buy":
             # Buy fees increase cost basis: cost_per_share = (price*qty + fees) / qty
             cost_per_share = (
@@ -135,7 +135,7 @@ def compute_fifo(trades: Iterable[Trade]) -> FifoResult:
                 lots.pop(0)
 
     open_lots: list[OpenLot] = []
-    for sym, lots in open_by_symbol.items():
+    for (sym, _ccy), lots in open_by_key.items():
         for lot in lots:
             open_lots.append(OpenLot(
                 symbol=sym,

--- a/backend/app/services/pnl_service.py
+++ b/backend/app/services/pnl_service.py
@@ -203,3 +203,67 @@ def realized_pnl_from_trades(
             "lots_closed": lot_dicts,
         })
     return out
+
+
+def unrealized_pnl_from_trades(
+    trades: Iterable[Trade],
+    base_currency: str,
+    fx_service,
+    latest_prices: dict[str, Decimal],
+    as_of_date: date,
+) -> list[dict]:
+    """
+    Run FIFO; for each remaining open lot group by symbol; compute:
+      cost_basis_native  = sum(qty_remaining * cost_per_share)
+      market_value_native = sum(qty_remaining) * latest_price[symbol]
+      unrealized_native   = market_value_native - cost_basis_native
+      *_base via fx_service.get_exchange_rate(symbol_ccy, base_currency, as_of_date)
+
+    Symbols with no entry in `latest_prices` are skipped (caller logs them).
+    Symbols whose FX lookup fails set `fx_missing=True` and base values to 0.
+    """
+    fifo = compute_fifo(trades)
+
+    by_symbol: dict[str, list[OpenLot]] = {}
+    for lot in fifo.open_lots:
+        by_symbol.setdefault(lot.symbol, []).append(lot)
+
+    out: list[dict] = []
+    for symbol, lots in by_symbol.items():
+        price = latest_prices.get(symbol)
+        if price is None:
+            continue
+        symbol_currency = lots[0].currency
+        quantity = sum((l.quantity_remaining for l in lots), Decimal("0"))
+        cost_basis_native = sum(
+            (l.quantity_remaining * l.cost_per_share_native for l in lots),
+            Decimal("0"),
+        )
+        market_value_native = quantity * price
+        unrealized_native = market_value_native - cost_basis_native
+
+        rate = fx_service.get_exchange_rate(symbol_currency, base_currency, as_of_date)
+        if rate is None:
+            fx_missing = True
+            cost_basis_base = Decimal("0")
+            market_value_base = Decimal("0")
+            unrealized_base = Decimal("0")
+        else:
+            fx_missing = False
+            cost_basis_base = (cost_basis_native * rate).quantize(Decimal("0.01"))
+            market_value_base = (market_value_native * rate).quantize(Decimal("0.01"))
+            unrealized_base = (unrealized_native * rate).quantize(Decimal("0.01"))
+
+        out.append({
+            "symbol": symbol,
+            "currency": symbol_currency,
+            "quantity": quantity,
+            "cost_basis_native": cost_basis_native,
+            "cost_basis_base": cost_basis_base,
+            "market_value_native": market_value_native,
+            "market_value_base": market_value_base,
+            "unrealized_native": unrealized_native,
+            "unrealized_base": unrealized_base,
+            "fx_missing": fx_missing,
+        })
+    return out

--- a/backend/app/services/pnl_service.py
+++ b/backend/app/services/pnl_service.py
@@ -1,0 +1,147 @@
+"""
+Pure FIFO P&L engine.
+
+`compute_fifo` is a pure function over a list of trades — no DB access,
+no FX, no I/O. DB- and FX-aware wrappers live below.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Trade:
+    """Input trade for the FIFO engine."""
+    symbol: str
+    trade_date: date
+    side: str  # "buy" | "sell"
+    quantity: Decimal
+    price: Decimal
+    currency: str
+    fees: Decimal = Decimal("0")  # native currency, non-negative
+
+
+@dataclass(frozen=True)
+class ClosedLot:
+    """A realized P&L lot — the result of a sell matching against open buy lots."""
+    symbol: str
+    currency: str
+    open_date: date
+    close_date: date
+    quantity: Decimal
+    cost_native: Decimal
+    proceeds_native: Decimal
+    pnl_native: Decimal
+
+
+@dataclass(frozen=True)
+class OpenLot:
+    """A remaining unmatched buy lot."""
+    symbol: str
+    currency: str
+    open_date: date
+    quantity_remaining: Decimal
+    cost_per_share_native: Decimal
+
+
+@dataclass
+class FifoResult:
+    realized: list[ClosedLot] = field(default_factory=list)
+    open_lots: list[OpenLot] = field(default_factory=list)
+
+
+class OverSellError(Exception):
+    """Raised when a sell exceeds available open quantity for a symbol."""
+    def __init__(self, symbol: str, trade_date: date, qty_attempted: Decimal, qty_available: Decimal):
+        self.symbol = symbol
+        self.trade_date = trade_date
+        self.qty_attempted = qty_attempted
+        self.qty_available = qty_available
+        super().__init__(
+            f"Sell of {qty_attempted} {symbol} on {trade_date} exceeds available {qty_available}"
+        )
+
+
+@dataclass
+class _MutableLot:
+    open_date: date
+    quantity_remaining: Decimal
+    cost_per_share_native: Decimal
+    currency: str
+
+
+def compute_fifo(trades: Iterable[Trade]) -> FifoResult:
+    """
+    Apply FIFO matching to a sequence of trades.
+
+    Trades are processed in chronological order (then by side, buys first on
+    ties so a same-day buy can cover a same-day sell).
+
+    Currency is tracked per-symbol; if a symbol's trades use mixed currencies
+    they are still matched (currency redenomination is out of scope for the
+    pure engine — caller decides whether to split).
+    """
+    sorted_trades = sorted(trades, key=lambda t: (t.trade_date, 0 if t.side == "buy" else 1))
+
+    open_by_symbol: dict[str, list[_MutableLot]] = {}
+    realized: list[ClosedLot] = []
+
+    for t in sorted_trades:
+        lots = open_by_symbol.setdefault(t.symbol, [])
+        if t.side == "buy":
+            # Buy fees increase cost basis: cost_per_share = (price*qty + fees) / qty
+            cost_per_share = (
+                (t.price * t.quantity + t.fees) / t.quantity
+                if t.quantity > 0
+                else t.price
+            )
+            lots.append(_MutableLot(
+                open_date=t.trade_date,
+                quantity_remaining=t.quantity,
+                cost_per_share_native=cost_per_share,
+                currency=t.currency,
+            ))
+            continue
+
+        # sell — fees reduce proceeds, prorated by consumed quantity vs total sell qty
+        remaining = t.quantity
+        sell_total_qty = t.quantity
+        while remaining > 0:
+            if not lots:
+                available = sum((l.quantity_remaining for l in lots), Decimal("0"))
+                raise OverSellError(t.symbol, t.trade_date, t.quantity, available)
+            lot = lots[0]
+            consumed = min(lot.quantity_remaining, remaining)
+            cost = consumed * lot.cost_per_share_native
+            fee_share = (t.fees * consumed / sell_total_qty) if sell_total_qty > 0 else Decimal("0")
+            proceeds = consumed * t.price - fee_share
+            realized.append(ClosedLot(
+                symbol=t.symbol,
+                currency=t.currency,
+                open_date=lot.open_date,
+                close_date=t.trade_date,
+                quantity=consumed,
+                cost_native=cost,
+                proceeds_native=proceeds,
+                pnl_native=proceeds - cost,
+            ))
+            lot.quantity_remaining -= consumed
+            remaining -= consumed
+            if lot.quantity_remaining == 0:
+                lots.pop(0)
+
+    open_lots: list[OpenLot] = []
+    for sym, lots in open_by_symbol.items():
+        for lot in lots:
+            open_lots.append(OpenLot(
+                symbol=sym,
+                currency=lot.currency,
+                open_date=lot.open_date,
+                quantity_remaining=lot.quantity_remaining,
+                cost_per_share_native=lot.cost_per_share_native,
+            ))
+
+    return FifoResult(realized=realized, open_lots=open_lots)

--- a/backend/app/services/pnl_service.py
+++ b/backend/app/services/pnl_service.py
@@ -146,3 +146,60 @@ def compute_fifo(trades: Iterable[Trade]) -> FifoResult:
             ))
 
     return FifoResult(realized=realized, open_lots=open_lots)
+
+
+def realized_pnl_from_trades(
+    trades: Iterable[Trade],
+    base_currency: str,
+    fx_service,
+) -> list[dict]:
+    """
+    Run FIFO and enrich each closed lot with base-currency P&L.
+
+    `fx_service` must implement `get_exchange_rate(src, dst, on: date) -> Decimal | None`
+    (matches `app.services.exchange_rate_service.ExchangeRateService`).
+
+    Groups closed lots by symbol; per-lot FX is taken on the lot's close_date.
+    Lots whose FX lookup fails contribute 0 to `realized_base` and are flagged
+    via a `fx_missing` boolean on the lot dict.
+    """
+    fifo = compute_fifo(trades)
+
+    by_symbol: dict[str, list[ClosedLot]] = {}
+    for lot in fifo.realized:
+        by_symbol.setdefault(lot.symbol, []).append(lot)
+
+    out: list[dict] = []
+    for symbol, lots in by_symbol.items():
+        symbol_currency = lots[0].currency
+        realized_native_total = Decimal("0")
+        realized_base_total = Decimal("0")
+        lot_dicts = []
+        for lot in lots:
+            rate = fx_service.get_exchange_rate(lot.currency, base_currency, lot.close_date)
+            if rate is None:
+                pnl_base = Decimal("0")
+                fx_missing = True
+            else:
+                pnl_base = (lot.pnl_native * rate).quantize(Decimal("0.01"))
+                fx_missing = False
+            realized_native_total += lot.pnl_native
+            realized_base_total += pnl_base
+            lot_dicts.append({
+                "open_date": lot.open_date.isoformat(),
+                "close_date": lot.close_date.isoformat(),
+                "quantity": lot.quantity,
+                "cost_native": lot.cost_native,
+                "proceeds_native": lot.proceeds_native,
+                "pnl_native": lot.pnl_native,
+                "pnl_base": pnl_base,
+                "fx_missing": fx_missing,
+            })
+        out.append({
+            "symbol": symbol,
+            "currency": symbol_currency,
+            "realized_native": realized_native_total,
+            "realized_base": realized_base_total,
+            "lots_closed": lot_dicts,
+        })
+    return out

--- a/backend/postgres_migration/add_broker_trades_fees.py
+++ b/backend/postgres_migration/add_broker_trades_fees.py
@@ -1,0 +1,38 @@
+"""
+One-off migration: add broker_trades.fees column.
+
+Usage (from backend/):
+    python postgres_migration/add_broker_trades_fees.py
+
+Idempotent: safe to re-run.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import create_engine, text
+
+from app.database import db_url
+
+
+SQL = """
+ALTER TABLE broker_trades
+  ADD COLUMN IF NOT EXISTS fees NUMERIC(28, 8) NOT NULL DEFAULT 0;
+"""
+
+
+def main() -> int:
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(text(SQL))
+    print("OK: broker_trades.fees present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_broker_trade_service.py
+++ b/backend/tests/test_broker_trade_service.py
@@ -54,3 +54,124 @@ def test_generate_external_id_differs_by_inputs():
     a = _generate_external_id(symbol="AAPL", **base_kwargs)
     b = _generate_external_id(symbol="MSFT", **base_kwargs)
     assert a != b
+
+
+from app.services.broker_trade_service import import_trades, ImportError as BrokerImportError
+from app.models import BrokerTrade, Holding
+
+
+@pytest.fixture
+def investment_account(db_session):
+    """Create a user + investment account; clean up after."""
+    from app.models import User, Account
+    import uuid
+
+    user = User(
+        id=f"test-user-{uuid.uuid4()}",
+        email=f"{uuid.uuid4()}@test.local",
+        functional_currency="EUR",
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    account = Account(
+        user_id=user.id,
+        name="Test Brokerage",
+        account_type="investment_brokerage",
+        currency="USD",
+        is_active=True,
+    )
+    db_session.add(account)
+    db_session.commit()
+
+    yield {"user_id": user.id, "account_id": str(account.id)}
+
+    # Teardown
+    db_session.query(BrokerTrade).filter(BrokerTrade.account_id == account.id).delete()
+    db_session.query(Holding).filter(Holding.account_id == account.id).delete()
+    db_session.delete(account)
+    db_session.delete(user)
+    db_session.commit()
+
+
+def test_import_trades_rejects_unknown_account(db_session):
+    with pytest.raises(BrokerImportError, match="account not found"):
+        import_trades(
+            db_session,
+            user_id="nobody",
+            account_id="00000000-0000-0000-0000-000000000000",
+            trades=[],
+            dry_run=False,
+        )
+
+
+def test_import_trades_rejects_account_not_owned(db_session, investment_account):
+    with pytest.raises(BrokerImportError, match="account not found"):
+        import_trades(
+            db_session,
+            user_id="someone-else",
+            account_id=investment_account["account_id"],
+            trades=[],
+            dry_run=False,
+        )
+
+
+def test_import_trades_rejects_non_investment_account(db_session):
+    from app.models import User, Account
+    import uuid
+
+    user = User(
+        id=f"test-user-{uuid.uuid4()}",
+        email=f"{uuid.uuid4()}@test.local",
+        functional_currency="EUR",
+    )
+    account = Account(
+        user_id=user.id,
+        name="Checking",
+        account_type="bank",
+        currency="EUR",
+        is_active=True,
+    )
+    db_session.add_all([user, account])
+    db_session.commit()
+
+    try:
+        with pytest.raises(BrokerImportError, match="not an investment account"):
+            import_trades(
+                db_session,
+                user_id=user.id,
+                account_id=str(account.id),
+                trades=[],
+                dry_run=False,
+            )
+    finally:
+        db_session.delete(account)
+        db_session.delete(user)
+        db_session.commit()
+
+
+def test_import_trades_validates_each_trade(db_session, investment_account):
+    bad_trades = [
+        # Missing side
+        {"symbol": "AAPL", "trade_date": "2024-01-10", "quantity": "10", "price": "150", "currency": "USD"},
+        # Negative quantity
+        {"symbol": "MSFT", "trade_date": "2024-01-10", "side": "buy", "quantity": "-1", "price": "100", "currency": "USD"},
+        # Bad currency length
+        {"symbol": "VWRA", "trade_date": "2024-01-10", "side": "buy", "quantity": "1", "price": "100", "currency": "USDD"},
+        # Bad side
+        {"symbol": "BTC", "trade_date": "2024-01-10", "side": "short", "quantity": "1", "price": "30000", "currency": "USD"},
+        # Bad date
+        {"symbol": "AAPL", "trade_date": "not-a-date", "side": "buy", "quantity": "1", "price": "100", "currency": "USD"},
+    ]
+    result = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=bad_trades,
+        dry_run=False,
+    )
+    assert result["inserted"] == 0
+    assert result["skipped_duplicate"] == 0
+    assert len(result["errors"]) == 5
+    # Each error references its index
+    assert {e["index"] for e in result["errors"]} == {0, 1, 2, 3, 4}

--- a/backend/tests/test_broker_trade_service.py
+++ b/backend/tests/test_broker_trade_service.py
@@ -289,3 +289,34 @@ def test_import_trades_caller_supplied_external_id_wins(db_session, investment_a
         .one()
     )
     assert row.external_id == "BROKER-CONFIRM-001"
+
+
+def test_import_trades_recomputes_holding_quantity_and_avg_cost(db_session, investment_account):
+    """After import, Holding.quantity = sum(buys) - sum(sells); avg_cost = weighted avg of open lots."""
+    payload = [
+        _trade("AAPL", "2024-01-10", "buy", "10", "100"),  # cost 1000
+        _trade("AAPL", "2024-02-10", "buy", "5", "120"),   # cost 600
+        _trade("AAPL", "2024-06-01", "sell", "8", "150"),  # consumes 8 from first lot
+    ]
+    result = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=False,
+    )
+    assert result["inserted"] == 3
+
+    holding = (
+        db_session.query(Holding)
+        .filter(
+            Holding.account_id == investment_account["account_id"],
+            Holding.symbol == "AAPL",
+        )
+        .one()
+    )
+    # Remaining: 2 from first lot @ 100 + 5 from second lot @ 120 = 7 shares
+    assert holding.quantity == Decimal("7")
+    # Weighted avg of remaining open lots: (2*100 + 5*120) / 7 = 800/7
+    assert holding.avg_cost == (Decimal("800") / Decimal("7")).quantize(Decimal("0.00000001"))
+    assert holding.source == "trade_import"

--- a/backend/tests/test_broker_trade_service.py
+++ b/backend/tests/test_broker_trade_service.py
@@ -320,3 +320,138 @@ def test_import_trades_recomputes_holding_quantity_and_avg_cost(db_session, inve
     # Weighted avg of remaining open lots: (2*100 + 5*120) / 7 = 800/7
     assert holding.avg_cost == (Decimal("800") / Decimal("7")).quantize(Decimal("0.00000001"))
     assert holding.source == "trade_import"
+
+
+def test_import_trades_cross_batch_same_key_assigns_distinct_ordinal(db_session, investment_account):
+    """A second batch with a genuine same-key trade must NOT collide with the first batch's #0."""
+    payload = [_trade("AAPL", "2024-01-10", "buy", "10", "150")]
+
+    # First batch: 1 trade → ordinal #0
+    r1 = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=False,
+    )
+    assert r1["inserted"] == 1
+
+    # Second batch: re-uploading the same statement (idempotent, dedup expected)
+    r2 = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=False,
+    )
+    assert r2["inserted"] == 0
+    assert r2["skipped_duplicate"] == 1
+
+    # Third batch: TWO identical-key trades; the first should dedup with #0,
+    # the second is genuinely new and must get ordinal beyond existing max.
+    r3 = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=[
+            _trade("AAPL", "2024-01-10", "buy", "10", "150"),
+            _trade("AAPL", "2024-01-10", "buy", "10", "150"),
+        ],
+        dry_run=False,
+    )
+    assert r3["inserted"] == 1
+    assert r3["skipped_duplicate"] == 1
+
+    rows = (
+        db_session.query(BrokerTrade)
+        .filter(BrokerTrade.account_id == investment_account["account_id"])
+        .all()
+    )
+    assert len(rows) == 2
+    ordinals = sorted(int(r.external_id.rsplit("#", 1)[1]) for r in rows)
+    assert ordinals == [0, 1]
+
+
+def test_import_trades_dry_run_surfaces_oversell_during_recompute(db_session, investment_account):
+    """dry_run must run holding recompute (which calls FIFO) so oversell errors propagate."""
+    from app.services.pnl_service import OverSellError
+
+    # First, import a buy of 10 shares (committed).
+    import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=[_trade("AAPL", "2024-01-10", "buy", "10", "100")],
+        dry_run=False,
+    )
+
+    # Now dry_run a sell of 999 — recompute should raise OverSellError.
+    with pytest.raises(OverSellError):
+        import_trades(
+            db_session,
+            user_id=investment_account["user_id"],
+            account_id=investment_account["account_id"],
+            trades=[_trade("AAPL", "2024-06-01", "sell", "999", "200")],
+            dry_run=True,
+        )
+
+    # And the dry_run rolled back: no new trades persisted, holding unchanged.
+    db_session.rollback()
+    trades = (
+        db_session.query(BrokerTrade)
+        .filter(BrokerTrade.account_id == investment_account["account_id"])
+        .all()
+    )
+    assert len(trades) == 1
+    assert trades[0].side == "buy"
+
+
+def test_import_trades_holding_lookup_filters_by_instrument_type(db_session, investment_account):
+    """A pre-existing non-equity holding with the same symbol must not be overwritten."""
+    # Pre-create a 'crypto' holding with AAPL symbol (contrived but plausible — different asset class).
+    crypto_holding = Holding(
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        symbol="AAPL",
+        instrument_type="crypto",
+        currency="USD",
+        quantity=Decimal("99"),
+        avg_cost=Decimal("0.5"),
+        as_of_date=date.fromisoformat("2024-01-01"),
+        source="manual",
+    )
+    db_session.add(crypto_holding)
+    db_session.commit()
+
+    import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=[_trade("AAPL", "2024-01-10", "buy", "10", "100")],
+        dry_run=False,
+    )
+
+    # The crypto holding should be untouched.
+    crypto_after = (
+        db_session.query(Holding)
+        .filter(
+            Holding.account_id == investment_account["account_id"],
+            Holding.symbol == "AAPL",
+            Holding.instrument_type == "crypto",
+        )
+        .one()
+    )
+    assert crypto_after.quantity == Decimal("99")
+    assert crypto_after.source == "manual"
+
+    # And a separate equity holding was created.
+    equity = (
+        db_session.query(Holding)
+        .filter(
+            Holding.account_id == investment_account["account_id"],
+            Holding.symbol == "AAPL",
+            Holding.instrument_type == "equity",
+        )
+        .one()
+    )
+    assert equity.quantity == Decimal("10")

--- a/backend/tests/test_broker_trade_service.py
+++ b/backend/tests/test_broker_trade_service.py
@@ -1,0 +1,56 @@
+"""Tests for the broker trade import service."""
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.services.broker_trade_service import _generate_external_id
+
+
+def test_generate_external_id_is_deterministic():
+    a = _generate_external_id(
+        trade_date=date.fromisoformat("2024-01-10"),
+        symbol="AAPL",
+        side="buy",
+        quantity=Decimal("10"),
+        price=Decimal("150.00"),
+        ordinal=0,
+    )
+    b = _generate_external_id(
+        trade_date=date.fromisoformat("2024-01-10"),
+        symbol="AAPL",
+        side="buy",
+        quantity=Decimal("10"),
+        price=Decimal("150.00"),
+        ordinal=0,
+    )
+    assert a == b
+    assert a.endswith("#0")
+
+
+def test_generate_external_id_differs_by_ordinal():
+    base_kwargs = dict(
+        trade_date=date.fromisoformat("2024-01-10"),
+        symbol="AAPL",
+        side="buy",
+        quantity=Decimal("10"),
+        price=Decimal("150.00"),
+    )
+    a = _generate_external_id(**base_kwargs, ordinal=0)
+    b = _generate_external_id(**base_kwargs, ordinal=1)
+    assert a != b
+    assert a.endswith("#0")
+    assert b.endswith("#1")
+
+
+def test_generate_external_id_differs_by_inputs():
+    base_kwargs = dict(
+        trade_date=date.fromisoformat("2024-01-10"),
+        side="buy",
+        quantity=Decimal("10"),
+        price=Decimal("150.00"),
+        ordinal=0,
+    )
+    a = _generate_external_id(symbol="AAPL", **base_kwargs)
+    b = _generate_external_id(symbol="MSFT", **base_kwargs)
+    assert a != b

--- a/backend/tests/test_broker_trade_service.py
+++ b/backend/tests/test_broker_trade_service.py
@@ -175,3 +175,117 @@ def test_import_trades_validates_each_trade(db_session, investment_account):
     assert len(result["errors"]) == 5
     # Each error references its index
     assert {e["index"] for e in result["errors"]} == {0, 1, 2, 3, 4}
+
+
+def _trade(symbol, d, side, qty, price, currency="USD", external_id=None):
+    t = {
+        "symbol": symbol,
+        "trade_date": d,
+        "side": side,
+        "quantity": qty,
+        "price": price,
+        "currency": currency,
+    }
+    if external_id is not None:
+        t["external_id"] = external_id
+    return t
+
+
+def test_import_trades_inserts_and_dedups(db_session, investment_account):
+    payload = [
+        _trade("AAPL", "2024-01-10", "buy", "10", "150"),
+        _trade("AAPL", "2024-06-01", "sell", "5", "200"),
+    ]
+
+    first = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=False,
+    )
+    assert first["inserted"] == 2
+    assert first["skipped_duplicate"] == 0
+    assert first["errors"] == []
+    assert set(first["affected_symbols"]) == {"AAPL"}
+
+    second = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=False,
+    )
+    assert second["inserted"] == 0
+    assert second["skipped_duplicate"] == 2
+
+    # Persisted rows
+    rows = (
+        db_session.query(BrokerTrade)
+        .filter(BrokerTrade.account_id == investment_account["account_id"])
+        .all()
+    )
+    assert len(rows) == 2
+
+
+def test_import_trades_assigns_distinct_external_ids_for_same_day_duplicates(
+    db_session, investment_account
+):
+    """Two genuine identical trades on the same day must both be stored."""
+    payload = [
+        _trade("AAPL", "2024-01-10", "buy", "10", "150"),
+        _trade("AAPL", "2024-01-10", "buy", "10", "150"),
+    ]
+    result = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=False,
+    )
+    assert result["inserted"] == 2
+    rows = (
+        db_session.query(BrokerTrade)
+        .filter(BrokerTrade.account_id == investment_account["account_id"])
+        .all()
+    )
+    assert {r.external_id for r in rows} != {None}
+    assert len({r.external_id for r in rows}) == 2
+
+
+def test_import_trades_dry_run_rolls_back(db_session, investment_account):
+    payload = [_trade("AAPL", "2024-01-10", "buy", "10", "150")]
+    result = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=True,
+    )
+    assert result["inserted"] == 1  # reported as if inserted
+    rows = (
+        db_session.query(BrokerTrade)
+        .filter(BrokerTrade.account_id == investment_account["account_id"])
+        .all()
+    )
+    assert rows == []  # but actually rolled back
+
+
+def test_import_trades_caller_supplied_external_id_wins(db_session, investment_account):
+    payload = [
+        _trade("AAPL", "2024-01-10", "buy", "10", "150", external_id="BROKER-CONFIRM-001"),
+    ]
+    result = import_trades(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=payload,
+        dry_run=False,
+    )
+    assert result["inserted"] == 1
+    row = (
+        db_session.query(BrokerTrade)
+        .filter(BrokerTrade.account_id == investment_account["account_id"])
+        .one()
+    )
+    assert row.external_id == "BROKER-CONFIRM-001"

--- a/backend/tests/test_mcp_broker_trade_import.py
+++ b/backend/tests/test_mcp_broker_trade_import.py
@@ -1,0 +1,93 @@
+"""MCP-layer tests for broker trade import + P&L tools."""
+from decimal import Decimal
+
+import pytest
+
+from app.models import Account, BrokerTrade, Holding, User
+from app.mcp.tools.investments import (
+    import_broker_trades_impl,
+    get_realized_pnl_impl,
+    get_unrealized_pnl_impl,
+)
+
+
+@pytest.fixture
+def investment_account(db_session):
+    import uuid
+    user = User(
+        id=f"test-user-{uuid.uuid4()}",
+        email=f"{uuid.uuid4()}@test.local",
+        functional_currency="EUR",
+    )
+    db_session.add(user)
+    db_session.flush()
+    account = Account(
+        user_id=user.id,
+        name="Test Brokerage",
+        account_type="investment_brokerage",
+        currency="USD",
+        is_active=True,
+    )
+    db_session.add(account)
+    db_session.commit()
+    yield {"user_id": user.id, "account_id": str(account.id)}
+
+    db_session.query(BrokerTrade).filter(BrokerTrade.account_id == account.id).delete()
+    db_session.query(Holding).filter(Holding.account_id == account.id).delete()
+    db_session.delete(account)
+    db_session.delete(user)
+    db_session.commit()
+
+
+def test_import_broker_trades_impl_inserts_trades(db_session, investment_account):
+    result = import_broker_trades_impl(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=[
+            {"symbol": "AAPL", "trade_date": "2024-01-10", "side": "buy", "quantity": "10", "price": "150", "currency": "USD"},
+        ],
+        dry_run=False,
+    )
+    assert result["inserted"] == 1
+    assert result["skipped_duplicate"] == 0
+    assert result["errors"] == []
+    assert result["affected_symbols"] == ["AAPL"]
+
+
+def test_get_realized_pnl_impl_returns_native_only_when_fx_missing(db_session, investment_account):
+    # Seed trades
+    import_broker_trades_impl(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=[
+            {"symbol": "AAPL", "trade_date": "2024-01-10", "side": "buy", "quantity": "10", "price": "150", "currency": "USD"},
+            {"symbol": "AAPL", "trade_date": "2024-06-01", "side": "sell", "quantity": "10", "price": "200", "currency": "USD"},
+        ],
+        dry_run=False,
+    )
+
+    result = get_realized_pnl_impl(db_session, user_id=investment_account["user_id"])
+
+    assert len(result) == 1
+    assert result[0]["symbol"] == "AAPL"
+    assert result[0]["realized_native"] == "500"
+
+
+def test_get_unrealized_pnl_impl_skips_symbols_without_latest_price(
+    db_session, investment_account
+):
+    import_broker_trades_impl(
+        db_session,
+        user_id=investment_account["user_id"],
+        account_id=investment_account["account_id"],
+        trades=[
+            {"symbol": "AAPL", "trade_date": "2024-01-10", "side": "buy", "quantity": "10", "price": "150", "currency": "USD"},
+        ],
+        dry_run=False,
+    )
+
+    # No HoldingValuation seeded → unrealized P&L list is empty for that symbol
+    result = get_unrealized_pnl_impl(db_session, user_id=investment_account["user_id"])
+    assert result == []

--- a/backend/tests/test_pnl_service.py
+++ b/backend/tests/test_pnl_service.py
@@ -121,3 +121,32 @@ def test_compute_fifo_multi_symbol_independent():
     assert len(result.realized) == 1
     assert result.realized[0].symbol == "AAPL"
     assert {l.symbol for l in result.open_lots} == {"MSFT"}
+
+
+from unittest.mock import MagicMock
+
+
+def test_realized_pnl_enriches_with_base_currency_fx():
+    """The DB-aware wrapper applies FX-on-close-date for base currency."""
+    from app.services.pnl_service import realized_pnl_from_trades
+
+    trades = [
+        _t("AAPL", "2024-01-10", "buy", 10, 150, currency="USD"),
+        _t("AAPL", "2024-06-01", "sell", 10, 200, currency="USD"),
+    ]
+
+    fx = MagicMock()
+    # 1 USD = 0.92 EUR on close date
+    fx.get_exchange_rate.return_value = Decimal("0.92")
+
+    result = realized_pnl_from_trades(trades, base_currency="EUR", fx_service=fx)
+
+    assert len(result) == 1
+    row = result[0]
+    assert row["symbol"] == "AAPL"
+    assert row["currency"] == "USD"
+    assert row["realized_native"] == Decimal("500")
+    assert row["realized_base"] == Decimal("460.00")
+    assert len(row["lots_closed"]) == 1
+    assert row["lots_closed"][0]["pnl_base"] == Decimal("460.00")
+    fx.get_exchange_rate.assert_called_with("USD", "EUR", date.fromisoformat("2024-06-01"))

--- a/backend/tests/test_pnl_service.py
+++ b/backend/tests/test_pnl_service.py
@@ -184,3 +184,28 @@ def test_unrealized_pnl_uses_latest_price_and_fx():
     assert row["unrealized_native"] == Decimal("600")
     # 600 USD * 0.90 = 540 EUR
     assert row["unrealized_base"] == Decimal("540.00")
+
+
+def test_compute_fifo_separates_lots_by_currency():
+    """Same symbol traded in two currencies must not cross-match in FIFO."""
+    trades = [
+        _t("BRK", "2024-01-10", "buy", 10, 100, currency="USD"),
+        _t("BRK", "2024-01-15", "buy", 10, 90, currency="EUR"),
+        # Sell 5 USD shares — must consume the USD lot, not the EUR one.
+        _t("BRK", "2024-06-01", "sell", 5, 120, currency="USD"),
+    ]
+
+    result = compute_fifo(trades)
+
+    assert len(result.realized) == 1
+    closed = result.realized[0]
+    assert closed.currency == "USD"
+    assert closed.cost_native == Decimal("500")  # 5 * 100 USD, not 5 * 90 EUR
+    assert closed.proceeds_native == Decimal("600")
+    assert closed.pnl_native == Decimal("100")
+
+    # Two open lots remain: 5 USD shares and the full 10 EUR shares.
+    open_by_currency = {l.currency: l for l in result.open_lots}
+    assert set(open_by_currency.keys()) == {"USD", "EUR"}
+    assert open_by_currency["USD"].quantity_remaining == Decimal("5")
+    assert open_by_currency["EUR"].quantity_remaining == Decimal("10")

--- a/backend/tests/test_pnl_service.py
+++ b/backend/tests/test_pnl_service.py
@@ -1,0 +1,39 @@
+"""Unit tests for the pure FIFO P&L engine."""
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.services.pnl_service import compute_fifo, OverSellError, Trade
+
+
+def _t(symbol, d, side, qty, price, currency="USD", fees="0"):
+    return Trade(
+        symbol=symbol,
+        trade_date=date.fromisoformat(d),
+        side=side,
+        quantity=Decimal(str(qty)),
+        price=Decimal(str(price)),
+        currency=currency,
+        fees=Decimal(str(fees)),
+    )
+
+
+def test_compute_fifo_single_buy_full_sell_with_fees():
+    """Buy fees increase cost basis; sell fees reduce proceeds."""
+    trades = [
+        _t("AAPL", "2024-01-10", "buy", 10, 150, fees="5"),    # cost = 1500 + 5 = 1505
+        _t("AAPL", "2024-06-01", "sell", 10, 200, fees="3"),   # proceeds = 2000 - 3 = 1997
+    ]
+
+    result = compute_fifo(trades)
+
+    assert len(result.realized) == 1
+    closed = result.realized[0]
+    assert closed.symbol == "AAPL"
+    assert closed.quantity == Decimal("10")
+    assert closed.cost_native == Decimal("1505")
+    assert closed.proceeds_native == Decimal("1997")
+    assert closed.pnl_native == Decimal("492")
+    assert closed.currency == "USD"
+    assert result.open_lots == []

--- a/backend/tests/test_pnl_service.py
+++ b/backend/tests/test_pnl_service.py
@@ -150,3 +150,37 @@ def test_realized_pnl_enriches_with_base_currency_fx():
     assert len(row["lots_closed"]) == 1
     assert row["lots_closed"][0]["pnl_base"] == Decimal("460.00")
     fx.get_exchange_rate.assert_called_with("USD", "EUR", date.fromisoformat("2024-06-01"))
+
+
+def test_unrealized_pnl_uses_latest_price_and_fx():
+    """Unrealized P&L = (market_value - cost_basis), in native and base currency."""
+    from app.services.pnl_service import unrealized_pnl_from_trades
+
+    trades = [
+        _t("AAPL", "2024-01-10", "buy", 10, 150, currency="USD"),
+        _t("AAPL", "2024-02-10", "buy", 5, 180, currency="USD"),
+    ]
+
+    # Latest price: 200 USD/share. 15 shares total. Cost basis = 1500 + 900 = 2400.
+    latest_prices = {"AAPL": Decimal("200")}
+
+    fx = MagicMock()
+    fx.get_exchange_rate.return_value = Decimal("0.90")  # USD -> EUR
+
+    result = unrealized_pnl_from_trades(
+        trades,
+        base_currency="EUR",
+        fx_service=fx,
+        latest_prices=latest_prices,
+        as_of_date=date.fromisoformat("2024-12-31"),
+    )
+
+    assert len(result) == 1
+    row = result[0]
+    assert row["symbol"] == "AAPL"
+    assert row["quantity"] == Decimal("15")
+    assert row["cost_basis_native"] == Decimal("2400")
+    assert row["market_value_native"] == Decimal("3000")
+    assert row["unrealized_native"] == Decimal("600")
+    # 600 USD * 0.90 = 540 EUR
+    assert row["unrealized_base"] == Decimal("540.00")

--- a/backend/tests/test_pnl_service.py
+++ b/backend/tests/test_pnl_service.py
@@ -37,3 +37,87 @@ def test_compute_fifo_single_buy_full_sell_with_fees():
     assert closed.pnl_native == Decimal("492")
     assert closed.currency == "USD"
     assert result.open_lots == []
+
+
+def test_compute_fifo_partial_sell_leaves_open_lot():
+    trades = [
+        _t("MSFT", "2024-01-10", "buy", 10, 100),
+        _t("MSFT", "2024-02-10", "buy", 5, 120),
+        _t("MSFT", "2024-06-01", "sell", 12, 150),
+    ]
+
+    result = compute_fifo(trades)
+
+    # Sell 12: consumes 10 from first lot + 2 from second lot
+    assert len(result.realized) == 2
+    assert result.realized[0].quantity == Decimal("10")
+    assert result.realized[0].cost_native == Decimal("1000")
+    assert result.realized[0].proceeds_native == Decimal("1500")
+    assert result.realized[0].pnl_native == Decimal("500")
+    assert result.realized[1].quantity == Decimal("2")
+    assert result.realized[1].cost_native == Decimal("240")
+    assert result.realized[1].proceeds_native == Decimal("300")
+    assert result.realized[1].pnl_native == Decimal("60")
+
+    assert len(result.open_lots) == 1
+    assert result.open_lots[0].symbol == "MSFT"
+    assert result.open_lots[0].quantity_remaining == Decimal("3")
+    assert result.open_lots[0].cost_per_share_native == Decimal("120")
+
+
+def test_compute_fifo_oversell_raises():
+    trades = [
+        _t("VWRA", "2024-01-10", "buy", 5, 100),
+        _t("VWRA", "2024-06-01", "sell", 10, 110),
+    ]
+
+    with pytest.raises(OverSellError) as exc:
+        compute_fifo(trades)
+
+    assert exc.value.symbol == "VWRA"
+    assert exc.value.qty_attempted == Decimal("10")
+    assert exc.value.qty_available == Decimal("5")
+
+
+def test_compute_fifo_buy_fees_carry_into_open_lot_cost():
+    """A buy with fees but no sell yet: open lot's cost_per_share reflects fees."""
+    trades = [_t("AAPL", "2024-01-10", "buy", 10, 100, fees="20")]
+
+    result = compute_fifo(trades)
+
+    assert result.realized == []
+    assert len(result.open_lots) == 1
+    # (100*10 + 20) / 10 = 102
+    assert result.open_lots[0].cost_per_share_native == Decimal("102")
+
+
+def test_compute_fifo_sell_fees_prorated_across_lots():
+    """When a sell consumes multiple lots, the sell's fee is prorated by quantity."""
+    trades = [
+        _t("MSFT", "2024-01-10", "buy", 10, 100),    # cost basis 100/share, 0 fees
+        _t("MSFT", "2024-02-10", "buy", 10, 100),    # cost basis 100/share, 0 fees
+        _t("MSFT", "2024-06-01", "sell", 20, 150, fees="10"),  # prorate 10 across 20 shares
+    ]
+
+    result = compute_fifo(trades)
+
+    assert len(result.realized) == 2
+    # Each closed lot of 10 shares gets 5 fee → proceeds = 1500 - 5 = 1495 per lot
+    for lot in result.realized:
+        assert lot.proceeds_native == Decimal("1495")
+        assert lot.cost_native == Decimal("1000")
+        assert lot.pnl_native == Decimal("495")
+
+
+def test_compute_fifo_multi_symbol_independent():
+    trades = [
+        _t("AAPL", "2024-01-10", "buy", 10, 150),
+        _t("MSFT", "2024-01-15", "buy", 5, 100),
+        _t("AAPL", "2024-06-01", "sell", 10, 200),
+    ]
+
+    result = compute_fifo(trades)
+
+    assert len(result.realized) == 1
+    assert result.realized[0].symbol == "AAPL"
+    assert {l.symbol for l in result.open_lots} == {"MSFT"}


### PR DESCRIPTION
## Description

Adds three new MCP tools so the LLM can ingest broker statements (CSV/PDF/XLSX, any broker) into a typed pipeline and surface FIFO P&L:

- **`import_broker_trades(account_id, trades, dry_run)`** — typed bulk import with stable `external_id` dedup (re-uploading the same statement is a no-op), `dry_run` preview, and automatic recompute of `Holding.quantity` + `Holding.avg_cost` from full FIFO history.
- **`get_realized_pnl(...)`** — FIFO realized P&L per symbol, native + base currency (FX on each lot's close date).
- **`get_unrealized_pnl(...)`** — open-lot cost basis vs latest `HoldingValuation`, native + base currency.

The LLM handles per-broker, per-format parsing on its side; the backend stays format-agnostic.

### Architecture

- `backend/app/services/pnl_service.py` — pure FIFO engine (`compute_fifo`) plus DB/FX-aware wrappers (`realized_pnl_from_trades`, `unrealized_pnl_from_trades`). The engine is pure-function and unit-testable without a DB.
- `backend/app/services/broker_trade_service.py` — orchestrates ownership check, validation, deterministic `external_id` hashing, bulk insert with `ON CONFLICT DO NOTHING`, and post-insert holding recompute. Supports `dry_run` with rollback.
- `backend/app/mcp/tools/investments.py` — adds `_impl` functions and thin wrappers matching the existing pattern.
- `backend/app/mcp/server.py` — registers the three new `@mcp.tool` endpoints and updates the server `instructions` docstring.

### Fee semantics

`broker_trades.fees` is added (idempotent migration `add_broker_trades_fees.py`, `NUMERIC(28,8) NOT NULL DEFAULT 0`). On buys, fees increase cost basis (`cost_per_share = (price*qty + fees) / qty`). On sells, fees reduce proceeds, prorated by quantity across consumed lots. This matches how brokers compute cost basis.

### Dedup

`external_id` is either caller-supplied (broker confirmation number) or generated as `sha256(date|symbol|side|qty|price)[:16] + "#N"` where `N` is a per-batch ordinal — so re-uploads are idempotent and same-day duplicate trades are preserved.

## Type of Change

- [x] New feature

## Test plan

- [x] 8 unit tests for `pnl_service` covering: simple buy/full-sell with fees, partial sells, oversell error, multi-symbol independence, buy-fee → open-lot cost-per-share, sell-fee proration, FX enrichment for realized + unrealized P&L
- [x] 12 integration tests for `broker_trade_service` covering: deterministic external_id, ownership check, account-type check, per-trade validation errors, insert + dedup, distinct external_ids for same-day duplicates, dry_run rollback, caller-supplied external_id, holding recompute after import
- [x] 3 MCP-layer tests for `import_broker_trades_impl`, `get_realized_pnl_impl`, `get_unrealized_pnl_impl`
- [x] Full backend suite: 178 pass; 1 failure + 12 errors are all pre-existing in unrelated test files (JSONB-on-SQLite setup, demo seed, OAuth metadata)
- [x] `python -m py_compile` clean for all modified files

## Migration

Run once after pulling, against the same `DATABASE_URL` used by the API:

```
cd backend && python postgres_migration/add_broker_trades_fees.py
```

Idempotent (`ADD COLUMN IF NOT EXISTS`).

## Out of scope (deferred)

- Trade↔holding reconciliation (mismatch detection)
- Corporate actions (splits, dividends as cost-basis adjustments)
- Tax-lot methods other than FIFO
- UI for trade history (this is MCP-only in v1)

## Checklist

- [x] Self-reviewed
- [x] Tests added and passing
- [x] No sensitive data or secrets
- [ ] Documentation update — N/A (MCP tool docstrings only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP tools to import broker trades and compute FIFO realized and unrealized P&L in native and base currency. Also fixes currency-separated FIFO, cross-batch `external_id` ordinals, dry-run recompute to surface oversells, equity-only holding updates, and deterministic ordering.

- New Features
  - `import_broker_trades(account_id, trades, dry_run)` — bulk import with stable `external_id` dedup; ordinals are cross-batch aware so genuine same-key trades don’t collide. Recomputes `Holding.quantity` and `Holding.avg_cost` from full FIFO history (equity-only). Buy fees increase cost basis; sell fees reduce proceeds. `dry_run` runs recompute to catch errors, then rolls back.
  - `get_realized_pnl(...)` — FIFO realized P&L per symbol, keyed by (symbol, currency). Returns native totals plus base-currency totals using FX on each lot’s close date.
  - `get_unrealized_pnl(...)` — FIFO open-lot cost basis vs latest `HoldingValuation`, keyed by (symbol, currency). Returns native and base; skips symbols without a price and flags missing FX. Deterministic ordering via `BrokerTrade.id`.

- Migration
  - Add `broker_trades.fees` (default 0). Run: cd backend && python postgres_migration/add_broker_trades_fees.py (idempotent).

<sup>Written for commit 0769b461b70f74e813f3f2e96d0bfb3d6d36dc07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

