### PR TITLE
feat(demo): seed mock IBKR + standalone investments and lock down demo

### DIFF
--- a/backend/app/services/demo_seed_service.py
+++ b/backend/app/services/demo_seed_service.py
@@ -6,21 +6,27 @@ The service is designed for shared demo environments where data is reset on a sc
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import random
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from decimal import Decimal, ROUND_HALF_UP
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
 from sqlalchemy import cast, func, Date
 
 from app.models import (
     Account,
+    AccountBalance,
+    BrokerConnection,
+    BrokerTrade,
     CategorizationRule,
     Category,
     CsvImport,
+    Holding,
+    HoldingValuation,
     Property,
     RecurringTransaction,
     SubscriptionSuggestion,
@@ -366,6 +372,88 @@ SPIKE_TEMPLATES: tuple[TxTemplate, ...] = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Investments demo data
+#
+# The demo portfolio is seeded directly into holdings/valuations/account
+# balances with a deterministic price path. We deliberately DO NOT use the
+# shared `price_snapshots` cache or the IBKR sync service: prices there are
+# global (keyed by symbol/date) and would collide with real users holding
+# the same tickers. Keeping demo valuations self-contained makes the data
+# deterministic and fully isolated. The demo investment accounts are also
+# excluded from the nightly investment sync (see tasks/investment_tasks.py).
+# ---------------------------------------------------------------------------
+
+DEMO_INVESTMENT_START_DATE = date(2024, 1, 1)
+
+
+@dataclass(frozen=True)
+class HoldingSpec:
+    symbol: str
+    name: str
+    instrument_type: str  # "equity" | "etf" | "cash"
+    currency: str
+    quantity: Decimal
+    base_price: Decimal  # native-currency price at the position's open date
+    drift_annual: float  # fractional annual price drift (e.g. 0.12 = +12%/yr)
+    volatility: float  # daily deterministic noise amplitude (fraction of price)
+    avg_cost: Optional[Decimal]  # native average cost (None for cash)
+
+
+@dataclass(frozen=True)
+class InvestmentAccountSpec:
+    name: str
+    account_type: str  # "investment_brokerage" | "investment_manual"
+    institution: str
+    provider: str  # "ibkr_flex" | "manual"
+    currency: str  # account base currency
+    source: str  # holdings source tag: "ibkr_flex" | "manual"
+    has_broker_connection: bool
+    holdings: Tuple[HoldingSpec, ...]
+
+
+INVESTMENT_ACCOUNT_SPECS: Tuple[InvestmentAccountSpec, ...] = (
+    InvestmentAccountSpec(
+        name="Interactive Brokers",
+        account_type="investment_brokerage",
+        institution="Interactive Brokers",
+        provider="ibkr_flex",
+        currency="USD",
+        source="ibkr_flex",
+        has_broker_connection=True,
+        holdings=(
+            HoldingSpec("AAPL", "Apple Inc.", "equity", "USD",
+                        Decimal("40"), Decimal("185.00"), 0.14, 0.012, Decimal("164.20")),
+            HoldingSpec("MSFT", "Microsoft Corp.", "equity", "USD",
+                        Decimal("22"), Decimal("372.00"), 0.16, 0.011, Decimal("328.50")),
+            HoldingSpec("NVDA", "NVIDIA Corp.", "equity", "USD",
+                        Decimal("18"), Decimal("48.00"), 0.55, 0.022, Decimal("21.40")),
+            HoldingSpec("VWRA", "Vanguard FTSE All-World UCITS ETF", "etf", "USD",
+                        Decimal("60"), Decimal("108.00"), 0.10, 0.008, Decimal("95.30")),
+            HoldingSpec("USD", "Cash (USD)", "cash", "USD",
+                        Decimal("3150.00"), Decimal("1"), 0.0, 0.0, None),
+        ),
+    ),
+    InvestmentAccountSpec(
+        name="Personal Portfolio",
+        account_type="investment_manual",
+        institution="Self-managed",
+        provider="manual",
+        currency="EUR",
+        source="manual",
+        has_broker_connection=False,
+        holdings=(
+            HoldingSpec("IWDA", "iShares Core MSCI World UCITS ETF", "etf", "EUR",
+                        Decimal("85"), Decimal("82.00"), 0.11, 0.008, Decimal("71.90")),
+            HoldingSpec("VWCE", "Vanguard FTSE All-World UCITS ETF (Acc)", "etf", "EUR",
+                        Decimal("45"), Decimal("112.00"), 0.10, 0.008, Decimal("99.40")),
+            HoldingSpec("EUR", "Cash (EUR)", "cash", "EUR",
+                        Decimal("1850.00"), Decimal("1"), 0.0, 0.0, None),
+        ),
+    ),
+)
+
+
 class DemoSeedService:
     """Creates and refreshes a deterministic demo dataset for a specific user."""
 
@@ -374,6 +462,7 @@ class DemoSeedService:
         self.random_seed = random_seed
         self.rng = random.Random(random_seed)
         self._external_counter = 0
+        self._usd_eur_cache: Dict[date, Decimal] = {}
 
     def resolve_user(self, user_id: Optional[str] = None, email: Optional[str] = None) -> User:
         """Resolve demo user by user_id or email. Raises ValueError if missing."""
@@ -451,6 +540,12 @@ class DemoSeedService:
         balances_result = balance_service.calculate_account_balances(user.id, account_ids=account_ids)
         timeseries_result = balance_service.calculate_account_timeseries(user.id, account_ids=account_ids)
 
+        investments_result = self._seed_investments(
+            user=user,
+            start_date=seed_start,
+            end_date=seed_end,
+        )
+
         currency_set = sorted({account.currency for account in accounts if account.currency})
         summary = {
             "user_id": user.id,
@@ -470,6 +565,7 @@ class DemoSeedService:
             "functional_amounts": functional_result,
             "balances_calculated": balances_result,
             "timeseries_calculated": timeseries_result,
+            "investments": investments_result,
         }
 
         logger.info(
@@ -591,6 +687,8 @@ class DemoSeedService:
         balances_result = balance_service.calculate_account_balances(user.id, account_ids=touched_account_ids)
         timeseries_result = balance_service.calculate_account_timeseries(user.id, account_ids=touched_account_ids)
 
+        investments_result = self._append_investment_valuations_for_day(user=user, day=day)
+
         summary = {
             "skipped": False,
             "target_date": day.isoformat(),
@@ -599,6 +697,7 @@ class DemoSeedService:
             "functional_amounts": functional_result,
             "balances_calculated": balances_result,
             "timeseries_calculated": timeseries_result,
+            "investments": investments_result,
         }
         logger.info(
             "[DEMO_DAILY] Added %s transactions for user=%s date=%s",
@@ -848,6 +947,347 @@ class DemoSeedService:
             self.db.refresh(category)
 
         return categories
+
+    # ------------------------------------------------------------------
+    # Investments
+    # ------------------------------------------------------------------
+
+    def _seed_investments(
+        self,
+        user: User,
+        start_date: date,
+        end_date: date,
+    ) -> Dict[str, object]:
+        """Create the demo investment portfolio (IBKR + standalone) plus a
+        deterministic daily valuation history across [start_date, end_date].
+
+        Valuations and account balances are written directly (no PriceSnapshot
+        cache, no IBKR/price sync) so the data is deterministic and isolated
+        from real users who may hold the same tickers.
+        """
+        self._clear_investment_data(user.id)
+
+        now = datetime.utcnow()
+        accounts: List[Tuple[Account, InvestmentAccountSpec]] = []
+
+        for acct_spec in INVESTMENT_ACCOUNT_SPECS:
+            account = Account(
+                user_id=user.id,
+                name=acct_spec.name,
+                account_type=acct_spec.account_type,
+                institution=acct_spec.institution,
+                currency=acct_spec.currency,
+                provider=acct_spec.provider,
+                is_active=True,
+                starting_balance=Decimal("0"),
+                functional_balance=Decimal("0") if acct_spec.currency == "EUR" else None,
+                created_at=now,
+                updated_at=now,
+            )
+            self.db.add(account)
+            accounts.append((account, acct_spec))
+
+        self.db.commit()
+        for account, _ in accounts:
+            self.db.refresh(account)
+
+        holdings: List[Tuple[Holding, HoldingSpec, Account]] = []
+        for account, acct_spec in accounts:
+            if acct_spec.has_broker_connection:
+                self.db.add(BrokerConnection(
+                    user_id=user.id,
+                    account_id=account.id,
+                    provider=acct_spec.provider,
+                    # Demo accounts are excluded from the real investment sync,
+                    # so these credentials are never decrypted. A sentinel keeps
+                    # the NOT NULL column populated without SYLLOGIC_SECRET_KEY.
+                    credentials_encrypted="demo-disabled",
+                    last_sync_status="ok",
+                    last_sync_at=now,
+                    created_at=now,
+                    updated_at=now,
+                ))
+            for h_spec in acct_spec.holdings:
+                holding = Holding(
+                    user_id=user.id,
+                    account_id=account.id,
+                    symbol=h_spec.symbol,
+                    name=h_spec.name,
+                    currency=h_spec.currency,
+                    instrument_type=h_spec.instrument_type,
+                    quantity=h_spec.quantity,
+                    avg_cost=h_spec.avg_cost,
+                    as_of_date=start_date,
+                    source=acct_spec.source,
+                    created_at=now,
+                    updated_at=now,
+                )
+                self.db.add(holding)
+                holdings.append((holding, h_spec, account))
+
+        self.db.commit()
+        for holding, _, _ in holdings:
+            self.db.refresh(holding)
+
+        trades_created = self._create_broker_trades(holdings, start_date)
+        valuation_summary = self._seed_investment_valuations(
+            holdings, accounts, start_date, end_date
+        )
+
+        logger.info(
+            "[DEMO_SEED] Seeded investments for user=%s accounts=%s holdings=%s "
+            "trades=%s valuations=%s",
+            user.id,
+            len(accounts),
+            len(holdings),
+            trades_created,
+            valuation_summary["valuations"],
+        )
+
+        return {
+            "accounts_created": len(accounts),
+            "holdings_created": len(holdings),
+            "broker_trades_created": trades_created,
+            "valuations_created": valuation_summary["valuations"],
+            "account_balances_created": valuation_summary["account_balances"],
+            "date_range": {"start": start_date.isoformat(), "end": end_date.isoformat()},
+        }
+
+    def _clear_investment_data(self, user_id: str) -> None:
+        """Remove existing demo investment accounts (cascades to holdings,
+        valuations, broker connections/trades, and account balances)."""
+        self.db.query(Account).filter(
+            Account.user_id == user_id,
+            Account.account_type.in_(("investment_brokerage", "investment_manual")),
+        ).delete(synchronize_session=False)
+        self.db.commit()
+
+    def _create_broker_trades(
+        self,
+        holdings: List[Tuple[Holding, HoldingSpec, Account]],
+        start_date: date,
+    ) -> int:
+        """Create a small buy-only trade history for brokerage positions so the
+        holding-detail trades/lots views populate. Lots sum to the held qty."""
+        created = 0
+        lots = (
+            (Decimal("0.6"), 0, Decimal("0.94")),
+            (Decimal("0.4"), 45, Decimal("1.07")),
+        )
+        for holding, h_spec, account in holdings:
+            if h_spec.instrument_type == "cash" or holding.source != "ibkr_flex":
+                continue
+            if h_spec.avg_cost is None:
+                continue
+            lot_n = 0
+            for frac, day_offset, price_mult in lots:
+                qty = (Decimal(h_spec.quantity) * frac).quantize(Decimal("0.00000001"))
+                if qty <= 0:
+                    continue
+                lot_n += 1
+                self.db.add(BrokerTrade(
+                    account_id=account.id,
+                    symbol=h_spec.symbol,
+                    trade_date=start_date + timedelta(days=day_offset),
+                    side="buy",
+                    quantity=qty,
+                    price=(Decimal(h_spec.avg_cost) * price_mult).quantize(Decimal("0.0001")),
+                    currency=h_spec.currency,
+                    fees=Decimal("1.00"),
+                    external_id=f"demo-trade-{h_spec.symbol}-{lot_n}",
+                ))
+                created += 1
+        self.db.commit()
+        return created
+
+    def _seed_investment_valuations(
+        self,
+        holdings: List[Tuple[Holding, HoldingSpec, Account]],
+        accounts: List[Tuple[Account, InvestmentAccountSpec]],
+        start_date: date,
+        end_date: date,
+    ) -> Dict[str, int]:
+        holdings_by_account: Dict[str, List[Tuple[Holding, HoldingSpec]]] = {}
+        for holding, h_spec, account in holdings:
+            holdings_by_account.setdefault(str(account.id), []).append((holding, h_spec))
+
+        valuations = 0
+        account_balances = 0
+        for day in _iter_dates(start_date, end_date):
+            rate_usd_eur = self._usd_to_eur_rate(day)
+            for account, acct_spec in accounts:
+                total_user = Decimal("0")
+                total_acct = Decimal("0")
+                for holding, h_spec in holdings_by_account.get(str(account.id), []):
+                    price = self._demo_holding_price(h_spec, start_date, day)
+                    value_native = (Decimal(h_spec.quantity) * price).quantize(Decimal("0.00000001"))
+                    value_user = self._convert_currency(value_native, h_spec.currency, "EUR", rate_usd_eur)
+                    value_acct = self._convert_currency(value_native, h_spec.currency, acct_spec.currency, rate_usd_eur)
+                    self.db.add(HoldingValuation(
+                        holding_id=holding.id,
+                        date=day,
+                        quantity=h_spec.quantity,
+                        price=price,
+                        value_user_currency=value_user,
+                        is_stale=False,
+                    ))
+                    valuations += 1
+                    total_user += value_user
+                    total_acct += value_acct
+                self.db.add(AccountBalance(
+                    account_id=account.id,
+                    date=day,
+                    balance_in_account_currency=total_acct,
+                    balance_in_functional_currency=total_user,
+                ))
+                account_balances += 1
+
+        # Reflect the most recent valuation on the account headline balance.
+        last_rate = self._usd_to_eur_rate(end_date)
+        for account, acct_spec in accounts:
+            total_acct = Decimal("0")
+            for holding, h_spec in holdings_by_account.get(str(account.id), []):
+                price = self._demo_holding_price(h_spec, start_date, end_date)
+                value_native = (Decimal(h_spec.quantity) * price).quantize(Decimal("0.00000001"))
+                total_acct += self._convert_currency(value_native, h_spec.currency, acct_spec.currency, last_rate)
+            account.balance_available = total_acct
+            account.last_synced_at = datetime.utcnow()
+
+        self.db.commit()
+        return {"valuations": valuations, "account_balances": account_balances}
+
+    def _append_investment_valuations_for_day(
+        self,
+        user: User,
+        day: date,
+    ) -> Dict[str, object]:
+        """Add one day of investment valuations for the demo portfolio.
+
+        Idempotent: skips when the day is already valued. Safe no-op when the
+        demo investment accounts don't exist yet (a full reset creates them)."""
+        accounts = self.db.query(Account).filter(
+            Account.user_id == user.id,
+            Account.is_active == True,
+            Account.account_type.in_(("investment_brokerage", "investment_manual")),
+        ).all()
+        if not accounts:
+            return {"skipped": True, "reason": "NO_INVESTMENT_ACCOUNTS"}
+
+        holdings = self.db.query(Holding).filter(Holding.user_id == user.id).all()
+        holding_ids = [h.id for h in holdings]
+        if holding_ids:
+            already = self.db.query(HoldingValuation).filter(
+                HoldingValuation.holding_id.in_(holding_ids),
+                HoldingValuation.date == day,
+            ).first()
+            if already is not None:
+                return {"skipped": True, "reason": "ALREADY_VALUED", "target_date": day.isoformat()}
+
+        holdings_by_account: Dict[str, List[Holding]] = {}
+        for h in holdings:
+            holdings_by_account.setdefault(str(h.account_id), []).append(h)
+
+        spec_lookup = _holding_spec_lookup()
+        rate_usd_eur = self._usd_to_eur_rate(day)
+        valuations = 0
+        account_balances = 0
+        for account in accounts:
+            total_user = Decimal("0")
+            total_acct = Decimal("0")
+            for h in holdings_by_account.get(str(account.id), []):
+                spec = spec_lookup.get((h.source, h.symbol, h.instrument_type))
+                if spec is None:
+                    continue
+                anchor = h.as_of_date or DEMO_DEFAULT_START_DATE
+                price = self._demo_holding_price(spec, anchor, day)
+                value_native = (Decimal(h.quantity) * price).quantize(Decimal("0.00000001"))
+                value_user = self._convert_currency(value_native, h.currency, "EUR", rate_usd_eur)
+                value_acct = self._convert_currency(value_native, h.currency, account.currency, rate_usd_eur)
+                self.db.add(HoldingValuation(
+                    holding_id=h.id,
+                    date=day,
+                    quantity=h.quantity,
+                    price=price,
+                    value_user_currency=value_user,
+                    is_stale=False,
+                ))
+                valuations += 1
+                total_user += value_user
+                total_acct += value_acct
+            self.db.add(AccountBalance(
+                account_id=account.id,
+                date=day,
+                balance_in_account_currency=total_acct,
+                balance_in_functional_currency=total_user,
+            ))
+            account_balances += 1
+            account.balance_available = total_acct
+            account.last_synced_at = datetime.utcnow()
+
+        self.db.commit()
+        return {
+            "skipped": False,
+            "target_date": day.isoformat(),
+            "valuations": valuations,
+            "account_balances": account_balances,
+        }
+
+    def _demo_holding_price(self, h_spec: HoldingSpec, anchor: date, day: date) -> Decimal:
+        """Deterministic native-currency price for a holding on a given day.
+
+        Pure function of (seed, symbol, day) so a full reset and an incremental
+        daily append always agree on the price for any given date."""
+        if h_spec.instrument_type == "cash":
+            return Decimal("1")
+        day_index = (day - anchor).days
+        if day_index < 0:
+            day_index = 0
+        drift = 1.0 + h_spec.drift_annual * (day_index / 365.0)
+        digest = hashlib.sha256(
+            f"{self.random_seed}:{h_spec.symbol}:{day.isoformat()}".encode()
+        ).hexdigest()
+        unit = (int(digest[:8], 16) / 0xFFFFFFFF) * 2.0 - 1.0  # [-1, 1]
+        factor = drift * (1.0 + h_spec.volatility * unit)
+        if factor < 0.05:
+            factor = 0.05
+        price = Decimal(h_spec.base_price) * Decimal(str(factor))
+        return price.quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+
+    def _convert_currency(
+        self,
+        amount: Decimal,
+        src: str,
+        dst: str,
+        rate_usd_eur: Decimal,
+    ) -> Decimal:
+        src = (src or "").upper()
+        dst = (dst or "").upper()
+        if src == dst:
+            converted = Decimal(amount)
+        elif src == "USD" and dst == "EUR":
+            converted = Decimal(amount) * rate_usd_eur
+        elif src == "EUR" and dst == "USD":
+            converted = Decimal(amount) / rate_usd_eur
+        else:
+            converted = Decimal(amount)
+        return converted.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    def _usd_to_eur_rate(self, day: date) -> Decimal:
+        cached = self._usd_eur_cache.get(day)
+        if cached is not None:
+            return cached
+        rate: Optional[Decimal] = None
+        try:
+            rate = ExchangeRateService(self.db).get_exchange_rate(
+                base_currency="USD",
+                target_currency="EUR",
+                for_date=day,
+            )
+        except Exception:  # noqa: BLE001 - fall back to a static rate
+            rate = None
+        value = Decimal(str(rate)) if rate else Decimal("0.92")
+        self._usd_eur_cache[day] = value
+        return value
 
     def _build_transactions(
         self,
@@ -2043,6 +2483,17 @@ class DemoSeedService:
 
         self.db.commit()
         return {"updated": updated, "skipped": skipped, "failed": failed}
+
+
+def _holding_spec_lookup() -> Dict[Tuple[str, str, str], HoldingSpec]:
+    """Map (source, symbol, instrument_type) -> HoldingSpec for the demo
+    portfolio, so the daily append can recompute the same deterministic price
+    path from persisted holdings."""
+    lookup: Dict[Tuple[str, str, str], HoldingSpec] = {}
+    for acct_spec in INVESTMENT_ACCOUNT_SPECS:
+        for h_spec in acct_spec.holdings:
+            lookup[(acct_spec.source, h_spec.symbol, h_spec.instrument_type)] = h_spec
+    return lookup
 
 
 def _quantize_currency(value: Decimal) -> Decimal:

--- a/backend/tasks/investment_tasks.py
+++ b/backend/tasks/investment_tasks.py
@@ -64,21 +64,17 @@ def daily_investment_sync_all() -> dict:
     try:
         demo_user_id = _resolve_demo_user_id(db)
 
-        # Fail safe: when demo mode is enabled but the demo identity cannot be
-        # resolved, skip entirely rather than risk syncing the demo portfolio.
-        # Its seeded holdings have no valid Flex token and must keep their
-        # deterministic valuations untouched.
+        # Fail loudly on misconfiguration: demo mode is on but we can't identify
+        # the demo user. Raising (rather than returning a success-like result)
+        # surfaces the deploy error in task monitoring, and aborting before the
+        # sync still protects the seeded demo portfolio — its holdings have no
+        # valid Flex token and must keep their deterministic valuations.
         if _env_bool("DEMO_MODE", default=False) and not demo_user_id:
-            logger.warning(
-                "Skipping investment sync: DEMO_MODE enabled but demo user "
-                "identity is not configured/resolvable"
+            raise RuntimeError(
+                "DEMO_MODE is enabled but the demo user identity "
+                "(DEMO_SHARED_USER_ID / DEMO_SHARED_USER_EMAIL) is not configured "
+                "or resolvable; refusing to run investment sync."
             )
-            return {
-                "queued": 0,
-                "demo_excluded": False,
-                "skipped": True,
-                "reason": "MISSING_DEMO_USER_IDENTITY",
-            }
 
         broker_q = (
             db.query(Account)

--- a/backend/tasks/investment_tasks.py
+++ b/backend/tasks/investment_tasks.py
@@ -1,16 +1,43 @@
 from __future__ import annotations
 from datetime import date
 import logging
+import os
 from uuid import UUID
 from celery import shared_task
+from sqlalchemy import func
 
 from app.database import SessionLocal
-from app.models import Account, BrokerConnection
+from app.models import Account, BrokerConnection, User
 from app.services.investment_sync_service import InvestmentSyncService
 from app.services.exchange_rate_service import ExchangeRateService
 from app.integrations.ibkr_flex_adapter import FlexStatementNotReady
 
 logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_demo_user_id(db) -> str | None:
+    """Resolve the shared demo user's id when demo mode is enabled.
+
+    The demo portfolio is seeded directly with deterministic valuations and
+    must NOT be touched by the real IBKR/price sync (no valid Flex token, and
+    live price fetches would make the data non-deterministic)."""
+    if not _env_bool("DEMO_MODE", default=False):
+        return None
+    user_id = os.getenv("DEMO_SHARED_USER_ID")
+    if user_id:
+        return user_id
+    email = os.getenv("DEMO_SHARED_USER_EMAIL")
+    if not email:
+        return None
+    user = db.query(User).filter(func.lower(User.email) == email.strip().lower()).first()
+    return user.id if user else None
 
 
 class _FxAdapter:
@@ -35,21 +62,27 @@ class _FxAdapter:
 def daily_investment_sync_all() -> dict:
     db = SessionLocal()
     try:
-        broker_account_ids = [
-            a.id for a in db.query(Account)
+        demo_user_id = _resolve_demo_user_id(db)
+
+        broker_q = (
+            db.query(Account)
             .join(BrokerConnection, BrokerConnection.account_id == Account.id)
             .filter(Account.is_active == True, Account.account_type == "investment_brokerage")
-            .all()
-        ]
-        manual_account_ids = [
-            a.id for a in db.query(Account)
+        )
+        manual_q = (
+            db.query(Account)
             .filter(Account.is_active == True, Account.account_type == "investment_manual")
-            .all()
-        ]
+        )
+        if demo_user_id:
+            broker_q = broker_q.filter(Account.user_id != demo_user_id)
+            manual_q = manual_q.filter(Account.user_id != demo_user_id)
+
+        broker_account_ids = [a.id for a in broker_q.all()]
+        manual_account_ids = [a.id for a in manual_q.all()]
         all_ids = list(broker_account_ids) + list(manual_account_ids)
         for aid in all_ids:
             sync_investment_account.delay(str(aid))
-        return {"queued": len(all_ids)}
+        return {"queued": len(all_ids), "demo_excluded": bool(demo_user_id)}
     finally:
         db.close()
 

--- a/backend/tasks/investment_tasks.py
+++ b/backend/tasks/investment_tasks.py
@@ -64,6 +64,22 @@ def daily_investment_sync_all() -> dict:
     try:
         demo_user_id = _resolve_demo_user_id(db)
 
+        # Fail safe: when demo mode is enabled but the demo identity cannot be
+        # resolved, skip entirely rather than risk syncing the demo portfolio.
+        # Its seeded holdings have no valid Flex token and must keep their
+        # deterministic valuations untouched.
+        if _env_bool("DEMO_MODE", default=False) and not demo_user_id:
+            logger.warning(
+                "Skipping investment sync: DEMO_MODE enabled but demo user "
+                "identity is not configured/resolvable"
+            )
+            return {
+                "queued": 0,
+                "demo_excluded": False,
+                "skipped": True,
+                "reason": "MISSING_DEMO_USER_IDENTITY",
+            }
+
         broker_q = (
             db.query(Account)
             .join(BrokerConnection, BrokerConnection.account_id == Account.id)

--- a/frontend/app/(dashboard)/investments/[holdingId]/page.tsx
+++ b/frontend/app/(dashboard)/investments/[holdingId]/page.tsx
@@ -9,6 +9,8 @@ import {
 import { Header } from "@/components/layout/header";
 import { HoldingDetailView } from "@/components/investments/HoldingDetailView";
 import { rangeToDates } from "@/lib/utils/date-ranges";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
 
 export const dynamic = "force-dynamic";
 
@@ -26,11 +28,13 @@ export default async function HoldingDetailPage({
   const [holdings, portfolio] = await Promise.all([listHoldings(), getPortfolio()]);
   const holding = holdings.find((h) => h.id === holdingId);
   if (!holding) return notFound();
-  const [history, trades, lots] = await Promise.all([
+  const [history, trades, lots, session] = await Promise.all([
     getHoldingHistory(holdingId, from, to),
     getHoldingTrades(holdingId).catch(() => []),
     getHoldingLots(holdingId).catch(() => []),
+    getAuthenticatedSession(),
   ]);
+  const isDemoRestricted = isDemoRestrictedUserEmail(session?.user?.email);
   return (
     <>
       <Header title={holding.symbol} />
@@ -41,6 +45,7 @@ export default async function HoldingDetailPage({
           initialHistory={history}
           trades={trades}
           lots={lots}
+          isDemoRestricted={isDemoRestricted}
         />
       </div>
     </>

--- a/frontend/app/(dashboard)/investments/_sections.tsx
+++ b/frontend/app/(dashboard)/investments/_sections.tsx
@@ -6,17 +6,22 @@ import {
 import { InvestmentsOverview } from "@/components/investments/InvestmentsOverview";
 import { InvestmentsEmpty } from "@/components/investments/InvestmentsEmpty";
 import { rangeToDates } from "@/lib/utils/date-ranges";
+import { getAuthenticatedSession } from "@/lib/auth-helpers";
+import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
 
 export async function InvestmentsSection() {
   const { from, to } = rangeToDates("1M");
-  const [portfolio, holdings, history] = await Promise.all([
+  const [portfolio, holdings, history, session] = await Promise.all([
     getPortfolio(),
     listHoldings(),
     getPortfolioHistory(from, to),
+    getAuthenticatedSession(),
   ]);
 
+  const isDemoRestricted = isDemoRestrictedUserEmail(session?.user?.email);
+
   if (holdings.length === 0) {
-    return <InvestmentsEmpty />;
+    return <InvestmentsEmpty isDemoRestricted={isDemoRestricted} />;
   }
 
   return (
@@ -25,6 +30,7 @@ export async function InvestmentsSection() {
       holdings={holdings}
       initialHistory={history}
       initialRange="1M"
+      isDemoRestricted={isDemoRestricted}
     />
   );
 }

--- a/frontend/app/(dashboard)/investments/connect/page.tsx
+++ b/frontend/app/(dashboard)/investments/connect/page.tsx
@@ -1,10 +1,17 @@
+import { redirect } from "next/navigation";
 import { listInvestmentAccounts } from "@/lib/api/investments";
 import { Header } from "@/components/layout/header";
 import { ConnectPathPicker } from "@/components/investments/ConnectPathPicker";
+import { getCurrentUserProfile } from "@/lib/actions/settings";
+import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
 
 export const dynamic = "force-dynamic";
 
 export default async function ConnectPage() {
+  const user = await getCurrentUserProfile();
+  if (!user) redirect("/login");
+  if (isDemoRestrictedUserEmail(user.email)) redirect("/investments");
+
   const accounts = await listInvestmentAccounts();
   return (
     <>

--- a/frontend/components/investments/HoldingDetailView.tsx
+++ b/frontend/components/investments/HoldingDetailView.tsx
@@ -46,12 +46,14 @@ export function HoldingDetailView({
   initialHistory,
   trades = [],
   lots = [],
+  isDemoRestricted = false,
 }: {
   holding: Holding;
   portfolio: PortfolioSummary;
   initialHistory: ValuationPoint[];
   trades?: HoldingTrade[];
   lots?: HoldingLot[];
+  isDemoRestricted?: boolean;
 }) {
   const router = useRouter();
   const [range, setRange] = useState<Range>("1M");
@@ -166,7 +168,7 @@ export function HoldingDetailView({
           <Badge variant="outline" className="ml-auto">
             {accountName}
           </Badge>
-          {holding.source === "manual" && (
+          {!isDemoRestricted && holding.source === "manual" && (
             <Button size="sm" variant="outline" onClick={() => setEditOpen(true)}>
               <RiEditLine className="size-4" />
               Edit
@@ -377,7 +379,7 @@ export function HoldingDetailView({
         </TabsContent>
       </Tabs>
 
-      {holding.source === "manual" && (
+      {!isDemoRestricted && holding.source === "manual" && (
         <EditHoldingDialog
           open={editOpen}
           onOpenChange={setEditOpen}

--- a/frontend/components/investments/HoldingsTableHF.tsx
+++ b/frontend/components/investments/HoldingsTableHF.tsx
@@ -62,6 +62,7 @@ export function HoldingsTableHF({
   portfolioCurrencySymbol,
   onAddClick,
   onDelete,
+  readOnly = false,
 }: {
   holdings: Holding[];
   accountNames: Record<string, string>;
@@ -69,6 +70,7 @@ export function HoldingsTableHF({
   portfolioCurrencySymbol: string;
   onAddClick?: () => void;
   onDelete?: (id: string) => void;
+  readOnly?: boolean;
 }) {
   const router = useRouter();
   const [filter, setFilter] = useState<Filter>("All");
@@ -331,7 +333,7 @@ export function HoldingsTableHF({
                         >
                           View details
                         </DropdownMenuItem>
-                        {h.source === "manual" && (
+                        {!readOnly && h.source === "manual" && (
                           <>
                             <DropdownMenuItem onClick={() => setEditingId(h.id)}>
                               Edit

--- a/frontend/components/investments/InvestmentsEmpty.tsx
+++ b/frontend/components/investments/InvestmentsEmpty.tsx
@@ -10,9 +10,37 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 
-export function InvestmentsEmpty() {
+export function InvestmentsEmpty({
+  isDemoRestricted = false,
+}: {
+  isDemoRestricted?: boolean;
+}) {
   const router = useRouter();
   const go = () => router.push("/investments/connect");
+
+  if (isDemoRestricted) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-10">
+        <div className="max-w-xl w-full">
+          <Card className="rounded-none">
+            <CardContent className="px-8 py-10 flex flex-col items-center text-center gap-3">
+              <div className="w-11 h-11 border border-border flex items-center justify-center bg-muted/40">
+                <RiLineChartLine size={20} className="text-muted-foreground" />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <div className="text-base font-semibold">No holdings yet</div>
+                <div className="text-xs text-muted-foreground leading-relaxed max-w-[340px]">
+                  Connecting brokers and adding holdings is disabled for the demo
+                  account.
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex-1 flex items-center justify-center p-10">
       <div className="max-w-xl w-full flex flex-col">

--- a/frontend/components/investments/InvestmentsOverview.tsx
+++ b/frontend/components/investments/InvestmentsOverview.tsx
@@ -28,11 +28,13 @@ export function InvestmentsOverview({
   holdings,
   initialHistory,
   initialRange = "1M",
+  isDemoRestricted = false,
 }: {
   portfolio: PortfolioSummary;
   holdings: Holding[];
   initialHistory: ValuationPoint[];
   initialRange?: Range;
+  isDemoRestricted?: boolean;
 }) {
   const router = useRouter();
   const [range, setRange] = useState<Range>(initialRange);
@@ -147,7 +149,7 @@ export function InvestmentsOverview({
 
   const sym = currencySymbol(portfolio.currency);
 
-  const refreshButton = (
+  const refreshButton = isDemoRestricted ? null : (
     <Button
       variant="outline"
       size="sm"
@@ -198,8 +200,13 @@ export function InvestmentsOverview({
         accountNames={accountNames}
         accountsCount={portfolio.accounts.length}
         portfolioCurrencySymbol={sym}
-        onAddClick={() => router.push("/investments/connect")}
-        onDelete={onDelete}
+        onAddClick={
+          isDemoRestricted
+            ? undefined
+            : () => router.push("/investments/connect")
+        }
+        onDelete={isDemoRestricted ? undefined : onDelete}
+        readOnly={isDemoRestricted}
       />
     </div>
   );

--- a/frontend/lib/api/investments.ts
+++ b/frontend/lib/api/investments.ts
@@ -3,6 +3,17 @@
 import { getAuthenticatedSession, requireAuth } from "@/lib/auth-helpers";
 import { getBackendBaseUrl } from "@/lib/backend-url";
 import { createInternalAuthHeaders } from "@/lib/internal-auth";
+import {
+  isDemoRestrictedUserEmail,
+  DEMO_RESTRICTED_ACTION_ERROR,
+} from "@/lib/demo-access";
+
+async function assertNotDemoRestricted(): Promise<void> {
+  const session = await getAuthenticatedSession();
+  if (isDemoRestrictedUserEmail(session?.user?.email)) {
+    throw new Error(DEMO_RESTRICTED_ACTION_ERROR);
+  }
+}
 
 export type Holding = {
   id: string;
@@ -205,6 +216,7 @@ export async function createBrokerConnection(payload: {
   account_name: string;
   base_currency: string;
 }): Promise<{ connection_id: string; account_id: string }> {
+  await assertNotDemoRestricted();
   const resp = await signedFetch("POST", "/api/investments/broker-connections", {
     body: payload,
   });
@@ -215,6 +227,7 @@ export async function createManualAccount(
   name: string,
   base_currency: string,
 ): Promise<{ account_id: string }> {
+  await assertNotDemoRestricted();
   const resp = await signedFetch("POST", "/api/investments/manual-accounts", {
     body: { name, base_currency },
   });
@@ -232,6 +245,7 @@ export async function addManualHolding(
     avg_cost?: string;
   },
 ): Promise<{ holding_id: string }> {
+  await assertNotDemoRestricted();
   const resp = await signedFetch(
     "POST",
     `/api/investments/manual-accounts/${accountId}/holdings`,
@@ -243,10 +257,14 @@ export async function addManualHolding(
 export async function deleteHolding(holdingId: string): Promise<void> {
   const session = await getAuthenticatedSession();
   if (!session?.user?.id) throw new Error("Not authenticated");
+  if (isDemoRestrictedUserEmail(session.user.email)) {
+    throw new Error(DEMO_RESTRICTED_ACTION_ERROR);
+  }
   await signedFetch("DELETE", `/api/investments/holdings/${holdingId}`);
 }
 
 export async function syncAllInvestments(): Promise<{ count: number }> {
+  await assertNotDemoRestricted();
   const resp = await signedFetch("POST", "/api/investments/sync-all");
   return readJsonOrThrow<{ count: number }>(resp);
 }
@@ -263,6 +281,9 @@ export async function updateHolding(
 ): Promise<void> {
   const session = await getAuthenticatedSession();
   if (!session?.user?.id) throw new Error("Not authenticated");
+  if (isDemoRestrictedUserEmail(session.user.email)) {
+    throw new Error(DEMO_RESTRICTED_ACTION_ERROR);
+  }
   const resp = await signedFetch("PATCH", `/api/investments/holdings/${holdingId}`, {
     body: payload,
   });


### PR DESCRIPTION
## Summary

The demo account regenerates data daily but had no investment data and could still reach the broker/manual connect flows. This PR seeds a realistic, deterministic demo investment portfolio and locks down all connect/edit entry points for the demo user. (Bank connectivity was already blocked for demo, so no changes there.)

### Backend — seed mock investments
- **`demo_seed_service.py`**: new `INVESTMENT_ACCOUNT_SPECS` for an **IBKR brokerage** account (source `ibkr_flex`: AAPL/MSFT/NVDA/VWRA + USD cash) and a **standalone manual** account (source `manual`: IWDA/VWCE + EUR cash). `_seed_investments()` creates the accounts, a sentinel `BrokerConnection`, holdings, buy-only `BrokerTrade` lots, and a deterministic `HoldingValuation` + `AccountBalance` history. Wired into the nightly reset (`seed_for_user`) and the idempotent daily append.
  - Prices come from `_demo_holding_price()`, a pure function of `(seed, symbol, day)`, so a full reset and an incremental daily append always agree on any date's price.
  - Writes valuations/balances directly — bypasses the shared `price_snapshots` cache and the IBKR/price sync — so demo data is fully isolated from real users holding the same tickers.
- **`investment_tasks.py`**: `daily_investment_sync_all` now excludes the demo user's investment accounts (resolved via `DEMO_SHARED_USER_ID`/`DEMO_SHARED_USER_EMAIL` when `DEMO_MODE` is on) so the real sync never clobbers seeded data. No-op when demo mode is off.

### Frontend — lock down connect/edit for demo
- Redirect demo from `/investments/connect` (mirrors the existing bank `connect-bank` guard).
- Enforce `DEMO_RESTRICTED_ACTION_ERROR` in investment server actions (`createBrokerConnection`, `createManualAccount`, `addManualHolding`, `updateHolding`, `deleteHolding`, `syncAllInvestments`).
- Thread `isDemoRestricted` through the UI to hide connect/add/edit/delete/refresh entry points.

## Test plan
- [ ] Run `pnpm exec tsc --noEmit` in an installed checkout (could not run here — worktree has no `node_modules`).
- [ ] Run backend suite against Postgres (`test_demo_seed_service`, `test_investment_tasks`) — SQLite can't render the existing `JSONB` column so these don't run locally.
- [ ] As the demo account: investments page shows both portfolios with a populated chart; holding detail shows trades/lots; all connect/add/edit/delete/refresh entry points are gone.
- [ ] Confirm a nightly reset + daily append keep valuations fresh and consistent, and the sync job skips the demo accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds a realistic demo investment portfolio (mock IBKR + standalone manual) with deterministic daily valuations, and locks down all connect/edit actions for the demo user. Adds a strict fail-safe that raises and aborts sync if the demo identity isn’t configured.

- **New Features**
  - Backend: create demo investment accounts, holdings, buy-only broker trades, and daily `HoldingValuation`/`AccountBalance` history with a deterministic price function; exclude the demo user from `daily_investment_sync_all` so real sync never overwrites seeded data.
  - Frontend: redirect demo users from `/investments/connect`, enforce `DEMO_RESTRICTED_ACTION_ERROR` in investment actions (`createBrokerConnection`, `createManualAccount`, `addManualHolding`, `updateHolding`, `deleteHolding`, `syncAllInvestments`), and hide connect/add/edit/delete/refresh UI across overview, holding detail, and empty states when `isDemoRestricted` is true.

- **Bug Fixes**
  - Fail-safe: when `DEMO_MODE` is on but the demo user can’t be resolved, raise and abort the investment sync to protect seeded demo portfolios and surface the misconfiguration.

<sup>Written for commit 8dff91bf43651f90a0920d909681720ad1320737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

