### PR TITLE
fix(ibkr): aggregate per-lot OpenPosition rows in Flex parser

### DIFF
--- a/backend/app/integrations/ibkr_flex_adapter.py
+++ b/backend/app/integrations/ibkr_flex_adapter.py
@@ -148,20 +148,54 @@ class IBKRFlexAdapter:
 
     def parse_positions_xml(self, xml: str) -> ParsedStatement:
         root = ET.fromstring(xml)
-        positions: list[ParsedPosition] = []
+        # IBKR Flex emits one <OpenPosition> per lot when the Flex Query is
+        # configured at lot granularity. Aggregate to one position per
+        # (symbol, instrument_type) so downstream upserts don't trip the
+        # holdings_account_symbol_type_uq unique constraint. quantity is
+        # summed; avg_cost is a quantity-weighted average over lots that
+        # report a costBasisPrice; mark_price takes the first non-null.
+        aggregates: dict[tuple[str, str], dict] = {}
         for op in root.iter("OpenPosition"):
             asset = (op.get("assetCategory") or "").upper()
             instrument_type = _ASSET_CATEGORY_MAP.get(asset)
             if instrument_type is None:
                 continue
+            symbol = op.get("symbol", "").strip()
+            if not symbol:
+                continue
+            qty = Decimal(op.get("position", "0"))
+            avg_cost = _dec(op.get("costBasisPrice"))
+            mark = _dec(op.get("markPrice"))
+            key = (symbol, instrument_type)
+            acc = aggregates.get(key)
+            if acc is None:
+                aggregates[key] = {
+                    "name": op.get("description", "").strip(),
+                    "currency": op.get("currency", "USD").strip().upper(),
+                    "quantity": qty,
+                    "cost_total": (qty * avg_cost) if avg_cost is not None else Decimal(0),
+                    "cost_qty": qty if avg_cost is not None else Decimal(0),
+                    "mark_price": mark,
+                }
+            else:
+                acc["quantity"] += qty
+                if avg_cost is not None:
+                    acc["cost_total"] += qty * avg_cost
+                    acc["cost_qty"] += qty
+                if acc["mark_price"] is None and mark is not None:
+                    acc["mark_price"] = mark
+
+        positions: list[ParsedPosition] = []
+        for (symbol, instrument_type), acc in aggregates.items():
+            avg = (acc["cost_total"] / acc["cost_qty"]) if acc["cost_qty"] != 0 else None
             positions.append(ParsedPosition(
-                symbol=op.get("symbol", "").strip(),
-                name=op.get("description", "").strip(),
-                quantity=Decimal(op.get("position", "0")),
-                currency=op.get("currency", "USD").strip().upper(),
+                symbol=symbol,
+                name=acc["name"],
+                quantity=acc["quantity"],
+                currency=acc["currency"],
                 instrument_type=instrument_type,
-                avg_cost=_dec(op.get("costBasisPrice")),
-                mark_price=_dec(op.get("markPrice")),
+                avg_cost=avg,
+                mark_price=acc["mark_price"],
             ))
         cash: list[ParsedCash] = []
         for c in root.iter("CashReportCurrency"):

--- a/backend/tests/fixtures/ibkr_flex_positions_lots.xml
+++ b/backend/tests/fixtures/ibkr_flex_positions_lots.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlexQueryResponse queryName="positions" type="AF">
+  <FlexStatements count="1">
+    <FlexStatement accountId="U1234567" fromDate="20260101" toDate="20260418" period="YearToDate">
+      <OpenPositions>
+        <!-- Three lots of PPC at different cost bases — IBKR-Flex lot granularity -->
+        <OpenPosition symbol="PPC" description="PUBLIC POWER CORP" assetCategory="STK" currency="EUR" position="100" markPrice="20.00" costBasisPrice="18.00"/>
+        <OpenPosition symbol="PPC" description="PUBLIC POWER CORP" assetCategory="STK" currency="EUR" position="50" markPrice="20.00" costBasisPrice="19.00"/>
+        <OpenPosition symbol="PPC" description="PUBLIC POWER CORP" assetCategory="STK" currency="EUR" position="50" markPrice="20.00" costBasisPrice="20.00"/>
+        <!-- Single-lot positions still parse correctly -->
+        <OpenPosition symbol="AAPL" description="APPLE INC" assetCategory="STK" currency="USD" position="10" markPrice="234.56" costBasisPrice="180.00"/>
+        <!-- Two lots, one lacks costBasisPrice — weighted avg ignores the missing one -->
+        <OpenPosition symbol="VWCE" description="VANGUARD FTSE ALL-WORLD" assetCategory="ETF" currency="EUR" position="20" markPrice="115.20" costBasisPrice="100.00"/>
+        <OpenPosition symbol="VWCE" description="VANGUARD FTSE ALL-WORLD" assetCategory="ETF" currency="EUR" position="22" markPrice="115.20" costBasisPrice=""/>
+      </OpenPositions>
+      <CashReport>
+        <CashReportCurrency currency="USD" endingCash="1500.00"/>
+      </CashReport>
+    </FlexStatement>
+  </FlexStatements>
+</FlexQueryResponse>

