### PR TITLE
fix(migrations): bump when timestamps to force re-apply 20-22 (hotfix #2 for #109)

### DIFF
--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -1,153 +1,153 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1768685392212,
-      "tag": "0000_stormy_roxanne_simpson",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1769808592212,
-      "tag": "0001_fix_balance_adjustment_signs",
-      "breakpoints": true
-    },
-    {
-      "idx": 2,
-      "version": "7",
-      "when": 1770401897806,
-      "tag": "0002_better_auth_admin_fields",
-      "breakpoints": true
-    },
-    {
-      "idx": 3,
-      "version": "7",
-      "when": 1770408054187,
-      "tag": "0003_schema_alignment",
-      "breakpoints": true
-    },
-    {
-      "idx": 4,
-      "version": "7",
-      "when": 1771006303622,
-      "tag": "0004_remove_bank_connections",
-      "breakpoints": true
-    },
-    {
-      "idx": 5,
-      "version": "7",
-      "when": 1771761600000,
-      "tag": "0005_accounts_logo_id",
-      "breakpoints": true
-    },
-    {
-      "idx": 6,
-      "version": "7",
-      "when": 1771099200000,
-      "tag": "0006_subscription_account_scope",
-      "breakpoints": true
-    },
-    {
-      "idx": 7,
-      "version": "7",
-      "when": 1771766400000,
-      "tag": "0007_recurring_account_id_hotfix",
-      "breakpoints": true
-    },
-    {
-      "idx": 8,
-      "version": "7",
-      "when": 1771820400000,
-      "tag": "0008_subscription_suggestions_account_category",
-      "breakpoints": true
-    },
-    {
-      "idx": 9,
-      "version": "7",
-      "when": 1772308800000,
-      "tag": "0009_data_encryption_columns",
-      "breakpoints": true
-    },
-    {
-      "idx": 10,
-      "version": "7",
-      "when": 1772395200000,
-      "tag": "0010_transaction_deletion_flows",
-      "breakpoints": true
-    },
-    {
-      "idx": 11,
-      "version": "7",
-      "when": 1744502400000,
-      "tag": "0011_enable_banking_connections",
-      "breakpoints": true
-    },
-    {
-      "idx": 12,
-      "version": "7",
-      "when": 1744588800000,
-      "tag": "0012_bank_connection_initial_sync_days",
-      "breakpoints": true
-    },
-    {
-      "idx": 13,
-      "version": "7",
-      "when": 1776470400000,
-      "tag": "0013_transaction_creditor_debtor",
-      "breakpoints": true
-    },
-    {
-      "idx": 14,
-      "version": "7",
-      "when": 1745020800000,
-      "tag": "0014_bank_connection_sync_started_at",
-      "breakpoints": true
-    },
-    {
-      "idx": 15,
-      "version": "7",
-      "when": 1776556800000,
-      "tag": "0015_oauth_provider_tables",
-      "breakpoints": true
-    },
-    {
-      "idx": 16,
-      "version": "7",
-      "when": 1776643200000,
-      "tag": "0016_jwks_table",
-      "breakpoints": true
-    },
-    {
-      "idx": 17,
-      "version": "7",
-      "when": 1776729600000,
-      "tag": "0017_verification_value_rename",
-      "breakpoints": true
-    },
-    {
-      "idx": 20,
-      "version": "7",
-      "when": 1746230400000,
-      "tag": "0020_people_and_ownership",
-      "breakpoints": true
-    },
-    {
-      "idx": 21,
-      "version": "7",
-      "when": 1777831390704,
-      "tag": "0021_routines",
-      "breakpoints": true
-    },
-    {
-      "idx": 22,
-      "version": "7",
-      "when": 1746316800000,
-      "tag": "0022_investment_plans",
-      "breakpoints": true
-    }
-  ]
+	"version": "7",
+	"dialect": "postgresql",
+	"entries": [
+		{
+			"idx": 0,
+			"version": "7",
+			"when": 1768685392212,
+			"tag": "0000_stormy_roxanne_simpson",
+			"breakpoints": true
+		},
+		{
+			"idx": 1,
+			"version": "7",
+			"when": 1769808592212,
+			"tag": "0001_fix_balance_adjustment_signs",
+			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "7",
+			"when": 1770401897806,
+			"tag": "0002_better_auth_admin_fields",
+			"breakpoints": true
+		},
+		{
+			"idx": 3,
+			"version": "7",
+			"when": 1770408054187,
+			"tag": "0003_schema_alignment",
+			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "7",
+			"when": 1771006303622,
+			"tag": "0004_remove_bank_connections",
+			"breakpoints": true
+		},
+		{
+			"idx": 5,
+			"version": "7",
+			"when": 1771761600000,
+			"tag": "0005_accounts_logo_id",
+			"breakpoints": true
+		},
+		{
+			"idx": 6,
+			"version": "7",
+			"when": 1771099200000,
+			"tag": "0006_subscription_account_scope",
+			"breakpoints": true
+		},
+		{
+			"idx": 7,
+			"version": "7",
+			"when": 1771766400000,
+			"tag": "0007_recurring_account_id_hotfix",
+			"breakpoints": true
+		},
+		{
+			"idx": 8,
+			"version": "7",
+			"when": 1771820400000,
+			"tag": "0008_subscription_suggestions_account_category",
+			"breakpoints": true
+		},
+		{
+			"idx": 9,
+			"version": "7",
+			"when": 1772308800000,
+			"tag": "0009_data_encryption_columns",
+			"breakpoints": true
+		},
+		{
+			"idx": 10,
+			"version": "7",
+			"when": 1772395200000,
+			"tag": "0010_transaction_deletion_flows",
+			"breakpoints": true
+		},
+		{
+			"idx": 11,
+			"version": "7",
+			"when": 1744502400000,
+			"tag": "0011_enable_banking_connections",
+			"breakpoints": true
+		},
+		{
+			"idx": 12,
+			"version": "7",
+			"when": 1744588800000,
+			"tag": "0012_bank_connection_initial_sync_days",
+			"breakpoints": true
+		},
+		{
+			"idx": 13,
+			"version": "7",
+			"when": 1776470400000,
+			"tag": "0013_transaction_creditor_debtor",
+			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1745020800000,
+			"tag": "0014_bank_connection_sync_started_at",
+			"breakpoints": true
+		},
+		{
+			"idx": 15,
+			"version": "7",
+			"when": 1776556800000,
+			"tag": "0015_oauth_provider_tables",
+			"breakpoints": true
+		},
+		{
+			"idx": 16,
+			"version": "7",
+			"when": 1776643200000,
+			"tag": "0016_jwks_table",
+			"breakpoints": true
+		},
+		{
+			"idx": 17,
+			"version": "7",
+			"when": 1776729600000,
+			"tag": "0017_verification_value_rename",
+			"breakpoints": true
+		},
+		{
+			"idx": 20,
+			"version": "7",
+			"when": 1777879472826,
+			"tag": "0020_people_and_ownership",
+			"breakpoints": true
+		},
+		{
+			"idx": 21,
+			"version": "7",
+			"when": 1777879473826,
+			"tag": "0021_routines",
+			"breakpoints": true
+		},
+		{
+			"idx": 22,
+			"version": "7",
+			"when": 1777879474826,
+			"tag": "0022_investment_plans",
+			"breakpoints": true
+		}
+	]
 }


