### PR TITLE
fix(holdings): yfinance FX backfill + today fallback for cost basis

### DIFF
--- a/backend/app/routes/investments.py
+++ b/backend/app/routes/investments.py
@@ -348,15 +348,18 @@ def list_holdings(
         if src == user_currency:
             return cost_native.quantize(Decimal("0.01"))
         for_date = on or date.today()
-        converted = fx_svc.convert_amount(
-            amount=cost_native,
-            from_currency=src,
-            to_currency=user_currency,
+        # Use the fallback resolver: DB → yfinance backfill at as_of date →
+        # today's FX. Avoids `cost_basis_user_currency = null` (which
+        # makes the dashboard render P&L as "—") for older as_of dates
+        # that don't have FX history yet.
+        rate = fx_svc.get_exchange_rate_with_fallback(
+            base_currency=src,
+            target_currency=user_currency,
             for_date=for_date,
         )
-        if converted is None:
+        if rate is None:
             return None
-        return Decimal(converted).quantize(Decimal("0.01"))
+        return (cost_native * Decimal(rate)).quantize(Decimal("0.01"))
 
     query = db.query(Holding).filter(Holding.user_id == user_id)
     if account_id is not None:

--- a/backend/app/services/exchange_rate_service.py
+++ b/backend/app/services/exchange_rate_service.py
@@ -574,3 +574,88 @@ class ExchangeRateService:
             return None
 
         return amount * rate
+
+    def get_exchange_rate_with_fallback(
+        self,
+        base_currency: str,
+        target_currency: str,
+        for_date: date,
+    ) -> Optional[Decimal]:
+        """
+        Resolve an FX rate with progressive fallbacks:
+
+        1. Try the DB lookup at `for_date` (with the existing 7-day backward window).
+        2. If still missing, fetch a small window from Yahoo Finance around
+           `for_date`, store any rates we got, then re-check the DB.
+        3. If still missing, fall back to today's rate (DB or yfinance).
+
+        Returns the rate, or None only if every fallback failed.
+        """
+        if base_currency == target_currency:
+            return Decimal("1.0")
+
+        # 1. Existing DB-with-window lookup.
+        rate = self.get_exchange_rate(base_currency, target_currency, for_date)
+        if rate is not None:
+            return rate
+
+        # 2. On-demand backfill from yfinance for `for_date` ± a few days.
+        try:
+            window_start = for_date - timedelta(days=5)
+            window_end = for_date + timedelta(days=1)
+            fetched = self.fetch_exchange_rates_batch(
+                base_currency=base_currency,
+                target_currencies=[target_currency],
+                start_date=window_start,
+                end_date=window_end,
+            )
+            stored_any = False
+            for rate_date, by_target in fetched.items():
+                rate_value = by_target.get(target_currency)
+                if rate_value is None:
+                    continue
+                self.store_exchange_rates(
+                    target_currency=target_currency,
+                    rates={base_currency: rate_value},
+                    for_date=rate_date,
+                )
+                stored_any = True
+            if stored_any:
+                rate = self.get_exchange_rate(base_currency, target_currency, for_date)
+                if rate is not None:
+                    return rate
+        except Exception as e:
+            logger.warning(
+                f"yfinance fallback failed for {base_currency}/{target_currency} "
+                f"on {for_date}: {e}"
+            )
+
+        # 3. Final fallback: today's rate (DB hit first, then yfinance current).
+        today = date.today()
+        if today != for_date:
+            rate = self.get_exchange_rate(base_currency, target_currency, today)
+            if rate is not None:
+                logger.info(
+                    f"Using today's FX as fallback for {base_currency}/{target_currency} "
+                    f"originally requested for {for_date}"
+                )
+                return rate
+            try:
+                current = self.fetch_current_exchange_rates(
+                    base_currency=base_currency,
+                    target_currencies=[target_currency],
+                )
+                rate_value = current.get(target_currency)
+                if rate_value is not None:
+                    self.store_exchange_rates(
+                        target_currency=target_currency,
+                        rates={base_currency: rate_value},
+                        for_date=today,
+                    )
+                    return rate_value
+            except Exception as e:
+                logger.warning(
+                    f"Today-FX fallback failed for {base_currency}/{target_currency}: {e}"
+                )
+
+        return None

--- a/backend/app/services/exchange_rate_service.py
+++ b/backend/app/services/exchange_rate_service.py
@@ -621,9 +621,22 @@ class ExchangeRateService:
                 )
                 stored_any = True
             if stored_any:
+                # Re-check at the exact date (uses the existing 7d backward window).
                 rate = self.get_exchange_rate(base_currency, target_currency, for_date)
                 if rate is not None:
                     return rate
+                # Also try forward dates: if the only rates returned by yfinance
+                # were for days after for_date (e.g. as_of is a Sunday and only
+                # Monday's rate came back), the backward window won't see them.
+                for days_forward in range(1, 6):
+                    candidate = for_date + timedelta(days=days_forward)
+                    rate = self.get_exchange_rate(base_currency, target_currency, candidate)
+                    if rate is not None:
+                        logger.info(
+                            f"Using forward FX fallback (+{days_forward}d) for "
+                            f"{base_currency}/{target_currency} originally requested for {for_date}"
+                        )
+                        return rate
         except Exception as e:
             logger.warning(
                 f"yfinance fallback failed for {base_currency}/{target_currency} "

--- a/backend/tests/test_exchange_rate_fallback.py
+++ b/backend/tests/test_exchange_rate_fallback.py
@@ -1,0 +1,93 @@
+"""Tests for ExchangeRateService.get_exchange_rate_with_fallback."""
+from datetime import date
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from app.models import ExchangeRate
+from app.services.exchange_rate_service import ExchangeRateService
+
+
+@pytest.fixture(autouse=True)
+def _isolate_fx_rates(db_session):
+    """ExchangeRate rows are committed in these tests; isolate per-test."""
+    db_session.query(ExchangeRate).delete()
+    db_session.commit()
+    yield
+    db_session.query(ExchangeRate).delete()
+    db_session.commit()
+
+
+@pytest.fixture
+def fx_svc(db_session):
+    return ExchangeRateService(db=db_session)
+
+
+def _put_rate(db_session, base, target, on, value):
+    from datetime import datetime
+    db_session.add(
+        ExchangeRate(
+            date=datetime.combine(on, datetime.min.time()),
+            base_currency=base,
+            target_currency=target,
+            rate=Decimal(str(value)),
+        )
+    )
+    db_session.commit()
+
+
+def test_fallback_returns_db_rate_when_present(fx_svc, db_session):
+    _put_rate(db_session, "USD", "EUR", date(2024, 1, 3), "0.91")
+    got = fx_svc.get_exchange_rate_with_fallback("USD", "EUR", date(2024, 1, 3))
+    assert got == Decimal("0.91")
+
+
+def test_fallback_uses_yfinance_when_db_missing_at_as_of_date(fx_svc, db_session):
+    """When the DB has no rate for the target date, we fetch from yfinance and store it."""
+    target = date(2024, 1, 3)
+
+    fake_fetch = {
+        target: {"EUR": Decimal("0.9123")},
+    }
+
+    with patch.object(fx_svc, "fetch_exchange_rates_batch", return_value=fake_fetch) as m:
+        got = fx_svc.get_exchange_rate_with_fallback("USD", "EUR", target)
+
+    assert got == Decimal("0.9123")
+    m.assert_called_once()
+    # And it was stored.
+    stored = (
+        db_session.query(ExchangeRate)
+        .filter(ExchangeRate.base_currency == "USD", ExchangeRate.target_currency == "EUR")
+        .all()
+    )
+    assert len(stored) == 1
+    assert stored[0].rate == Decimal("0.9123")
+
+
+def test_fallback_uses_today_when_db_and_yfinance_miss_target_date(fx_svc, db_session):
+    """If yfinance returns nothing for the target date, use today's rate."""
+    today = date.today()
+    target = date(2020, 6, 1)  # ancient date, no DB row, no yfinance result
+
+    _put_rate(db_session, "USD", "EUR", today, "0.88")
+
+    with patch.object(fx_svc, "fetch_exchange_rates_batch", return_value={}):
+        got = fx_svc.get_exchange_rate_with_fallback("USD", "EUR", target)
+
+    assert got == Decimal("0.88")
+
+
+def test_fallback_returns_none_when_everything_misses(fx_svc, db_session):
+    """If all paths fail (no DB, no yfinance, no current rate), return None."""
+    with patch.object(fx_svc, "fetch_exchange_rates_batch", return_value={}), \
+         patch.object(fx_svc, "fetch_current_exchange_rates", return_value={}):
+        got = fx_svc.get_exchange_rate_with_fallback("USD", "EUR", date(2020, 6, 1))
+
+    assert got is None
+
+
+def test_fallback_short_circuits_when_currencies_equal(fx_svc):
+    got = fx_svc.get_exchange_rate_with_fallback("USD", "USD", date(2024, 1, 3))
+    assert got == Decimal("1.0")

--- a/backend/tests/test_exchange_rate_fallback.py
+++ b/backend/tests/test_exchange_rate_fallback.py
@@ -91,3 +91,21 @@ def test_fallback_returns_none_when_everything_misses(fx_svc, db_session):
 def test_fallback_short_circuits_when_currencies_equal(fx_svc):
     got = fx_svc.get_exchange_rate_with_fallback("USD", "USD", date(2024, 1, 3))
     assert got == Decimal("1.0")
+
+
+def test_fallback_uses_forward_date_when_backfill_only_returns_after(fx_svc, db_session):
+    """If yfinance returns only post-`for_date` rates (e.g. for_date is Sunday
+    and only Monday is in the response), the 7-day backward window won't see
+    them — the resolver should walk forward up to 5 days and pick up the rate.
+    """
+    target = date(2024, 1, 7)  # Sunday — typically no rate returned
+    monday = date(2024, 1, 8)
+
+    fake_fetch = {
+        monday: {"EUR": Decimal("0.9201")},
+    }
+
+    with patch.object(fx_svc, "fetch_exchange_rates_batch", return_value=fake_fetch):
+        got = fx_svc.get_exchange_rate_with_fallback("USD", "EUR", target)
+
+    assert got == Decimal("0.9201")


### PR DESCRIPTION
## Summary

- The dashboard's P&L column renders \"—\" for holdings whose \`as_of_date\` predates the FX history in our DB (e.g. MSFT/NVDA imported via broker trades with as_of in early 2024 — there's no USD→EUR rate within the 7-day window the route currently uses).
- Adds \`ExchangeRateService.get_exchange_rate_with_fallback\`: DB → yfinance backfill at as_of (±5d) → today's FX. Each step logs when it kicks in.
- Wires \`/holdings\` route's \`_convert_cost_to_user\` to use it. \`cost_basis_user_currency\` becomes non-null whenever any FX path exists.

## Test plan

- [x] Unit tests for each fallback branch (5 new tests in \`test_exchange_rate_fallback.py\`)
- [x] All 32 tests in pnl/broker/mcp/fx files pass
- [ ] Manual: after deploy, hit refresh on Revolut Investments → MSFT/NVDA show P&L

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing P&L for holdings whose `as_of_date` predates our FX history by adding a reliable FX fallback. The `/holdings` route now resolves rates via DB → `yfinance` backfill (±5d, with forward-date check) → today’s rate, so `cost_basis_user_currency` is filled whenever any FX path exists.

- Bug Fixes
  - Added `ExchangeRateService.get_exchange_rate_with_fallback`: DB lookup → `yfinance` backfill around `for_date`, then walk forward up to +5d if only post-date rates exist → today’s rate; logs when fallbacks trigger.
  - Updated `/holdings` `_convert_cost_to_user` to use the fallback rate and compute cost in the user currency.
  - Added unit tests for each branch: DB hit, `yfinance` backfill, forward-date (Sunday→Monday), today fallback, total miss, and same-currency short-circuit.

<sup>Written for commit 79247a57f0582c3fe4baa5d2b30399a9d1759134. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

