### PR TITLE
fix(landing): correct Railway template deploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="https://github.com/orgs/syllogic-ai/packages">
     <img src="https://img.shields.io/badge/Docker-GHCR-blue?logo=docker" alt="Docker" />
   </a>
-  <a href="https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=hero_railway">
+  <a href="https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=hero_railway">
     <img src="https://img.shields.io/badge/Deploy-Railway-blueviolet?logo=railway" alt="Deploy on Railway" />
   </a>
 </p>
@@ -105,7 +105,7 @@ For advanced configuration (TLS, custom domains, MCP server), see [`deploy/compo
 
 ### Railway (One-Click)
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=quickstart_railway)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=quickstart_railway)
 
 The template configures everything through Railway **Shared Variables** — one place
 that every service reads from. The required secrets (`POSTGRES_PASSWORD`,

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -34,7 +34,7 @@ For the manual setup, use [README.md](README.md#quick-start).
 
 ### 3. Deploy on Railway
 
-[Deploy on Railway](https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_source=github&utm_medium=start_here&utm_campaign=oss_promotion&utm_content=railway_cta)
+[Deploy on Railway](https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_source=github&utm_medium=start_here&utm_campaign=oss_promotion&utm_content=railway_cta)
 
 ## Next links
 

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -2,7 +2,7 @@
 
 ## One-Click Deploy
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_medium=integration&utm_source=template&utm_campaign=generic)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
 Keep secrets in Railway Shared Variables, not in the URL.
 

--- a/landing/lib/links.ts
+++ b/landing/lib/links.ts
@@ -48,19 +48,19 @@ export const LINKS = {
   },
   railway: {
     hero: withUtm(
-      "https://railway.com/deploy/syllogic?referralCode=25KFsK",
+      "https://railway.com/deploy/N98lwA?referralCode=25KFsK",
       "hero_railway",
       "landing",
       "site"
     ),
     install: withUtm(
-      "https://railway.com/deploy/syllogic?referralCode=25KFsK",
+      "https://railway.com/deploy/N98lwA?referralCode=25KFsK",
       "install_railway",
       "landing",
       "site"
     ),
     readme: withUtm(
-      "https://railway.com/deploy/syllogic?referralCode=25KFsK",
+      "https://railway.com/deploy/N98lwA?referralCode=25KFsK",
       "readme_railway",
       "github",
       "readme"


### PR DESCRIPTION
## Summary
- The Railway "Deploy" link used the slug `syllogic`, which returns a 404
- Replaced it with the correct template ID `N98lwA` across the landing page (`landing/lib/links.ts`), `README.md`, `START_HERE.md`, and `deploy/railway/README.md`
- Landing page UTM tracking via `withUtm()` is preserved

## Test plan
- [ ] Click the "Deploy on Railway" CTA on the landing page and confirm it resolves to the template instead of 404
- [ ] Verify README/START_HERE Railway badges link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed broken Railway deploy links across the landing page and docs by switching from slug `syllogic` to the correct template ID `N98lwA`. One‑click deploy now works. UTM tracking via `withUtm()` is unchanged.

- **Bug Fixes**
  - Updated Railway links in `landing/lib/links.ts` (hero, install, readme).
  - Fixed badges/CTAs in `README.md`, `START_HERE.md`, and `deploy/railway/README.md` to point to `N98lwA`.

<sup>Written for commit 724d7664e01daba766b318b5b420e4d447ed91df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