### PR DESCRIPTION
## Description

Second hotfix for the failed deploy of PR #109. After PR #110 fixed the SQL-statement-breakpoint issue and was deployed, the migrate script still completed without creating the `people`, `routines`, or `investment_plans` tables. App threw 500s with \`relation \"people\" does not exist\`.

## Root cause

Drizzle's migrator dedups migrations by the journal's `when` field (folderMillis), **not by the SQL hash**. The deduplication query roughly:

\`\`\`js
const last = await session.execute(\`SELECT created_at FROM drizzle.__drizzle_migrations ORDER BY created_at DESC\`);
for (const m of migrations) {
  if (last && Number(last.created_at) >= m.folderMillis) continue;  // skip
  await session.execute(sql.raw(m.sql));
  await session.execute(\`INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES ('\${m.hash}', \${m.folderMillis})\`);
}
\`\`\`

Production's `__drizzle_migrations` already has rows from the first broken deploy with `created_at` equal to the journal entries' `when` values. Even after #110 fixed the SQL, the migrator saw the timestamps as already-applied and skipped 20/21/22 silently — never creating the tables.

## Fix

Bump `when` on entries 20-22 in `_journal.json` to fresh timestamps newer than what's recorded in `__drizzle_migrations`. The migrator now sees them as new → applies them. `CREATE TABLE IF NOT EXISTS` makes the apply safe even if anything was partially created.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## After deploy

1. Migrate creates `people`, `routines`, `investment_plans`, all `*_owners`, etc.
2. Manual SQL `0020_people_backfill.manual.sql` runs (no longer no-ops because tables now exist) → backfills self-Person + 100% ownership for existing entities
3. Manual SQL `0023_share_check_constraint.manual.sql` runs → adds CHECK constraints
4. Settings → Household tab works, no more 500s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force re-apply of migrations 0020–0022 by bumping their journal `when` timestamps. Recovers the missing tables in production and stops 500s.

- **Bug Fixes**
  - Updated `frontend/lib/db/migrations/meta/_journal.json` with fresh `when` values so the Drizzle migrator applies 0020–0022.
  - On deploy, creates `people`, `routines`, `investment_plans` and related owner tables; safe via `CREATE TABLE IF NOT EXISTS`.

<sup>Written for commit ef4ddcca4b47539ebb1433629386cc65277ebc80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

