### PR TITLE
fix(ibkr): retry transient FlexError 1001 with backoff

### DIFF
--- a/backend/app/integrations/ibkr_flex_adapter.py
+++ b/backend/app/integrations/ibkr_flex_adapter.py
@@ -7,6 +7,7 @@ Two-step flow:
 """
 from __future__ import annotations
 import logging
+import time
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
@@ -23,6 +24,11 @@ GET_URL = f"{BASE}/FlexStatementService.GetStatement"
 
 FLEX_NOT_READY_CODES = {"1019"}
 FLEX_AUTH_ERROR_CODES = {"1012", "1003"}
+# 1001 = "Statement could not be generated at this time. Please try again shortly."
+# Distinct from 1019 (still generating after a successful SendRequest) and 1018
+# (rate limit: 1 req/sec, 10 req/min per token — see IBKR Flex v3 error docs).
+# Default retry schedule (5s, 15s, 45s) stays well under both limits.
+FLEX_TRANSIENT_CODES = {"1001"}
 
 
 class FlexError(RuntimeError):
@@ -34,6 +40,10 @@ class FlexStatementNotReady(FlexError):
 
 
 class FlexAuthError(FlexError):
+    pass
+
+
+class FlexTransientError(FlexError):
     pass
 
 
@@ -75,19 +85,47 @@ class ParsedTrade:
 
 
 class IBKRFlexAdapter:
-    def __init__(self, token: str, query_id_positions: str, query_id_trades: str, *, client: httpx.Client | None = None):
+    def __init__(
+        self,
+        token: str,
+        query_id_positions: str,
+        query_id_trades: str,
+        *,
+        client: httpx.Client | None = None,
+        transient_retries: int = 3,
+        transient_backoff_seconds: float = 5.0,
+        sleep: callable = time.sleep,
+    ):
         self.token = token
         self.query_id_positions = query_id_positions
         self.query_id_trades = query_id_trades
         self._client = client or httpx.Client(timeout=30.0)
+        self._transient_retries = transient_retries
+        self._transient_backoff = transient_backoff_seconds
+        self._sleep = sleep
 
     def request_statement(self, query_id: str) -> str:
-        resp = self._client.get(SEND_URL, params={"v": "3", "t": self.token, "q": query_id}, timeout=30.0)
-        root = ET.fromstring(resp.text)
-        status = (root.findtext("Status") or "").strip()
-        if status != "Success":
-            self._raise_for_error(root)
-        return (root.findtext("ReferenceCode") or "").strip()
+        last_exc: FlexTransientError | None = None
+        for attempt in range(self._transient_retries + 1):
+            try:
+                resp = self._client.get(SEND_URL, params={"v": "3", "t": self.token, "q": query_id}, timeout=30.0)
+                root = ET.fromstring(resp.text)
+                status = (root.findtext("Status") or "").strip()
+                if status != "Success":
+                    self._raise_for_error(root)
+                return (root.findtext("ReferenceCode") or "").strip()
+            except FlexTransientError as e:
+                last_exc = e
+                if attempt >= self._transient_retries:
+                    break
+                delay = self._transient_backoff * (3 ** attempt)
+                logger.warning(
+                    "IBKR Flex transient error on SendRequest (q=%s), retry %d/%d in %.1fs: %s",
+                    query_id, attempt + 1, self._transient_retries, delay, e,
+                )
+                self._sleep(delay)
+        assert last_exc is not None
+        raise last_exc
 
     def fetch_statement(self, reference_code: str) -> str:
         resp = self._client.get(GET_URL, params={"v": "3", "t": self.token, "q": reference_code}, timeout=60.0)
@@ -104,6 +142,8 @@ class IBKRFlexAdapter:
             raise FlexStatementNotReady(message)
         if code in FLEX_AUTH_ERROR_CODES:
             raise FlexAuthError(message)
+        if code in FLEX_TRANSIENT_CODES:
+            raise FlexTransientError(f"{code}: {message}")
         raise FlexError(f"{code}: {message}")
 
     def parse_positions_xml(self, xml: str) -> ParsedStatement:

--- a/backend/app/services/investment_sync_service.py
+++ b/backend/app/services/investment_sync_service.py
@@ -15,7 +15,7 @@ from app.services.credentials_crypto import decrypt
 from app.services.holding_valuation_service import HoldingValuationService, FxConverter
 from app.services.price_service import PriceService
 from app.integrations.ibkr_flex_adapter import (
-    IBKRFlexAdapter, FlexAuthError, FlexStatementNotReady, FlexError,
+    IBKRFlexAdapter, FlexAuthError, FlexStatementNotReady, FlexTransientError, FlexError,
 )
 
 logger = logging.getLogger(__name__)
@@ -70,6 +70,11 @@ class InvestmentSyncService:
             conn.last_sync_status = "pending"
             self.db.commit()
             raise
+        except FlexTransientError as e:
+            conn.last_sync_status = "pending"
+            conn.last_sync_error = str(e)
+            self.db.commit()
+            raise
         except FlexError as e:
             conn.last_sync_status = "error"
             conn.last_sync_error = str(e)
@@ -112,6 +117,9 @@ class InvestmentSyncService:
         except FlexStatementNotReady as e:
             trades_error = f"trades not ready: {e}"
             logger.info("IBKR trades not ready for %s: %s", account.id, e)
+        except FlexTransientError as e:
+            trades_error = f"trades transient error: {e}"
+            logger.info("IBKR trades transient error for %s: %s", account.id, e)
         except FlexError as e:
             trades_error = f"trades fetch failed: {e}"
             logger.warning("IBKR trades sync failed for %s: %s", account.id, e)

--- a/backend/scripts/check_ibkr_token_sharing.py
+++ b/backend/scripts/check_ibkr_token_sharing.py
@@ -30,6 +30,7 @@ def main() -> None:
         )
 
         token_groups: dict[str, list[str]] = defaultdict(list)
+        missing_token: list[str] = []
         print(f"{'account_id':<38} {'name':<24} {'token_fp':<14} {'qpos_fp':<14} {'qtrd_fp':<14} {'last_status':<12} {'last_error'}")
         for conn, acct in rows:
             try:
@@ -37,10 +38,15 @@ def main() -> None:
             except Exception as e:
                 print(f"{acct.id} {acct.name[:24]:<24} <DECRYPT FAILED: {e}>")
                 continue
-            tfp = fp(creds.get("flex_token", ""))
-            qp = fp(creds.get("query_id_positions", ""))
-            qt = fp(creds.get("query_id_trades", ""))
-            token_groups[tfp].append(str(acct.id))
+            raw_token = creds.get("flex_token") or ""
+            qp = fp(creds.get("query_id_positions") or "") if (creds.get("query_id_positions") or "") else "<missing>"
+            qt = fp(creds.get("query_id_trades") or "") if (creds.get("query_id_trades") or "") else "<missing>"
+            if raw_token:
+                tfp = fp(raw_token)
+                token_groups[tfp].append(str(acct.id))
+            else:
+                tfp = "<missing>"
+                missing_token.append(str(acct.id))
             print(
                 f"{str(acct.id):<38} {acct.name[:24]:<24} {tfp:<14} {qp:<14} {qt:<14} "
                 f"{(conn.last_sync_status or ''):<12} {(conn.last_sync_error or '')[:60]}"
@@ -49,12 +55,16 @@ def main() -> None:
         print("\nToken-sharing summary:")
         shared = {fp_: ids for fp_, ids in token_groups.items() if len(ids) > 1}
         if not shared:
-            print("  No token sharing detected — every IBKR connection uses a distinct flex_token.")
+            print("  No token sharing detected — every IBKR connection with a token uses a distinct flex_token.")
         else:
             for fp_, ids in shared.items():
                 print(f"  token_fp={fp_} shared by {len(ids)} accounts:")
                 for aid in ids:
                     print(f"    - {aid}")
+        if missing_token:
+            print(f"\n  WARNING: {len(missing_token)} connection(s) have no flex_token (excluded from sharing analysis):")
+            for aid in missing_token:
+                print(f"    - {aid}")
     finally:
         db.close()
 

--- a/backend/scripts/check_ibkr_token_sharing.py
+++ b/backend/scripts/check_ibkr_token_sharing.py
@@ -1,0 +1,63 @@
+"""Diagnostic: report whether IBKR Flex tokens are shared across BrokerConnections.
+
+Prints a SHA256 fingerprint (first 12 chars) of each connection's flex_token plus
+its query IDs — never the plaintext. Run inside the backend service:
+
+    railway run -s backend python scripts/check_ibkr_token_sharing.py
+"""
+from __future__ import annotations
+import hashlib
+from collections import defaultdict
+
+from app.database import SessionLocal
+from app.models import BrokerConnection, Account
+from app.services.credentials_crypto import decrypt
+
+
+def fp(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()[:12]
+
+
+def main() -> None:
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(BrokerConnection, Account)
+            .join(Account, Account.id == BrokerConnection.account_id)
+            .filter(BrokerConnection.provider == "ibkr_flex")
+            .order_by(BrokerConnection.user_id, BrokerConnection.created_at)
+            .all()
+        )
+
+        token_groups: dict[str, list[str]] = defaultdict(list)
+        print(f"{'account_id':<38} {'name':<24} {'token_fp':<14} {'qpos_fp':<14} {'qtrd_fp':<14} {'last_status':<12} {'last_error'}")
+        for conn, acct in rows:
+            try:
+                creds = decrypt(conn.credentials_encrypted)
+            except Exception as e:
+                print(f"{acct.id} {acct.name[:24]:<24} <DECRYPT FAILED: {e}>")
+                continue
+            tfp = fp(creds.get("flex_token", ""))
+            qp = fp(creds.get("query_id_positions", ""))
+            qt = fp(creds.get("query_id_trades", ""))
+            token_groups[tfp].append(str(acct.id))
+            print(
+                f"{str(acct.id):<38} {acct.name[:24]:<24} {tfp:<14} {qp:<14} {qt:<14} "
+                f"{(conn.last_sync_status or ''):<12} {(conn.last_sync_error or '')[:60]}"
+            )
+
+        print("\nToken-sharing summary:")
+        shared = {fp_: ids for fp_, ids in token_groups.items() if len(ids) > 1}
+        if not shared:
+            print("  No token sharing detected — every IBKR connection uses a distinct flex_token.")
+        else:
+            for fp_, ids in shared.items():
+                print(f"  token_fp={fp_} shared by {len(ids)} accounts:")
+                for aid in ids:
+                    print(f"    - {aid}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_ibkr_flex_adapter.py
+++ b/backend/tests/test_ibkr_flex_adapter.py
@@ -9,6 +9,7 @@ from app.integrations.ibkr_flex_adapter import (
     IBKRFlexAdapter,
     FlexStatementNotReady,
     FlexAuthError,
+    FlexTransientError,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -68,3 +69,37 @@ def test_fetch_statement_raises_auth_error():
     with patch.object(adapter._client, "get", return_value=httpx.Response(200, text=response_xml)):
         with pytest.raises(FlexAuthError):
             adapter.fetch_statement("REF1")
+
+
+def test_request_statement_retries_on_1001_then_succeeds():
+    sleeps: list[float] = []
+    adapter = IBKRFlexAdapter(
+        token="t", query_id_positions="qp", query_id_trades="qt",
+        transient_retries=3, transient_backoff_seconds=1.0,
+        sleep=sleeps.append,
+    )
+    transient = '<FlexStatementResponse><Status>Fail</Status><ErrorCode>1001</ErrorCode><ErrorMessage>Statement could not be generated at this time. Please try again shortly.</ErrorMessage></FlexStatementResponse>'
+    success = '<FlexStatementResponse><Status>Success</Status><ReferenceCode>REF1</ReferenceCode></FlexStatementResponse>'
+    responses = [
+        httpx.Response(200, text=transient),
+        httpx.Response(200, text=transient),
+        httpx.Response(200, text=success),
+    ]
+    with patch.object(adapter._client, "get", side_effect=responses):
+        ref = adapter.request_statement("qp")
+    assert ref == "REF1"
+    assert sleeps == [1.0, 3.0]
+
+
+def test_request_statement_raises_after_exhausting_retries_on_1001():
+    sleeps: list[float] = []
+    adapter = IBKRFlexAdapter(
+        token="t", query_id_positions="qp", query_id_trades="qt",
+        transient_retries=2, transient_backoff_seconds=1.0,
+        sleep=sleeps.append,
+    )
+    transient = '<FlexStatementResponse><Status>Fail</Status><ErrorCode>1001</ErrorCode><ErrorMessage>Statement could not be generated at this time. Please try again shortly.</ErrorMessage></FlexStatementResponse>'
+    with patch.object(adapter._client, "get", return_value=httpx.Response(200, text=transient)):
+        with pytest.raises(FlexTransientError):
+            adapter.request_statement("qp")
+    assert sleeps == [1.0, 3.0]


### PR DESCRIPTION
# Pull Request

## Description

Production logs show the IBKR cron sync aborting on `FlexError: 1001` for one account while the other two accounts under the same user sync fine:

```
ERROR [INVESTMENT_SYNC] Failed in-process sync for account a39c2e31-...
app.integrations.ibkr_flex_adapter.FlexError: 1001: Statement could not be
generated at this time. Please try again shortly.
```

Per IBKR's [Flex v3 error docs](https://www.ibkrguides.com/orgportal/performanceandstatements/flex3error.htm), code 1001 is the "try again shortly" transient signal — distinct from 1019 (statement still generating after a successful SendRequest) and 1018 (rate limit: 1 req/sec, 10 req/min per token). We were treating 1001 as a fatal error.

This PR makes 1001 retryable inside the adapter and downgrades the persisted status from `error` to `pending`/`partial` so the user's UI doesn't show a hard failure for a transient IBKR-side issue.

### Adapter changes (`ibkr_flex_adapter.py`)
- New `FlexTransientError(FlexError)` and `FLEX_TRANSIENT_CODES = {"1001"}`.
- `request_statement` now retries with exponential backoff (defaults: 3 retries, 5s → 15s → 45s). Configurable via constructor; `sleep` is injectable for tests.
- Backoff stays well under IBKR's published per-token limits: min gap 5s ≫ 1 req/sec; worst-case 4 calls in 65s ≪ 10 req/min.

### Sync service changes (`investment_sync_service.py`)
- `_sync_brokerage` catches the exhausted `FlexTransientError` on the positions step and marks the connection as `pending` (mirrors how 1019 is treated), instead of `error`.
- On the trades step, an exhausted `FlexTransientError` is logged and the run is marked `partial`, matching existing behaviour for `FlexStatementNotReady`.

### Diagnostic script (`backend/scripts/check_ibkr_token_sharing.py`)
- Prints SHA256 fingerprints (12 chars, no plaintext) of each `BrokerConnection`'s `flex_token` and query IDs, then reports any shared tokens.
- Used to investigate whether the failing account shares a Flex token with the other two — which would explain why three back-to-back syncs in the same cron tick can push a single token close to IBKR's 10/min ceiling and trigger 1001/1018.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (7/7 in `test_ibkr_flex_adapter.py`)
- [x] I have checked my changes for sensitive data or secrets

## Additional Context

The pre-existing `IBKR_FLEX_INTER_QUERY_DELAY_SEC=5` between positions and trades within one account is preserved. **Not in this PR but worth a follow-up**: there is no inter-account spacing in the sync runner. If multiple `BrokerConnection`s share one Flex token, three accounts × ~10 requests each within seconds can exceed 10/min per token and trigger 1018. The diagnostic script in this PR is the first step toward confirming whether that's happening in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries IBKR Flex error 1001 with exponential backoff and treats it as transient so syncs don’t fail hard and can recover on the next run. Adds a diagnostic to detect shared Flex tokens and ignores missing tokens so they aren’t misreported as shared.

- **Bug Fixes**
  - Handle Flex 1001 as transient (`FlexTransientError`) and retry in the adapter with 5s → 15s → 45s backoff (configurable). Stays under IBKR’s per-token limits.
  - On exhausted retries: set positions sync to pending; set trades to partial. Logs updated for clarity. Existing 1019 and auth errors unchanged.

- **New Features**
  - `backend/scripts/check_ibkr_token_sharing.py`: prints SHA256 fingerprints of `flex_token` and query IDs (no plaintext) to spot shared tokens. Missing tokens are excluded from grouping and shown as "<missing>" (same for absent query IDs).

<sup>Written for commit fc4241c6ce0f0ecd787d5299e9527f40b8815d43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

