### PR TITLE
fix(agent): heal stringified payloads + enable prompt caching + lower step cap

### DIFF
--- a/backend/app/services/_agent_loop.py
+++ b/backend/app/services/_agent_loop.py
@@ -38,14 +38,29 @@ def call_agent_step(client, model: str, system: str, messages: list[dict], tools
     if client is None:
         client = anthropic_client.get_client()
 
+    # Apply Anthropic prompt caching to the system prompt and the tools array.
+    # The system prompt (~3-5k tokens) and tool definitions including the
+    # emit_*_output schema (~5-15k tokens) are STATIC across every iteration
+    # of an agent loop. Marking the last block of each with cache_control=ephemeral
+    # caches them for 5 minutes — subsequent iterations pay 0.1× input cost on
+    # the cached portion (90% discount). For a typical 10-step loop with
+    # web_search this cuts total run cost roughly in half.
+    cached_system = [{"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}]
+    cached_tools = list(tools)
+    if cached_tools:
+        # Marking the LAST tool caches every tool definition above it as well.
+        last_tool = dict(cached_tools[-1])
+        last_tool["cache_control"] = {"type": "ephemeral"}
+        cached_tools[-1] = last_tool
+
     last_err: Exception | None = None
     for attempt in range(_RATE_LIMIT_OUTER_RETRIES):
         try:
             return client.messages.create(
                 model=model,
                 max_tokens=4096,
-                system=system,
-                tools=tools,
+                system=cached_system,
+                tools=cached_tools,
                 messages=messages,
             )
         except RateLimitError as exc:

--- a/backend/app/services/investment_plan_runner.py
+++ b/backend/app/services/investment_plan_runner.py
@@ -23,7 +23,7 @@ from app.services.grounding import collect_grounding
 
 log = logging.getLogger(__name__)
 
-MAX_AGENT_STEPS = 30
+MAX_AGENT_STEPS = 15  # Tighter cap — each web_search-using step grows input by 5-20k tokens
 
 EMIT_OUTPUT_TOOL = {
     "name": "emit_investment_plan_output",
@@ -136,7 +136,29 @@ def _agent_loop(plan: InvestmentPlan, transcript: list[dict], usage_totals: dict
     return None, last_message
 
 
+def _normalize_payload(payload: dict) -> dict:
+    """Heal common Anthropic tool-input quirks.
+
+    Sonnet sometimes serializes nested object/array values as JSON-encoded strings
+    when the tool's input_schema has deeply nested types. We pre-walk the payload
+    and json.loads any string that looks like a JSON object or array. Idempotent.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    healed: dict = {}
+    for k, v in payload.items():
+        if isinstance(v, str) and v and v[0] in ("{", "["):
+            try:
+                healed[k] = json.loads(v)
+                continue
+            except json.JSONDecodeError:
+                pass
+        healed[k] = v
+    return healed
+
+
 def _validate(payload: dict) -> tuple[dict, list[str]]:
+    payload = _normalize_payload(payload)
     try:
         validated = InvestmentPlanOutput.model_validate(payload).model_dump(by_alias=True)
         return validated, []

--- a/backend/app/services/routine_runner.py
+++ b/backend/app/services/routine_runner.py
@@ -25,7 +25,7 @@ from app.services._agent_loop import call_agent_step, dispatch_mcp, serialize_bl
 
 log = logging.getLogger(__name__)
 
-MAX_AGENT_STEPS = 30
+MAX_AGENT_STEPS = 15  # Tighter cap — each web_search-using step grows input by 5-20k tokens
 EVIDENCE_THRESHOLD = 3
 
 # Built from the Pydantic schema so the agent sees exactly what we'll validate against.
@@ -149,8 +149,30 @@ def _agent_loop(routine: Routine, transcript: list[dict], usage_totals: dict) ->
     return None, last_message
 
 
+def _normalize_payload(payload: dict) -> dict:
+    """Heal common Anthropic tool-input quirks.
+
+    Sonnet sometimes serializes nested object/array values as JSON-encoded strings
+    when the tool's input_schema has deeply nested types. We pre-walk the payload
+    and json.loads any string that looks like a JSON object or array. Idempotent.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    healed: dict = {}
+    for k, v in payload.items():
+        if isinstance(v, str) and v and v[0] in ("{", "["):
+            try:
+                healed[k] = json.loads(v)
+                continue
+            except json.JSONDecodeError:
+                pass
+        healed[k] = v
+    return healed
+
+
 def _validate_or_downgrade(payload: dict) -> tuple[dict, list[str]]:
     """Validate against the Pydantic schema; if AMBER/RED with insufficient evidence, downgrade to GREEN."""
+    payload = _normalize_payload(payload)
     errors: list[str] = []
     try:
         validated = RoutineOutput.model_validate(payload).model_dump(by_alias=True)


### PR DESCRIPTION
## Description

Investment plan run hit two issues at once:
- **Validation failed twice**: \`monthlyAction\` was emitted as a JSON-encoded string instead of a nested object → Pydantic rejected → run marked failed.
- **\$1.40 cost** for one failed run — way too high.

This PR fixes both and adds a step-count guardrail.

## Fixes

### 1. \`_normalize_payload\` — heal stringified nested fields

Sonnet sometimes returns nested object/array values in tool-input as JSON-encoded **strings** rather than native objects when the tool schema is deeply nested (the \`InvestmentPlanOutput\` schema is). Example we just saw:

\`\`\`json
{ "monthlyAction": "{\"proposedBuys\":[{\"symbol\":\"VUAA\",...}]}", ... }
\`\`\`

Pre-walk the payload before Pydantic validation; \`json.loads\` any string starting with \`{\` or \`[\`. Applied identically in \`routine_runner._validate_or_downgrade\` and \`investment_plan_runner._validate\`.

### 2. Anthropic prompt caching on system + tools

The system prompt (3-5k tokens) and tool definitions including the \`InvestmentPlanOutput\` JSON schema (5-15k tokens) are **static** across every iteration of an agent loop. We were re-paying full input cost (\$3/M for Sonnet) on these tokens every step.

Marking the last block of \`system\` and \`tools\` with \`cache_control: { type: \"ephemeral\" }\` caches them for 5 minutes — easily long enough to cover the entire loop. Cached tokens cost 0.1× = **\$0.30/M** instead of \$3/M.

For a 10-step run that was costing \$1.40, this drops to roughly **\$0.50-0.70**. Bigger wins on longer loops.

### 3. \`MAX_AGENT_STEPS\` 30 → 15

Each step that uses \`web_search\` adds 5-20k tokens of search-result content. That content is re-included in every subsequent iteration's input → cost grows quadratically. Capping the loop bounds worst-case spend.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Tests

\`tests/services/test_routine_runner.py\` and \`tests/services/test_investment_plan_runner.py\` (6/6) still pass — they patch \`call_agent_step\` so caching internals don't affect tests, and the validation-test payload is well-formed so \`_normalize_payload\` is a no-op.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes validation failures from stringified nested tool payloads and reduces agent run cost by enabling prompt caching in `anthropic` and lowering the step cap. `MAX_AGENT_STEPS` is now 15, and runs that previously failed on fields like `monthlyAction` now pass; typical loops cost ~50% less.

- **Bug Fixes**
  - Pre-parse JSON-like strings in tool payloads before Pydantic validation in both routine and investment plan runners.

<sup>Written for commit e031a20a6f039b21342daa453a6bc6721bbd7527. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

