### PR TITLE
fix(investments): true unrealized P&L total + sane stale flag window

### DIFF
--- a/backend/app/services/holding_valuation_service.py
+++ b/backend/app/services/holding_valuation_service.py
@@ -46,6 +46,12 @@ class HoldingValuationService:
         self.db.commit()
         return total_user
 
+    # Number of days between `on` and the latest snapshot beyond which we
+    # consider the price stale. 3 days covers normal weekend gaps (Friday
+    # close → Monday morning lookup) and most one-off holidays without
+    # producing constant false-positive stale flags.
+    STALE_AFTER_DAYS = 3
+
     def _price_for(self, h: Holding, on: date) -> tuple[Decimal, str, bool]:
         if h.instrument_type == "cash":
             return Decimal("1"), h.currency, False
@@ -53,7 +59,9 @@ class HoldingValuationService:
         snap = self.price_service.latest_snapshot(lookup_symbol, on)
         if snap is None:
             return Decimal("0"), h.currency, True
-        return Decimal(snap.close), snap.currency, snap.date != on
+        gap_days = (on - snap.date).days
+        is_stale = gap_days > self.STALE_AFTER_DAYS
+        return Decimal(snap.close), snap.currency, is_stale
 
     def _upsert_valuation(self, holding_id, on: date, qty: Decimal, price: Decimal,
                           value_user: Decimal, is_stale: bool) -> None:

--- a/backend/tests/test_holding_valuation_service.py
+++ b/backend/tests/test_holding_valuation_service.py
@@ -84,14 +84,34 @@ def test_cash_holding_skips_price_lookup(db):
     assert val.value_user_currency == Decimal("1380.00")
 
 
-def test_marks_stale_when_no_same_day_snapshot(db):
+def test_does_not_mark_stale_within_freshness_window(db):
+    """Snapshot from up to 3 days ago is fresh — covers weekend / 1-day holiday."""
     user = _make_user(db, currency="EUR")
     acc = _make_account(db, user.id, currency="EUR")
     h = Holding(id=uuid4(), user_id=user.id, account_id=acc.id, symbol="AAPL",
                 currency="USD", instrument_type="equity",
                 quantity=Decimal("10"), source="manual")
     db.add(h)