--- a/backend/tests/test_ibkr_flex_adapter.py
+++ b/backend/tests/test_ibkr_flex_adapter.py
@@ -30,6 +30,37 @@ def test_parse_positions_extracts_holdings_and_cash():
     assert {c.currency: c.balance for c in parsed.cash} == {"USD": Decimal("1500.00"), "EUR": Decimal("320.50")}
 
 
+def test_parse_positions_aggregates_per_lot_rows():
+    """IBKR Flex Queries configured at lot granularity emit one OpenPosition
+    per lot. The parser must aggregate them — quantities sum, avg_cost is
+    quantity-weighted, lots without costBasisPrice are excluded from the
+    weighted average."""
+    adapter = IBKRFlexAdapter(token="t", query_id_positions="qp", query_id_trades="qt")
+    parsed = adapter.parse_positions_xml(_read("ibkr_flex_positions_lots.xml"))
+    by_sym = {p.symbol: p for p in parsed.positions}
+
+    # Three PPC lots: 100@18 + 50@19 + 50@20 = 3750 over 200 shares → 18.75
+    assert by_sym["PPC"].quantity == Decimal("200")
+    assert by_sym["PPC"].avg_cost == Decimal("18.75")
+    assert by_sym["PPC"].instrument_type == "equity"
+
+    # Single-lot positions still parse correctly
+    assert by_sym["AAPL"].quantity == Decimal("10")
+    assert by_sym["AAPL"].avg_cost == Decimal("180.00")
+
+    # Two VWCE lots; the second lacks costBasisPrice. Weighted avg = 100.00
+    # over the 20 shares that have a price; the 22-share lot still
+    # contributes to total quantity.
+    assert by_sym["VWCE"].quantity == Decimal("42")
+    assert by_sym["VWCE"].avg_cost == Decimal("100.00")
+    assert by_sym["VWCE"].instrument_type == "etf"
+
+    # No duplicate (symbol, instrument_type) pairs in the output — this is
+    # exactly what the holdings_account_symbol_type_uq constraint enforces.
+    keys = [(p.symbol, p.instrument_type) for p in parsed.positions]
+    assert len(keys) == len(set(keys))
+
+
 def test_parse_trades_extracts_trades():
     adapter = IBKRFlexAdapter(token="t", query_id_positions="qp", query_id_trades="qt")
     trades = adapter.parse_trades_xml(_read("ibkr_flex_trades.xml"))


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #118. Now that the FlexError 1001 fix unblocks the SendRequest step, the sync for account `a39c2e31-…` reaches `_upsert_positions` and immediately fails with:

```
UniqueViolation: duplicate key value violates unique constraint "holdings_account_symbol_type_uq"
DETAIL: Key (account_id, symbol, instrument_type)=(a39c2e31-…, PPC, equity) already exists.
```

The IBKR Flex Query for that account is configured at **lot granularity**, so the statement returns multiple `<OpenPosition>` rows per symbol (e.g. three lots of PPC at different cost bases). The parser yielded one `ParsedPosition` per lot, the upsert called `db.add()` for each, and the unique constraint fired on flush.

The other two IBKR accounts under the same user don't hit this — their Flex Queries report aggregated positions, or their holdings happen to be single-lot.

### Fix

Aggregate by `(symbol, instrument_type)` inside `parse_positions_xml`:

- `quantity` — summed across lots
- `avg_cost` — quantity-weighted average over lots that report a `costBasisPrice`. Lots without one still contribute to the total quantity but are excluded from the cost numerator/denominator (so the weighted avg reflects the lots we have prices for).
- `mark_price` — first non-null (uniform across lots in practice for a given trading day).

This keeps accounting logic in the adapter (single source of truth) and leaves `_upsert_positions` unchanged.

### Tests

New fixture `ibkr_flex_positions_lots.xml` covers:
- Three PPC lots at 18 / 19 / 20 → 200 shares, weighted avg 18.75
- Single-lot AAPL — still parses correctly
- Two VWCE lots, one with empty `costBasisPrice` — quantity sums to 42, weighted avg uses only the priced lot

Test asserts aggregated quantities, weighted-avg costs, and the absence of duplicate `(symbol, instrument_type)` keys in the parsed output. All 8 adapter tests pass.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (8/8 in `test_ibkr_flex_adapter.py`)
- [x] I have checked my changes for sensitive data or secrets

## Additional Context

Verified end-to-end against production after #118 deployed: the sync now successfully fetches and parses the IBKR statement, and the only remaining failure path was this lot-duplication issue — which this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregate IBKR Flex per-lot OpenPosition rows in the positions parser so each symbol/instrument pair is emitted once. This fixes duplicate holding upserts and the unique-constraint error for lot‑granularity Flex Queries.

- **Bug Fixes**
  - Aggregate by (symbol, instrument_type): quantity sums; avg_cost is quantity‑weighted over lots with costBasisPrice; lots without it count toward quantity but not the average; mark_price takes the first non‑null.
  - Kept aggregation in the adapter; no changes to holdings upsert logic.
  - Added `ibkr_flex_positions_lots.xml` and tests covering multi‑lot PPC, single‑lot AAPL, and VWCE with missing costBasisPrice; verifies math and no duplicate keys.

<sup>Written for commit 17f8b6d22c876ec715b6a3441b512f2d326819da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

