### PR TITLE
fix(landing): revert Railway deploy link to syllogic slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="https://github.com/orgs/syllogic-ai/packages">
     <img src="https://img.shields.io/badge/Docker-GHCR-blue?logo=docker" alt="Docker" />
   </a>
-  <a href="https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=hero_railway">
+  <a href="https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=hero_railway">
     <img src="https://img.shields.io/badge/Deploy-Railway-blueviolet?logo=railway" alt="Deploy on Railway" />
   </a>
 </p>
@@ -105,7 +105,7 @@ For advanced configuration (TLS, custom domains, MCP server), see [`deploy/compo
 
 ### Railway (One-Click)
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=quickstart_railway)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_source=github&utm_medium=readme&utm_campaign=oss_promotion&utm_content=quickstart_railway)
 
 The template configures everything through Railway **Shared Variables** — one place
 that every service reads from. The required secrets (`POSTGRES_PASSWORD`,

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -34,7 +34,7 @@ For the manual setup, use [README.md](README.md#quick-start).
 
 ### 3. Deploy on Railway
 
-[Deploy on Railway](https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_source=github&utm_medium=start_here&utm_campaign=oss_promotion&utm_content=railway_cta)
+[Deploy on Railway](https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_source=github&utm_medium=start_here&utm_campaign=oss_promotion&utm_content=railway_cta)
 
 ## Next links
 

--- a/deploy/railway/README.md
+++ b/deploy/railway/README.md
@@ -2,7 +2,7 @@
 
 ## One-Click Deploy
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/N98lwA?referralCode=25KFsK&utm_medium=integration&utm_source=template&utm_campaign=generic)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/syllogic?referralCode=25KFsK&utm_medium=integration&utm_source=template&utm_campaign=generic)
 
 Keep secrets in Railway Shared Variables, not in the URL.
 

--- a/landing/lib/links.ts
+++ b/landing/lib/links.ts
@@ -48,19 +48,19 @@ export const LINKS = {
   },
   railway: {
     hero: withUtm(
-      "https://railway.com/deploy/N98lwA?referralCode=25KFsK",
+      "https://railway.com/deploy/syllogic?referralCode=25KFsK",
       "hero_railway",
       "landing",
       "site"
     ),
     install: withUtm(
-      "https://railway.com/deploy/N98lwA?referralCode=25KFsK",
+      "https://railway.com/deploy/syllogic?referralCode=25KFsK",
       "install_railway",
       "landing",
       "site"
     ),
     readme: withUtm(
-      "https://railway.com/deploy/N98lwA?referralCode=25KFsK",
+      "https://railway.com/deploy/syllogic?referralCode=25KFsK",
       "readme_railway",
       "github",
       "readme"


### PR DESCRIPTION
## Summary
- The `N98lwA` template ID from #128 returns "template not found"
- The correct, working Railway template is the `syllogic` slug
- Reverts the deploy link across landing page, README, START_HERE, and deploy docs

## Test plan
- [ ] Click "Deploy on Railway" CTA on the landing page and confirm the template loads (no 404 / "template not found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the broken Railway deploy button by reverting the template link from the `N98lwA` ID to the working `syllogic` slug. Updates the landing links, README, START_HERE, and deploy docs so one-click deploy opens the correct template.

<sup>Written for commit e9a9e1870cdbfddde044ac1192eb7a2a79d33b7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