-    db.add(PriceSnapshot(symbol="AAPL", currency="USD", date=date(2026, 4, 17),
+    # Snapshot 3 days before `on` — on the boundary, still fresh.
+    db.add(PriceSnapshot(symbol="AAPL", currency="USD", date=date(2026, 4, 15),
+                         close=Decimal("230.00"), provider="yahoo"))
+    db.commit()
+    fx = MagicMock(); fx.convert.return_value = Decimal("2100.00")
+    HoldingValuationService(db=db, fx=fx).compute(account_id=acc.id, on=date(2026, 4, 18))
+    val = db.query(HoldingValuation).filter_by(holding_id=h.id, date=date(2026, 4, 18)).one()
+    assert val.is_stale is False
+
+
+def test_marks_stale_when_snapshot_older_than_window(db):
+    """Snapshot more than 3 days old is stale."""
+    user = _make_user(db, currency="EUR")
+    acc = _make_account(db, user.id, currency="EUR")
+    h = Holding(id=uuid4(), user_id=user.id, account_id=acc.id, symbol="AAPL",
+                currency="USD", instrument_type="equity",
+                quantity=Decimal("10"), source="manual")
+    db.add(h)
+    # Snapshot 4 days before `on` — outside the freshness window.
+    db.add(PriceSnapshot(symbol="AAPL", currency="USD", date=date(2026, 4, 14),
                          close=Decimal("230.00"), provider="yahoo"))
     db.commit()
     fx = MagicMock(); fx.convert.return_value = Decimal("2100.00")

--- a/frontend/components/investments/InvestmentsOverview.tsx
+++ b/frontend/components/investments/InvestmentsOverview.tsx
@@ -52,23 +52,28 @@ export function InvestmentsOverview({
   const totalValue = Number(portfolio.total_value);
 
   // Real cost basis & unrealized P&L from per-holding cost_basis_user_currency
-  // (server-side derived from FIFO avg_cost × FX). Falls back to the chart-
-  // range delta only when cost basis is unavailable for ALL active positions
-  // — using partial cost basis would understate it and overstate P&L.
+  // (server-side derived from FIFO avg_cost × FX).
   //
-  // "Active position" = one that contributes to total value. Fully-closed
-  // positions (qty=0, avg_cost=null, value=0) are expected to have null cost
-  // and contribute zero to both sides; we deliberately ignore them in the
-  // completeness check.
+  // "Active position" = one we still hold (quantity > 0). This INCLUDES
+  // holdings that are currently worth zero (e.g. delisted/worthless stock
+  // we haven't sold) — those are real unrealized losses and must be
+  // counted. EXCLUDES fully-sold positions (qty=0, avg_cost=null), whose
+  // P&L is already realized.
+  //
+  // Falls back to the chart-range delta only when cost basis is unavailable
+  // for some active position — using partial cost basis would understate
+  // it and overstate P&L. An empty portfolio (no holdings, no active
+  // positions) reports zero P&L, not the chart delta.
   let activePositions = 0;
   let activeWithCost = 0;
   let costBasisFromHoldings = 0;
   let valueFromHoldings = 0;
   for (const h of holdings) {
-    const v = Number(h.current_value_user_currency ?? 0);
-    if (!Number.isFinite(v) || v === 0) continue;
+    const qty = Number(h.quantity ?? 0);
+    if (!Number.isFinite(qty) || qty <= 0) continue;
     activePositions += 1;
-    valueFromHoldings += v;
+    const v = Number(h.current_value_user_currency ?? 0);
+    if (Number.isFinite(v)) valueFromHoldings += v;
     const c = h.cost_basis_user_currency;
     if (c != null) {
       const cn = Number(c);
@@ -78,9 +83,18 @@ export function InvestmentsOverview({
       }
     }
   }
-  const useHoldingsBased = activePositions > 0 && activeWithCost === activePositions;
-  const costBasis = useHoldingsBased ? costBasisFromHoldings : totalValue - absChange;
-  const unrealizedPnl = useHoldingsBased ? valueFromHoldings - costBasisFromHoldings : absChange;
+  const isEmptyPortfolio = activePositions === 0;
+  const hasCompleteCost = !isEmptyPortfolio && activeWithCost === activePositions;
+  const costBasis = isEmptyPortfolio
+    ? 0
+    : hasCompleteCost
+      ? costBasisFromHoldings
+      : totalValue - absChange;
+  const unrealizedPnl = isEmptyPortfolio
+    ? 0
+    : hasCompleteCost
+      ? valueFromHoldings - costBasisFromHoldings
+      : absChange;
   const accountNames = Object.fromEntries(
     portfolio.accounts.map((a) => [a.id, a.name]),
   );

--- a/frontend/components/investments/InvestmentsOverview.tsx
+++ b/frontend/components/investments/InvestmentsOverview.tsx
@@ -50,7 +50,26 @@ export function InvestmentsOverview({
   const absChange = last - first;
   const pctChange = first > 0 ? (absChange / first) * 100 : 0;
   const totalValue = Number(portfolio.total_value);
-  const costBasis = totalValue - absChange;
+
+  // Real cost basis & unrealized P&L from per-holding cost_basis_user_currency
+  // (server-side derived from FIFO avg_cost × FX). Falls back to the chart-
+  // range delta only if no holding has cost basis yet (e.g. fresh account
+  // with no FX data).
+  const costBasisFromHoldings = holdings.reduce<number | null>((acc, h) => {
+    const c = h.cost_basis_user_currency;
+    if (c == null) return acc;
+    const v = Number(c);
+    if (!Number.isFinite(v)) return acc;
+    return (acc ?? 0) + v;
+  }, null);
+  const valueFromHoldings = holdings.reduce<number>((acc, h) => {
+    const v = Number(h.current_value_user_currency ?? 0);
+    return Number.isFinite(v) ? acc + v : acc;
+  }, 0);
+  const costBasis =
+    costBasisFromHoldings != null ? costBasisFromHoldings : totalValue - absChange;
+  const unrealizedPnl =
+    costBasisFromHoldings != null ? valueFromHoldings - costBasisFromHoldings : absChange;
   const accountNames = Object.fromEntries(
     portfolio.accounts.map((a) => [a.id, a.name]),
   );
@@ -135,7 +154,7 @@ export function InvestmentsOverview({
           <PortfolioChart data={series} currencySymbol={sym} />
           <PortfolioStatsStrip
             costBasis={costBasis}
-            unrealizedPnl={absChange}
+            unrealizedPnl={unrealizedPnl}
             returnPct={pctChange}
             holdingsCount={holdings.length}
             accountsCount={portfolio.accounts.length}

--- a/frontend/components/investments/InvestmentsOverview.tsx
+++ b/frontend/components/investments/InvestmentsOverview.tsx
@@ -53,23 +53,34 @@ export function InvestmentsOverview({
 
   // Real cost basis & unrealized P&L from per-holding cost_basis_user_currency
   // (server-side derived from FIFO avg_cost × FX). Falls back to the chart-
-  // range delta only if no holding has cost basis yet (e.g. fresh account
-  // with no FX data).
-  const costBasisFromHoldings = holdings.reduce<number | null>((acc, h) => {
-    const c = h.cost_basis_user_currency;
-    if (c == null) return acc;
-    const v = Number(c);
-    if (!Number.isFinite(v)) return acc;
-    return (acc ?? 0) + v;
-  }, null);
-  const valueFromHoldings = holdings.reduce<number>((acc, h) => {
+  // range delta only when cost basis is unavailable for ALL active positions
+  // — using partial cost basis would understate it and overstate P&L.
+  //
+  // "Active position" = one that contributes to total value. Fully-closed
+  // positions (qty=0, avg_cost=null, value=0) are expected to have null cost
+  // and contribute zero to both sides; we deliberately ignore them in the
+  // completeness check.
+  let activePositions = 0;
+  let activeWithCost = 0;
+  let costBasisFromHoldings = 0;
+  let valueFromHoldings = 0;
+  for (const h of holdings) {
     const v = Number(h.current_value_user_currency ?? 0);
-    return Number.isFinite(v) ? acc + v : acc;
-  }, 0);
-  const costBasis =
-    costBasisFromHoldings != null ? costBasisFromHoldings : totalValue - absChange;
-  const unrealizedPnl =
-    costBasisFromHoldings != null ? valueFromHoldings - costBasisFromHoldings : absChange;
+    if (!Number.isFinite(v) || v === 0) continue;
+    activePositions += 1;
+    valueFromHoldings += v;
+    const c = h.cost_basis_user_currency;
+    if (c != null) {
+      const cn = Number(c);
+      if (Number.isFinite(cn)) {
+        costBasisFromHoldings += cn;
+        activeWithCost += 1;
+      }
+    }
+  }
+  const useHoldingsBased = activePositions > 0 && activeWithCost === activePositions;
+  const costBasis = useHoldingsBased ? costBasisFromHoldings : totalValue - absChange;
+  const unrealizedPnl = useHoldingsBased ? valueFromHoldings - costBasisFromHoldings : absChange;
   const accountNames = Object.fromEntries(
     portfolio.accounts.map((a) => [a.id, a.name]),
   );


### PR DESCRIPTION
## Summary

- **Total \"Unrealized P&L\" was using chart-range delta as P&L** — caused negative totals (e.g. -€254) when every individual position was in profit, because freshly-imported trades have no historical timeseries yet. Now derives true total from \`sum(holdings.cost_basis_user_currency)\` vs \`sum(current_value_user_currency)\`. Falls back to the old delta only when no holding has cost basis.
- **\"Stale\" flag was set on strict same-day equality** — every weekend / pre-market / provider-lag triggered \"stale\" on every holding. Now uses a 3-day freshness window: snapshots ≤3 days old are fresh.
- Updates one existing test, adds one new test for the freshness boundary.

## Test plan

- [x] Backend scoped suite (\`test_pnl_service\`, \`test_broker_trade_service\`, \`test_mcp_broker_trade_import\`, \`test_exchange_rate_fallback\`) — 33 passed
- [ ] Manual: after deploy → refresh prices on Revolut Investments → orange dots clear, total P&L matches sum of per-row P&Ls

## Note on portfolio-history backfill

User also requested historical timeseries backfill on trade import (so the chart shows portfolio value over time). That's larger scope and will be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect Unrealized P&L totals and reduces false “stale” price flags. P&L now uses true cost basis when complete, includes zero-value-but-held positions, shows 0 for empty portfolios, and prices are fresh if the latest snapshot is within 3 days.

- **Bug Fixes**
  - Unrealized P&L: In `InvestmentsOverview.tsx`, use per-holding `cost_basis_user_currency` vs `current_value_user_currency` only when all active positions (qty > 0) have cost; include worthless-but-held positions; exclude fully-closed positions; empty portfolios return 0; otherwise fall back to chart delta.
  - Stale flag: In `HoldingValuationService`, mark stale only if `(on - snapshot.date) > 3` days (`STALE_AFTER_DAYS = 3`); added boundary tests.

<sup>Written for commit 13cdf2a84da2d77b190f884f59dd8ef7d43002d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

