### PR TITLE
fix(migrations): add statement-breakpoint separators (hotfix for #109 deploy)

### DIFF
--- a/frontend/lib/db/migrations/0020_people_and_ownership.sql
+++ b/frontend/lib/db/migrations/0020_people_and_ownership.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS "people" (
   "created_at" timestamp DEFAULT now() NOT NULL,
   "updated_at" timestamp DEFAULT now() NOT NULL
 );
-
+--> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "account_owners" (
   "account_id" uuid NOT NULL REFERENCES "accounts"("id") ON DELETE CASCADE,
   "person_id" uuid NOT NULL REFERENCES "people"("id") ON DELETE CASCADE,
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS "account_owners" (
   "created_at" timestamp DEFAULT now() NOT NULL,
   CONSTRAINT "account_owners_pkey" PRIMARY KEY ("account_id", "person_id")
 );
-
+--> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "property_owners" (
   "property_id" uuid NOT NULL REFERENCES "properties"("id") ON DELETE CASCADE,
   "person_id" uuid NOT NULL REFERENCES "people"("id") ON DELETE CASCADE,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS "property_owners" (
   "created_at" timestamp DEFAULT now() NOT NULL,
   CONSTRAINT "property_owners_pkey" PRIMARY KEY ("property_id", "person_id")
 );
-
+--> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "vehicle_owners" (
   "vehicle_id" uuid NOT NULL REFERENCES "vehicles"("id") ON DELETE CASCADE,
   "person_id" uuid NOT NULL REFERENCES "people"("id") ON DELETE CASCADE,
@@ -34,9 +34,13 @@ CREATE TABLE IF NOT EXISTS "vehicle_owners" (
   "created_at" timestamp DEFAULT now() NOT NULL,
   CONSTRAINT "vehicle_owners_pkey" PRIMARY KEY ("vehicle_id", "person_id")
 );
-
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_people_user" ON "people" ("user_id");
+--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "people_user_self_uq" ON "people" ("user_id") WHERE "kind" = 'self';
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_account_owners_person" ON "account_owners" ("person_id");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_property_owners_person" ON "property_owners" ("person_id");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_vehicle_owners_person" ON "vehicle_owners" ("person_id");

--- a/frontend/lib/db/migrations/0020_people_backfill.manual.sql
+++ b/frontend/lib/db/migrations/0020_people_backfill.manual.sql
@@ -1,28 +1,55 @@
 -- Backfill: create one 'self' person per existing user, and 100%-share
 -- ownership rows for every existing account, property, and vehicle.
 -- Idempotent so it can be re-run safely (e.g. on baselined deploys).
+--
+-- Defensive: each block is wrapped in a "table must exist" guard so the
+-- backfill no-ops if the corresponding DDL migration hasn't run yet (avoids
+-- crashing the pre-deploy script during a partial / out-of-order migrate).
 
-INSERT INTO people (id, user_id, name, kind, created_at, updated_at)
-SELECT gen_random_uuid(), u.id, COALESCE(NULLIF(u.name, ''), 'You'), 'self', NOW(), NOW()
-FROM users u
-WHERE NOT EXISTS (
-  SELECT 1 FROM people p WHERE p.user_id = u.id AND p.kind = 'self'
-);
+DO $$
+BEGIN
+  IF to_regclass('public.people') IS NOT NULL THEN
+    INSERT INTO people (id, user_id, name, kind, created_at, updated_at)
+    SELECT gen_random_uuid(), u.id, COALESCE(NULLIF(u.name, ''), 'You'), 'self', NOW(), NOW()
+    FROM users u
+    WHERE NOT EXISTS (
+      SELECT 1 FROM people p WHERE p.user_id = u.id AND p.kind = 'self'
+    );
+  END IF;
+END $$;
 
-INSERT INTO account_owners (account_id, person_id, share, created_at)
-SELECT a.id, p.id, NULL, NOW()
-FROM accounts a
-JOIN people p ON p.user_id = a.user_id AND p.kind = 'self'
-ON CONFLICT (account_id, person_id) DO NOTHING;
+DO $$
+BEGIN
+  IF to_regclass('public.account_owners') IS NOT NULL
+     AND to_regclass('public.people') IS NOT NULL THEN
+    INSERT INTO account_owners (account_id, person_id, share, created_at)
+    SELECT a.id, p.id, NULL, NOW()
+    FROM accounts a
+    JOIN people p ON p.user_id = a.user_id AND p.kind = 'self'
+    ON CONFLICT (account_id, person_id) DO NOTHING;
+  END IF;
+END $$;
 
-INSERT INTO property_owners (property_id, person_id, share, created_at)
-SELECT pr.id, p.id, NULL, NOW()
-FROM properties pr
-JOIN people p ON p.user_id = pr.user_id AND p.kind = 'self'
-ON CONFLICT (property_id, person_id) DO NOTHING;
+DO $$
+BEGIN
+  IF to_regclass('public.property_owners') IS NOT NULL
+     AND to_regclass('public.people') IS NOT NULL THEN
+    INSERT INTO property_owners (property_id, person_id, share, created_at)
+    SELECT pr.id, p.id, NULL, NOW()
+    FROM properties pr
+    JOIN people p ON p.user_id = pr.user_id AND p.kind = 'self'
+    ON CONFLICT (property_id, person_id) DO NOTHING;
+  END IF;
+END $$;
 
-INSERT INTO vehicle_owners (vehicle_id, person_id, share, created_at)
-SELECT v.id, p.id, NULL, NOW()
-FROM vehicles v
-JOIN people p ON p.user_id = v.user_id AND p.kind = 'self'
-ON CONFLICT (vehicle_id, person_id) DO NOTHING;
+DO $$
+BEGIN
+  IF to_regclass('public.vehicle_owners') IS NOT NULL
+     AND to_regclass('public.people') IS NOT NULL THEN
+    INSERT INTO vehicle_owners (vehicle_id, person_id, share, created_at)
+    SELECT v.id, p.id, NULL, NOW()
+    FROM vehicles v
+    JOIN people p ON p.user_id = v.user_id AND p.kind = 'self'
+    ON CONFLICT (vehicle_id, person_id) DO NOTHING;
+  END IF;
+END $$;

--- a/frontend/lib/db/migrations/0021_routines.sql
+++ b/frontend/lib/db/migrations/0021_routines.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS "routines" (
   "created_at" timestamp DEFAULT now() NOT NULL,
   "updated_at" timestamp DEFAULT now() NOT NULL
 );
-
+--> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "routine_runs" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
   "routine_id" uuid NOT NULL REFERENCES "routines"("id") ON DELETE CASCADE,
@@ -34,8 +34,11 @@ CREATE TABLE IF NOT EXISTS "routine_runs" (
   "completed_at" timestamp,
   "created_at" timestamp DEFAULT now() NOT NULL
 );
-
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_routines_user" ON "routines" ("user_id");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_routines_due" ON "routines" ("enabled", "next_run_at");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_routine_runs_routine" ON "routine_runs" ("routine_id", "created_at");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_routine_runs_user" ON "routine_runs" ("user_id", "created_at");

--- a/frontend/lib/db/migrations/0022_investment_plans.sql
+++ b/frontend/lib/db/migrations/0022_investment_plans.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS "investment_plans" (
   "created_at" timestamp DEFAULT now() NOT NULL,
   "updated_at" timestamp DEFAULT now() NOT NULL
 );
-
+--> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "investment_plan_runs" (
   "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
   "plan_id" uuid NOT NULL REFERENCES "investment_plans"("id") ON DELETE CASCADE,
@@ -37,8 +37,11 @@ CREATE TABLE IF NOT EXISTS "investment_plan_runs" (
   "completed_at" timestamp,
   "created_at" timestamp DEFAULT now() NOT NULL
 );
-
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_investment_plans_user" ON "investment_plans" ("user_id");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_investment_plans_due" ON "investment_plans" ("enabled", "next_run_at");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_investment_plan_runs_plan" ON "investment_plan_runs" ("plan_id", "created_at");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_investment_plan_runs_user" ON "investment_plan_runs" ("user_id", "created_at");

--- a/frontend/lib/db/migrations/0023_share_check_constraint.manual.sql
+++ b/frontend/lib/db/migrations/0023_share_check_constraint.manual.sql
@@ -1,21 +1,40 @@
 -- Defense in depth: enforce that share is in (0, 1] or NULL at the DB layer.
 -- Application validation already enforces this; this catches manual SQL or
 -- buggy callers that bypass the service layer.
+--
+-- Defensive: skip silently when target tables aren't present yet (e.g. on a
+-- partial migrate where 0020 hasn't applied yet — the next pre-deploy will
+-- pick up where this left off).
 
-ALTER TABLE "account_owners"
-  DROP CONSTRAINT IF EXISTS "account_owners_share_range";
-ALTER TABLE "account_owners"
-  ADD CONSTRAINT "account_owners_share_range"
-  CHECK (share IS NULL OR (share > 0 AND share <= 1));
+DO $$
+BEGIN
+  IF to_regclass('public.account_owners') IS NOT NULL THEN
+    ALTER TABLE "account_owners"
+      DROP CONSTRAINT IF EXISTS "account_owners_share_range";
+    ALTER TABLE "account_owners"
+      ADD CONSTRAINT "account_owners_share_range"
+      CHECK (share IS NULL OR (share > 0 AND share <= 1));
+  END IF;
+END $$;
 
-ALTER TABLE "property_owners"
-  DROP CONSTRAINT IF EXISTS "property_owners_share_range";
-ALTER TABLE "property_owners"
-  ADD CONSTRAINT "property_owners_share_range"
-  CHECK (share IS NULL OR (share > 0 AND share <= 1));
+DO $$
+BEGIN
+  IF to_regclass('public.property_owners') IS NOT NULL THEN
+    ALTER TABLE "property_owners"
+      DROP CONSTRAINT IF EXISTS "property_owners_share_range";
+    ALTER TABLE "property_owners"
+      ADD CONSTRAINT "property_owners_share_range"
+      CHECK (share IS NULL OR (share > 0 AND share <= 1));
+  END IF;
+END $$;
 
-ALTER TABLE "vehicle_owners"
-  DROP CONSTRAINT IF EXISTS "vehicle_owners_share_range";
-ALTER TABLE "vehicle_owners"
-  ADD CONSTRAINT "vehicle_owners_share_range"
-  CHECK (share IS NULL OR (share > 0 AND share <= 1));
+DO $$
+BEGIN
+  IF to_regclass('public.vehicle_owners') IS NOT NULL THEN
+    ALTER TABLE "vehicle_owners"
+      DROP CONSTRAINT IF EXISTS "vehicle_owners_share_range";
+    ALTER TABLE "vehicle_owners"
+      ADD CONSTRAINT "vehicle_owners_share_range"
+      CHECK (share IS NULL OR (share > 0 AND share <= 1));
+  END IF;
+END $$;


### PR DESCRIPTION
## Description

Hotfix for the failed Railway deploy of PR #109. The pre-deploy migration script crashed with:

> migration 0020_people_backfill.manual.sql references a "people" table that does not exist in the database

## Root cause

Drizzle's migrator splits each `.sql` migration on `--> statement-breakpoint` and runs each chunk separately. **Our hand-authored migrations 0020/0021/0022 had zero breakpoints.** As a result, only the first CREATE TABLE in each file was executed (or none — depending on how postgres-js batches the chunk), Drizzle still recorded the migration's hash as "applied", and then the manual backfill ran and failed because the rest of the schema didn't exist.

For comparison, every existing working journaled migration (e.g. `0015_oauth_provider_tables.sql`) has `--> statement-breakpoint` between every statement.

## Fixes

1. **Add `--> statement-breakpoint` between every statement** in 0020/0021/0022 — the format every earlier journaled migration in this repo uses.
2. **Wrap each operation in the manual SQLs** (`0020_people_backfill.manual.sql`, `0023_share_check_constraint.manual.sql`) in `IF to_regclass('public.foo') IS NOT NULL` guards. Belt-and-braces: if any future deploy ever runs the manual step before its DDL is in place, it no-ops gracefully instead of crashing the entrypoint and blocking deploy entirely.

## Recovery on production

After this lands and the new image deploys:
- Drizzle sees new hashes for 0020/0021/0022 (file content changed) → re-runs them. `CREATE TABLE IF NOT EXISTS` makes that safe.
- This time each statement runs as its own chunk → all tables created.
- Manual SQLs run; tables now exist → backfill + CHECK constraint apply.

No data loss, no manual recovery needed beyond the redeploy.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Migrations are idempotent (`IF NOT EXISTS` / `IF to_regclass(...) IS NOT NULL`)
- [x] Format matches established convention in earlier migrations
- [x] No schema diff vs. PR #109 — same tables, columns, indexes, constraints
- [x] Defensive guards mean the script can survive a partial migrate without failing the deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed pre-deploy migrations by adding statement breakpoints and defensive guards so Drizzle runs all statements and manual steps no longer crash. Unblocks the deploy from PR #109 by ensuring tables exist before backfills and constraints.

- **Bug Fixes**
  - Added `--> statement-breakpoint` between all statements in `0020_people_and_ownership.sql`, `0021_routines.sql`, `0022_investment_plans.sql`.
  - Wrapped operations in `0020_people_backfill.manual.sql` and `0023_share_check_constraint.manual.sql` with `to_regclass(...) IS NOT NULL` guards to no-op if tables are missing.

- **Migration**
  - Changed file hashes trigger Drizzle to re-run `0020`–`0022`; `CREATE ... IF NOT EXISTS` keeps it safe.
  - Backfill and constraints run after tables exist. No manual recovery needed.

<sup>Written for commit 532c368f4c1b84ba5ebe75044a84eb754ef2260f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

