### PR TITLE
fix(investment-plans): accept null for proposedReplacement

### DIFF
--- a/frontend/lib/investment-plans/schema.ts
+++ b/frontend/lib/investment-plans/schema.ts
@@ -65,7 +65,9 @@ export const pinnedResultSchema = z.object({
   rationale: z.string(),
   riskFlags: z.array(z.string()).default([]),
   newsRefs: z.array(z.number()).default([]),
-  proposedReplacement: z.object({ symbol: z.string(), reason: z.string() }).optional(),
+  // Use .nullish() so the agent can emit either `null` (common) or omit the
+  // field entirely. `.optional()` alone rejects `null` and crashes Zod parsing.
+  proposedReplacement: z.object({ symbol: z.string(), reason: z.string() }).nullish(),
 });
 
 export const topPickSchema = z.object({


### PR DESCRIPTION
## Description

Investment plan run-detail page showed:

> Output failed schema validation: pinned[0].proposedReplacement — Expected object, received null

The agent emits `proposedReplacement: null` on pinned slots whose verdict isn't `replace`. Zod's `.optional()` accepts `undefined` but rejects `null`.

## Fix

Switch `proposedReplacement` from `.optional()` to `.nullish()` (`null | undefined | object`). Pydantic already accepts None via `Optional[dict] = None`, so the backend persists runs correctly; only the frontend's schema-parse-for-display was failing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Tests

`lib/investment-plans/__tests__/schema.test.ts` (4/4) still passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept `null` for `proposedReplacement` in investment plan pinned results to stop schema validation errors on the run-detail page. This aligns the frontend with the backend and restores display.

- **Bug Fixes**
  - Switched `zod` schema from `.optional()` to `.nullish()` so `proposedReplacement` can be `null` or omitted.

<sup>Written for commit 43a9fcd1a26542549410eb3c7641b9da3c756fc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

