### PR TITLE
fix(agent): retry on Anthropic 429 rate-limit errors

### DIFF
--- a/backend/app/services/_agent_loop.py
+++ b/backend/app/services/_agent_loop.py
@@ -4,7 +4,11 @@ Used by routine_runner and investment_plan_runner.
 """
 from __future__ import annotations
 
+import logging
+import time
 from typing import Any
+
+from anthropic import RateLimitError
 
 from app.mcp.tools import (
     accounts as account_tools,
@@ -13,22 +17,59 @@ from app.mcp.tools import (
 )
 from app.services import anthropic_client
 
+log = logging.getLogger(__name__)
+
+# Outer retry on top of the SDK's built-in max_retries. Useful for sustained
+# rate-limit pressure on low-tier orgs where the per-minute window is the
+# bottleneck — the SDK's exponential backoff (capped at ~8s) doesn't span a
+# full 60s window. We sleep for the server-suggested Retry-After (or 60s) and
+# try again.
+_RATE_LIMIT_OUTER_RETRIES = 3
+
 
 def call_agent_step(client, model: str, system: str, messages: list[dict], tools: list[dict]):
     """Wrapper around Anthropic messages.create so callers can patch one function in tests.
 
     Pass ``client=None`` to lazy-resolve via ``anthropic_client.get_client()`` — useful so
     tests don't need ANTHROPIC_API_KEY set when the entire function is mocked.
+
+    Adds an outer retry loop for sustained 429s that exhaust the SDK's built-in retries.
     """
     if client is None:
         client = anthropic_client.get_client()
-    return client.messages.create(
-        model=model,
-        max_tokens=4096,
-        system=system,
-        tools=tools,
-        messages=messages,
-    )
+
+    last_err: Exception | None = None
+    for attempt in range(_RATE_LIMIT_OUTER_RETRIES):
+        try:
+            return client.messages.create(
+                model=model,
+                max_tokens=4096,
+                system=system,
+                tools=tools,
+                messages=messages,
+            )
+        except RateLimitError as exc:
+            last_err = exc
+            # Honor Retry-After if Anthropic provided it; otherwise wait a full
+            # 60s window so the next attempt starts in a fresh per-minute bucket.
+            retry_after_header = (
+                exc.response.headers.get("retry-after") if exc.response is not None else None
+            )
+            try:
+                wait_seconds = float(retry_after_header) if retry_after_header else 60.0
+            except (TypeError, ValueError):
+                wait_seconds = 60.0
+            wait_seconds = max(5.0, min(wait_seconds, 120.0))
+            log.warning(
+                "Anthropic rate limit hit (attempt %d/%d); sleeping %.1fs before retry",
+                attempt + 1,
+                _RATE_LIMIT_OUTER_RETRIES,
+                wait_seconds,
+            )
+            time.sleep(wait_seconds)
+    # Exhausted outer retries.
+    assert last_err is not None
+    raise last_err
 
 
 def serialize_block(b) -> dict:

--- a/backend/app/services/anthropic_client.py
+++ b/backend/app/services/anthropic_client.py
@@ -37,7 +37,10 @@ def get_client() -> Anthropic:
     api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
     if not api_key:
         raise RuntimeError("ANTHROPIC_API_KEY is not configured")
-    return Anthropic(api_key=api_key)
+    # Increase max_retries from default (2) so transient 429s on low-tier orgs
+    # ride out the per-minute window automatically. Anthropic's SDK honors the
+    # Retry-After header when the server provides one.
+    return Anthropic(api_key=api_key, max_retries=6)
 
 
 def is_configured() -> bool:


### PR DESCRIPTION
## Description

Production agent run failed with:

> Error code: 429 — This request would exceed your organization's rate limit of 30,000 input tokens per minute

After a single transient 429 mid-loop, the run is marked `failed` even though the next minute would succeed. This PR makes the agent ride out short rate-limit pressure.

## Fix

Two layers of defense:

1. **Bump Anthropic SDK `max_retries` from 2 → 6** in `anthropic_client.get_client()`. The SDK honors `Retry-After` headers automatically; more attempts means transient bursts ride out without surfacing.

2. **Explicit outer retry in `_agent_loop.call_agent_step`**: catches `RateLimitError`, reads `Retry-After` from the response (or defaults to 60s — a fresh per-minute bucket), sleeps, retries up to 3 times. Capped at 120s wait per attempt.

Combined, an agent step can survive ~3-4 minutes of sustained rate pressure before giving up and marking the run failed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Tests

`tests/services/test_routine_runner.py` and `tests/services/test_investment_plan_runner.py` (6/6) still pass — they patch `call_agent_step` so the retry logic is not exercised by tests, but the unchanged signature ensures no regression.

## Note for the operator

This fix is a band-aid over the per-minute window. For sustained agent workloads, upgrading the Anthropic org tier (Tier 2 = 50k tokens/min, Tier 3 = 100k/min) is the real solution. https://docs.claude.com/en/api/rate-limits

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the agent resilient to Anthropic 429 rate-limit bursts by increasing SDK retries and adding an outer retry that honors Retry-After. Runs no longer fail on brief per-minute spikes.

- **Bug Fixes**
  - Increased `anthropic` client `max_retries` from 2 to 6 in `anthropic_client.get_client()` to leverage SDK backoff and `Retry-After`.
  - Added outer retry in `_agent_loop.call_agent_step` that catches `RateLimitError`, waits `Retry-After` or 60s (capped at 120s), and retries up to 3 times to ride out short rate pressure.

<sup>Written for commit 9337d4c3710d396fead3a28889c6754c027a4282. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

