### PR TITLE
fix(uploads,assets): render people avatars and preload owners on Assets

### DIFF
--- a/deploy/casaos/docker-compose.yml
+++ b/deploy/casaos/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   uploads-init:
     image: alpine:3.20
-    command: ["sh", "-c", "mkdir -p /uploads && chown -R ${PUID:-1000}:${PGID:-1000} /uploads"]
+    command: ["sh", "-c", "mkdir -p /uploads/profile /uploads/logos /uploads/imports /uploads/people && chown -R ${PUID:-1000}:${PGID:-1000} /uploads"]
     volumes:
       - type: bind
         source: /DATA/AppData/$AppID/uploads
@@ -219,14 +219,15 @@ services:
       DATA_ENCRYPTION_KEY_ID: ${DATA_ENCRYPTION_KEY_ID:-k1}
       BACKEND_URL: ${BACKEND_URL:-http://backend:8000}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER:-local}
-      LOCAL_STORAGE_PATH: ${LOCAL_STORAGE_PATH:-uploads}
+      # Absolute path: persistent volume served via /uploads/* route handler.
+      LOCAL_STORAGE_PATH: ${LOCAL_STORAGE_PATH:-/data/uploads}
       # Optional features
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       LOGO_DEV_API_KEY: ${LOGO_DEV_API_KEY:-}
     volumes:
       - type: bind
         source: /DATA/AppData/$AppID/uploads
-        target: /app/public/uploads
+        target: /data/uploads
     depends_on:
       - uploads-init
       - migrate
@@ -276,7 +277,7 @@ services:
           description:
             en_US: Timezone (e.g. Europe/Athens).
       volumes:
-        - container: /app/public/uploads
+        - container: /data/uploads
           description:
             en_US: User uploads and CSV storage.
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   uploads-init:
     image: alpine:3.20
     container_name: syllogic-uploads-init
-    command: ["sh", "-c", "mkdir -p /uploads && chown -R 1000:1000 /uploads"]
+    command: ["sh", "-c", "mkdir -p /uploads/profile /uploads/logos /uploads/imports /uploads/people && chown -R 1000:1000 /uploads"]
     volumes:
       - uploads_data:/uploads
     restart: "no"
@@ -174,12 +174,14 @@ services:
       DATA_ENCRYPTION_KEY_ID: ${DATA_ENCRYPTION_KEY_ID:-k1}
       BACKEND_URL: ${BACKEND_URL:-http://backend:8000}
       STORAGE_PROVIDER: ${STORAGE_PROVIDER:-local}
-      LOCAL_STORAGE_PATH: ${LOCAL_STORAGE_PATH:-uploads}
+      # Absolute path: files live on a persistent volume outside the build
+      # output and are served via the /uploads/* route handler.
+      LOCAL_STORAGE_PATH: ${LOCAL_STORAGE_PATH:-/data/uploads}
       # Optional features
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       LOGO_DEV_API_KEY: ${LOGO_DEV_API_KEY:-}
     volumes:
-      - uploads_data:/app/public/uploads
+      - uploads_data:/data/uploads
     depends_on:
       uploads-init:
         condition: service_completed_successfully

--- a/deploy/railway/docker-compose.yml
+++ b/deploy/railway/docker-compose.yml
@@ -137,12 +137,12 @@ services:
   # Keep PORT=3000 so Railway proxy routes traffic correctly.
   app:
     image: ghcr.io/syllogic-ai/syllogic-frontend:v1.0.0
-    command: /bin/sh -lc "mkdir -p /app/public/uploads/profile /app/public/uploads/logos /app/public/uploads/imports && chmod -R u+rwX,g+rwX /app/public/uploads && node scripts/migrate.js && exec node_modules/.bin/next start -p 3000 -H 0.0.0.0"
+    command: /bin/sh -lc "mkdir -p /data/uploads/profile /data/uploads/logos /data/uploads/imports /data/uploads/people && chmod -R u+rwX,g+rwX /data/uploads && node scripts/migrate.js && exec node_modules/.bin/next start -p 3000 -H 0.0.0.0"
     healthcheck:
       test:
         [
           "CMD-SHELL",
-          "test -w /app/public/uploads && node -e \"require('http').get('http://127.0.0.1:3000/', (r)=>process.exit(r.statusCode && r.statusCode < 500 ? 0 : 1)).on('error', ()=>process.exit(1))\"",
+          "test -w /data/uploads && node -e \"require('http').get('http://127.0.0.1:3000/', (r)=>process.exit(r.statusCode && r.statusCode < 500 ? 0 : 1)).on('error', ()=>process.exit(1))\"",
         ]
       interval: 15s
       timeout: 5s
@@ -163,12 +163,16 @@ services:
       DATA_ENCRYPTION_KEY_ID: ${{shared.DATA_ENCRYPTION_KEY_ID}}
       BACKEND_URL: http://${{backend.RAILWAY_PRIVATE_DOMAIN}}:${{backend.PORT}}
       STORAGE_PROVIDER: local
-      LOCAL_STORAGE_PATH: uploads
+      # Absolute path: files live on a persistent volume outside the build
+      # output. They're served via the Next.js /uploads/* route handler
+      # (frontend/app/uploads/[...slug]/route.ts), not the public/ folder.
+      LOCAL_STORAGE_PATH: /data/uploads
       OPENAI_API_KEY: ${{shared.OPENAI_API_KEY}}
       LOGO_DEV_API_KEY: ${{shared.LOGO_DEV_API_KEY}}
     volumes:
-      # Persist uploaded files and keep them directly web-accessible at /uploads/*
-      - uploads_data:/app/public/uploads
+      # Persistent volume for uploaded files (avatars, logos, CSVs).
+      # Served via /uploads/* route handler.
+      - uploads_data:/data/uploads
     restart: always
 
 volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -76,8 +76,10 @@ COPY --from=builder --chown=node:node /app/public ./public
 COPY --from=builder --chown=node:node /app/scripts/migrate.js ./scripts/migrate.js
 COPY --from=builder --chown=node:node /app/lib/db/migrations ./lib/db/migrations
 
-# Ensure uploads dir exists (can be mounted as a volume in production).
-RUN mkdir -p /app/public/uploads && chown -R node:node /app/public/uploads
+# Uploads live on a persistent volume in production (LOCAL_STORAGE_PATH,
+# typically /data/uploads) and are served via the /uploads/* route handler,
+# not the public/ directory. No build-time mkdir needed — the storage
+# provider creates its root on first write.
 
 USER node
 

--- a/frontend/app/(dashboard)/assets/_sections.tsx
+++ b/frontend/app/(dashboard)/assets/_sections.tsx
@@ -1,20 +1,35 @@
 import { getAccounts } from "@/lib/actions/accounts";
 import { getProperties } from "@/lib/actions/properties";
 import { getVehicles } from "@/lib/actions/vehicles";
+import { getPeople } from "@/lib/people";
+import { avatarUrl } from "@/lib/people/avatars";
+import { requireAuth } from "@/lib/auth-helpers";
 import { AssetManagement } from "./asset-management";
 
 export async function AssetsSection() {
-  const [accounts, properties, vehicles] = await Promise.all([
+  const userId = await requireAuth();
+
+  const [accounts, properties, vehicles, peopleRows] = await Promise.all([
     getAccounts(),
     getProperties(),
     getVehicles(),
+    userId ? getPeople(userId) : Promise.resolve([]),
   ]);
+
+  const people = peopleRows.map((p) => ({
+    id: p.id,
+    name: p.name,
+    kind: p.kind,
+    color: p.color,
+    avatarUrl: avatarUrl(p.avatarPath),
+  }));
 
   return (
     <AssetManagement
       initialAccounts={accounts}
       initialProperties={properties}
       initialVehicles={vehicles}
+      initialPeople={people}
     />
   );
 }

--- a/frontend/app/(dashboard)/assets/asset-management.tsx
+++ b/frontend/app/(dashboard)/assets/asset-management.tsx
@@ -108,6 +108,7 @@ interface AssetManagementProps {
   initialAccounts: AccountWithLogo[];
   initialProperties: Property[];
   initialVehicles: Vehicle[];
+  initialPeople?: Person[];
 }
 
 type AccountWithLogo = Account & {
@@ -122,6 +123,7 @@ export function AssetManagement({
   initialAccounts,
   initialProperties,
   initialVehicles,
+  initialPeople,
 }: AssetManagementProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
@@ -179,19 +181,25 @@ export function AssetManagement({
   const [editVehicleValue, setEditVehicleValue] = useState("");
   const [editVehicleCurrency, setEditVehicleCurrency] = useState("");
 
-  // Shared ownership state for edit dialogs
-  const [people, setPeople] = useState<Person[]>([]);
+  // Shared ownership state for edit dialogs.
+  // People are preloaded server-side so the OwnersField gate is correct on
+  // first render — no client fetch race, no silent failures.
+  const [people, setPeople] = useState<Person[]>(initialPeople ?? []);
   const [editAccountOwners, setEditAccountOwners] = useState<OwnerValue[]>([]);
   const [editPropertyOwners, setEditPropertyOwners] = useState<OwnerValue[]>([]);
   const [editVehicleOwners, setEditVehicleOwners] = useState<OwnerValue[]>([]);
 
-  // Load people list once
+  // Refresh client-side too, in case the household was edited in another tab
+  // since the server render. Only runs if the server didn't pass anything.
   useEffect(() => {
+    if (initialPeople && initialPeople.length > 0) return;
     fetch("/api/people")
       .then((r) => r.json())
-      .then((data: { people: Person[] }) => setPeople(data.people))
+      .then((data: { people: Person[] }) => {
+        if (Array.isArray(data?.people)) setPeople(data.people);
+      })
       .catch(() => {});
-  }, []);
+  }, [initialPeople]);
 
   const handleRefresh = () => {
     router.refresh();

--- a/frontend/app/uploads/[...slug]/route.ts
+++ b/frontend/app/uploads/[...slug]/route.ts
@@ -1,23 +1,11 @@
 import { promises as fs } from "fs";
 import path from "path";
 import { NextRequest, NextResponse } from "next/server";
+import { resolveLocalStorageRoot } from "@/lib/storage/local-paths";
 
-const DEFAULT_STORAGE_ROOT = "uploads";
-const PUBLIC_UPLOAD_DIRS = new Set(["profile", "logos"]);
-
-function normalizeStorageRoot(root: string): string {
-  let normalized = root.trim();
-  if (normalized.startsWith("/")) normalized = normalized.slice(1);
-  if (normalized.startsWith("public/")) normalized = normalized.slice("public/".length);
-  return normalized || DEFAULT_STORAGE_ROOT;
-}
-
-function resolveStorageRoot(): string {
-  const root = normalizeStorageRoot(
-    process.env.LOCAL_STORAGE_PATH || DEFAULT_STORAGE_ROOT
-  );
-  return path.resolve(process.cwd(), "public", root);
-}
+// Subdirectories of the storage root that may be served publicly.
+// CSV imports and other private files must NOT be added here.
+const PUBLIC_UPLOAD_DIRS = new Set(["profile", "logos", "people"]);
 
 function contentTypeFor(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase();
@@ -52,11 +40,14 @@ export async function GET(
     return new NextResponse("Not Found", { status: 404 });
   }
 
-  const storageRoot = resolveStorageRoot();
+  const storageRoot = resolveLocalStorageRoot();
   const filePath = path.resolve(storageRoot, ...slug);
 
   // Prevent path traversal
-  if (!filePath.startsWith(`${storageRoot}${path.sep}`)) {
+  if (
+    filePath !== storageRoot &&
+    !filePath.startsWith(`${storageRoot}${path.sep}`)
+  ) {
     return new NextResponse("Not Found", { status: 404 });
   }
 

--- a/frontend/lib/storage/local-paths.ts
+++ b/frontend/lib/storage/local-paths.ts
@@ -1,0 +1,37 @@
+import { existsSync } from "fs";
+import path from "path";
+
+const DEFAULT_STORAGE_ROOT = "uploads";
+
+function resolvePublicDir(): string {
+  const cwd = process.cwd();
+  const directPublic = path.join(cwd, "public");
+  const nestedPublic = path.join(cwd, "frontend", "public");
+  if (existsSync(directPublic)) return directPublic;
+  if (existsSync(nestedPublic)) return nestedPublic;
+  return directPublic;
+}
+
+/**
+ * Resolves the on-disk root for local file storage.
+ *
+ * - Absolute `LOCAL_STORAGE_PATH` (e.g. `/data/uploads`) is used as-is. This is
+ *   the recommended setup: mount a persistent volume there and serve files via
+ *   the `/uploads/*` route handler instead of the `public/` directory.
+ * - Relative values are resolved under the Next.js `public/` directory for
+ *   backwards compatibility. `public/` and leading slashes are stripped.
+ */
+export function resolveLocalStorageRoot(): string {
+  const raw = (process.env.LOCAL_STORAGE_PATH || DEFAULT_STORAGE_ROOT).trim();
+
+  if (path.isAbsolute(raw)) {
+    return path.resolve(raw);
+  }
+
+  let normalized = raw;
+  if (normalized.startsWith("public/")) {
+    normalized = normalized.slice("public/".length);
+  }
+  if (!normalized) normalized = DEFAULT_STORAGE_ROOT;
+  return path.resolve(resolvePublicDir(), normalized);
+}

--- a/frontend/lib/storage/local.ts
+++ b/frontend/lib/storage/local.ts
@@ -1,49 +1,19 @@
 import { promises as fs, existsSync } from "fs";
 import path from "path";
+import { resolveLocalStorageRoot } from "./local-paths";
 import type { StorageProvider, StorageFile, UploadOptions } from "./types";
-
-const DEFAULT_STORAGE_ROOT = "uploads";
-const STORAGE_ROOT = process.env.LOCAL_STORAGE_PATH || DEFAULT_STORAGE_ROOT;
-
-function normalizeStorageRoot(root: string): string {
-  let normalized = root.trim();
-  if (normalized.startsWith("/")) {
-    normalized = normalized.slice(1);
-  }
-  if (normalized.startsWith("public/")) {
-    normalized = normalized.slice("public/".length);
-  }
-  if (!normalized) {
-    normalized = DEFAULT_STORAGE_ROOT;
-  }
-  return normalized;
-}
-
-function resolvePublicDir(): string {
-  const cwd = process.cwd();
-  const directPublic = path.join(cwd, "public");
-  const nestedPublic = path.join(cwd, "frontend", "public");
-
-  if (existsSync(directPublic)) {
-    return directPublic;
-  }
-
-  if (existsSync(nestedPublic)) {
-    return nestedPublic;
-  }
-
-  return directPublic;
-}
 
 export class LocalStorageProvider implements StorageProvider {
   private storageRoot: string;
   private baseUrl: string;
 
   constructor() {
-    const publicDir = resolvePublicDir();
-    const normalizedRoot = normalizeStorageRoot(STORAGE_ROOT);
-    this.storageRoot = path.resolve(publicDir, normalizedRoot);
-    this.baseUrl = `/${normalizedRoot}`;
+    this.storageRoot = resolveLocalStorageRoot();
+    this.baseUrl = "/uploads";
+    // Best-effort: ensure root exists so first uploads don't fail before mkdir.
+    if (!existsSync(this.storageRoot)) {
+      fs.mkdir(this.storageRoot, { recursive: true }).catch(() => {});
+    }
   }
 
   private getFullPath(filePath: string): string {
@@ -121,6 +91,6 @@ export class LocalStorageProvider implements StorageProvider {
   }
 
   getUrl(filePath: string): string {
-    return `${this.baseUrl}/${filePath}`;
+    return `${this.baseUrl}/${filePath.replace(/^\/+/, "")}`;
   }
 }


### PR DESCRIPTION
## Summary
- Person avatars under `/uploads/people/<id>` now render — added `people` to the public uploads whitelist in the route handler (was 404'ing).
- `LOCAL_STORAGE_PATH` is now absolute-aware via a shared resolver (`frontend/lib/storage/local-paths.ts`); uploads can live outside `public/` and are still served via the `/uploads/*` route handler.
- OwnersField on the Assets edit dialogs now appears on first render — household people are preloaded server-side in `_sections.tsx` so the picker no longer depends on a client-side fetch race.
- Railway / self-hosted compose / CasaOS deploys: volume mounts moved from `/app/public/uploads` to `/data/uploads`, with `LOCAL_STORAGE_PATH=/data/uploads`. URL stability preserved (still `/uploads/*`), so existing DB-stored URLs keep working.

## Test plan
- [ ] Upload an avatar for a household member → renders correctly in Settings → Household.
- [ ] Visit Assets → Edit account → Owners picker appears with both household members.
- [ ] Existing logo URLs continue to load (no broken images on transactions list).
- [ ] On redeploy, copy any existing files from the previous `/app/public/uploads` volume into the new `/data/uploads` volume on Railway, or remap the existing volume to the new mount path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken people avatars and makes the Assets Owners picker show up on first render. Also switches local uploads to an absolute-aware storage root, with deploys mounting `/data/uploads` while keeping `/uploads/*` URLs.

- **Bug Fixes**
  - Serve people avatars by adding `people` to the public uploads allowlist (`/uploads/people/<id>` now works).
  - Preload household people server-side in Assets, so the OwnersField renders immediately (no client fetch race).

- **Migration**
  - For self-hosted (Railway/compose/CasaOS): set `LOCAL_STORAGE_PATH=/data/uploads` and mount your volume to `/data/uploads`.
  - Move or remap any existing uploads from `/app/public/uploads` to `/data/uploads`. URLs remain `/uploads/*`.

<sup>Written for commit ebdca7279193ed812f4320f73daf6b202559f087. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

