### PR TITLE
feat(demo): make Settings read-only for the demo account

### DIFF
--- a/frontend/app/api/people/[id]/route.ts
+++ b/frontend/app/api/people/[id]/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { updatePerson, deletePerson, getPeople } from "@/lib/people";
 import { uploadPersonAvatar, deletePersonAvatar, avatarUrl } from "@/lib/people/avatars";
-import { requireAuth } from "@/lib/auth-helpers";
+import { isDemoRestrictedSession, requireAuth } from "@/lib/auth-helpers";
+import { DEMO_RESTRICTED_ACTION_ERROR } from "@/lib/demo-access";
 
 const patchSchema = z.object({
   name: z.string().min(1).max(255).optional(),
@@ -17,6 +18,9 @@ const patchSchema = z.object({
 export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   const userId = await requireAuth();
   if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (await isDemoRestrictedSession()) {
+    return NextResponse.json({ error: DEMO_RESTRICTED_ACTION_ERROR }, { status: 403 });
+  }
   const { id } = await ctx.params;
   const form = await req.formData();
   const parsed = patchSchema.safeParse({
@@ -68,6 +72,9 @@ export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: strin
 export async function DELETE(_req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
   const userId = await requireAuth();
   if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (await isDemoRestrictedSession()) {
+    return NextResponse.json({ error: DEMO_RESTRICTED_ACTION_ERROR }, { status: 403 });
+  }
   const { id } = await ctx.params;
   try {
     // Capture the avatar path before deletion to clean up.

--- a/frontend/app/api/people/route.ts
+++ b/frontend/app/api/people/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { getPeople, createPerson, updatePerson } from "@/lib/people";
 import { uploadPersonAvatar, avatarUrl } from "@/lib/people/avatars";
-import { requireAuth } from "@/lib/auth-helpers";
+import { isDemoRestrictedSession, requireAuth } from "@/lib/auth-helpers";
+import { DEMO_RESTRICTED_ACTION_ERROR } from "@/lib/demo-access";
 
 export async function GET() {
   const userId = await requireAuth();
@@ -24,6 +25,9 @@ const createSchema = z.object({
 export async function POST(req: NextRequest) {
   const userId = await requireAuth();
   if (!userId) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  if (await isDemoRestrictedSession()) {
+    return NextResponse.json({ error: DEMO_RESTRICTED_ACTION_ERROR }, { status: 403 });
+  }
   const form = await req.formData();
   const parsed = createSchema.safeParse({
     name: form.get("name"),

--- a/frontend/components/household/people-list.tsx
+++ b/frontend/components/household/people-list.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { PersonForm, type PersonFormValues } from "./person-form";
 import { PersonAvatar } from "./person-avatar";
 import { clearOwnerBadgesCache } from "./owner-badges";
+import { DemoReadOnlyNotice } from "@/components/settings/demo-readonly-notice";
 
 type Person = {
   id: string;
@@ -23,7 +24,8 @@ function buildFormData(values: PersonFormValues): FormData {
   return fd;
 }
 
-export function PeopleList(props: { initialPeople: Person[] }) {
+export function PeopleList(props: { initialPeople: Person[]; readOnly?: boolean }) {
+  const readOnly = props.readOnly ?? false;
   const [people, setPeople] = useState(props.initialPeople);
   const [adding, setAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -63,6 +65,7 @@ export function PeopleList(props: { initialPeople: Person[] }) {
 
   return (
     <div className="space-y-4">
+      {readOnly && <DemoReadOnlyNotice />}
       <ul className="divide-y rounded-md border">
         {people.map((p) => (
           <li key={p.id} className="flex items-center gap-3 p-3">
@@ -71,10 +74,12 @@ export function PeopleList(props: { initialPeople: Person[] }) {
             {p.kind === "self" && (
               <span className="text-xs text-muted-foreground">you</span>
             )}
-            <Button variant="ghost" size="sm" onClick={() => setEditingId(p.id)}>
-              Edit
-            </Button>
-            {p.kind !== "self" && (
+            {!readOnly && (
+              <Button variant="ghost" size="sm" onClick={() => setEditingId(p.id)}>
+                Edit
+              </Button>
+            )}
+            {!readOnly && p.kind !== "self" && (
               <Button variant="ghost" size="sm" onClick={() => remove(p.id)}>
                 Delete
               </Button>
@@ -101,20 +106,21 @@ export function PeopleList(props: { initialPeople: Person[] }) {
         </div>
       )}
 
-      {adding ? (
-        <div className="rounded-md border p-4">
-          <h2 className="mb-3 font-medium">Add person</h2>
-          <PersonForm
-            submitLabel="Add person"
-            onSubmit={create}
-            onCancel={() => setAdding(false)}
-          />
-        </div>
-      ) : (
-        <Button variant="outline" onClick={() => setAdding(true)}>
-          Add person
-        </Button>
-      )}
+      {!readOnly &&
+        (adding ? (
+          <div className="rounded-md border p-4">
+            <h2 className="mb-3 font-medium">Add person</h2>
+            <PersonForm
+              submitLabel="Add person"
+              onSubmit={create}
+              onCancel={() => setAdding(false)}
+            />
+          </div>
+        ) : (
+          <Button variant="outline" onClick={() => setAdding(true)}>
+            Add person
+          </Button>
+        ))}
     </div>
   );
 }

--- a/frontend/components/onboarding/category-row.tsx
+++ b/frontend/components/onboarding/category-row.tsx
@@ -8,9 +8,10 @@ interface CategoryRowProps {
   category: CategoryInput;
   onEdit: () => void;
   onDelete: () => void;
+  readOnly?: boolean;
 }
 
-export function CategoryRow({ category, onEdit, onDelete }: CategoryRowProps) {
+export function CategoryRow({ category, onEdit, onDelete, readOnly = false }: CategoryRowProps) {
   const isSystem = category.isSystem ?? false;
 
   return (
@@ -39,30 +40,32 @@ export function CategoryRow({ category, onEdit, onDelete }: CategoryRowProps) {
       </div>
 
       {/* Action buttons */}
-      <div className="flex items-center gap-1 shrink-0">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={onEdit}
-          title={isSystem ? "Edit description and categorization instructions" : "Edit category"}
-        >
-          <RiEditLine className="h-4 w-4" />
-        </Button>
-        {!isSystem && (
+      {!readOnly && (
+        <div className="flex items-center gap-1 shrink-0">
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            className="h-8 w-8 text-destructive hover:text-destructive"
-            onClick={onDelete}
-            title="Delete category"
+            className="h-8 w-8"
+            onClick={onEdit}
+            title={isSystem ? "Edit description and categorization instructions" : "Edit category"}
           >
-            <RiDeleteBinLine className="h-4 w-4" />
+            <RiEditLine className="h-4 w-4" />
           </Button>
-        )}
-      </div>
+          {!isSystem && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-destructive hover:text-destructive"
+              onClick={onDelete}
+              title="Delete category"
+            >
+              <RiDeleteBinLine className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/onboarding/profile-photo-upload.tsx
+++ b/frontend/components/onboarding/profile-photo-upload.tsx
@@ -11,6 +11,7 @@ interface ProfilePhotoUploadProps {
   onChange: (file: File | null) => void;
   defaultImage?: string | null;
   name?: string;
+  disabled?: boolean;
 }
 
 export function ProfilePhotoUpload({
@@ -18,6 +19,7 @@ export function ProfilePhotoUpload({
   onChange,
   defaultImage,
   name,
+  disabled = false,
 }: ProfilePhotoUploadProps) {
   const [preview, setPreview] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
@@ -90,13 +92,14 @@ export function ProfilePhotoUpload({
     <div className="flex flex-col items-start gap-4">
       <div
         className={cn(
-          "relative cursor-pointer transition-all",
+          "relative transition-all",
+          disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
           isDragging && "ring-2 ring-primary ring-offset-2"
         )}
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onClick={() => inputRef.current?.click()}
+        onDrop={disabled ? undefined : handleDrop}
+        onDragOver={disabled ? undefined : handleDragOver}
+        onDragLeave={disabled ? undefined : handleDragLeave}
+        onClick={disabled ? undefined : () => inputRef.current?.click()}
       >
         <Avatar className="h-24 w-24">
           {displayImage ? (
@@ -105,10 +108,12 @@ export function ProfilePhotoUpload({
             <AvatarFallback className="text-2xl">{getInitials(name)}</AvatarFallback>
           )}
         </Avatar>
-        <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity hover:opacity-100">
-          <RiCameraLine className="h-6 w-6 text-white" />
-        </div>
-        {displayImage && (
+        {!disabled && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity hover:opacity-100">
+            <RiCameraLine className="h-6 w-6 text-white" />
+          </div>
+        )}
+        {displayImage && !disabled && (
           <Button
             type="button"
             variant="destructive"
@@ -129,6 +134,7 @@ export function ProfilePhotoUpload({
         accept="image/*"
         className="hidden"
         onChange={handleInputChange}
+        disabled={disabled}
       />
     </div>
   );

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -26,6 +26,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { triggerSync, disconnectBank, triggerRecategorize } from "@/lib/actions/bank-connections";
+import { DemoReadOnlyNotice } from "./demo-readonly-notice";
 type BankConnectionItem = {
   id: string;
   aspspName: string;
@@ -39,6 +40,7 @@ type BankConnectionItem = {
 
 interface BankConnectionsManagerProps {
   connections: BankConnectionItem[];
+  isDemoUser?: boolean;
 }
 
 type SyncProgress = {
@@ -50,7 +52,7 @@ type SyncProgress = {
   started_at?: string;
 };
 
-export function BankConnectionsManager({ connections }: BankConnectionsManagerProps) {
+export function BankConnectionsManager({ connections, isDemoUser = false }: BankConnectionsManagerProps) {
   const router = useRouter();
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
   const [recategorizingIds, setRecategorizingIds] = useState<Set<string>>(new Set());
@@ -268,6 +270,7 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
 
   return (
     <div className="space-y-6">
+      {isDemoUser && <DemoReadOnlyNotice />}
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-lg font-semibold">Bank Connections</h2>
@@ -275,13 +278,20 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
             Connect your bank accounts via Open Banking to automatically sync transactions.
           </p>
         </div>
-        <Link
-          href="/settings/connect-bank"
-          className={buttonVariants({ variant: "default", size: "default" })}
-        >
-          <RiAddLine className="mr-1.5 h-4 w-4" />
-          Connect Bank
-        </Link>
+        {isDemoUser ? (
+          <Button variant="default" size="default" disabled>
+            <RiAddLine className="mr-1.5 h-4 w-4" />
+            Connect Bank
+          </Button>
+        ) : (
+          <Link
+            href="/settings/connect-bank"
+            className={buttonVariants({ variant: "default", size: "default" })}
+          >
+            <RiAddLine className="mr-1.5 h-4 w-4" />
+            Connect Bank
+          </Link>
+        )}
       </div>
 
       {activeConnections.length === 0 ? (
@@ -355,6 +365,7 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                   )}
                 </div>
               </div>
+              {!isDemoUser && (
               <div className="flex items-center gap-2">
                 {connection.status === "active" && (
                   <Button
@@ -419,6 +430,7 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                   </AlertDialogContent>
                 </AlertDialog>
               </div>
+              )}
               </div>
               {syncingIds.has(connection.id) && (
                 <div className="mt-3 space-y-1.5">

--- a/frontend/components/settings/category-manager.tsx
+++ b/frontend/components/settings/category-manager.tsx
@@ -16,6 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { CategoryRow } from "@/components/onboarding/category-row";
 import { CategoryFormDialog } from "@/components/onboarding/category-form-dialog";
 import { DeleteCategoryDialog } from "./delete-category-dialog";
+import { DemoReadOnlyNotice } from "./demo-readonly-notice";
 import {
   createCategory,
   updateCategory,
@@ -30,9 +31,10 @@ import { groupCategoriesByType, getCategoryTypeLabel, type CategoryType } from "
 
 interface CategoryManagerProps {
   initialCategories: Category[];
+  isDemoUser?: boolean;
 }
 
-export function CategoryManager({ initialCategories }: CategoryManagerProps) {
+export function CategoryManager({ initialCategories, isDemoUser = false }: CategoryManagerProps) {
   const router = useRouter();
   const [categories, setCategories] = useState<Category[]>(initialCategories);
   const [activeTab, setActiveTab] = useState<CategoryType>("expense");
@@ -216,6 +218,7 @@ export function CategoryManager({ initialCategories }: CategoryManagerProps) {
                   category={input}
                   onEdit={() => handleEdit(category)}
                   onDelete={() => handleDelete(category)}
+                  readOnly={isDemoUser}
                 />
               );
             })
@@ -223,19 +226,21 @@ export function CategoryManager({ initialCategories }: CategoryManagerProps) {
         </div>
 
         {/* Add button */}
-        <div className="pt-4">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={() => handleAddClick(categoryType)}
-            disabled={isLoading}
-          >
-            <RiAddLine className="mr-2 h-4 w-4" />
-            Add {getCategoryTypeLabel(categoryType)} Category
-          </Button>
-        </div>
+        {!isDemoUser && (
+          <div className="pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => handleAddClick(categoryType)}
+              disabled={isLoading}
+            >
+              <RiAddLine className="mr-2 h-4 w-4" />
+              Add {getCategoryTypeLabel(categoryType)} Category
+            </Button>
+          </div>
+        )}
       </div>
     );
   };
@@ -250,6 +255,7 @@ export function CategoryManager({ initialCategories }: CategoryManagerProps) {
           </CardDescription>
         </CardHeader>
         <CardContent>
+          {isDemoUser && <DemoReadOnlyNotice className="mb-4" />}
           <Tabs
             value={activeTab}
             onValueChange={(v) => setActiveTab(v as CategoryType)}

--- a/frontend/components/settings/demo-readonly-notice.tsx
+++ b/frontend/components/settings/demo-readonly-notice.tsx
@@ -1,0 +1,20 @@
+import { RiEyeLine } from "@remixicon/react";
+
+/**
+ * Inline banner shown on settings panels when the current user is the
+ * restricted demo account. Settings remain fully viewable but every
+ * mutating control is disabled (and blocked server-side as a backstop).
+ */
+export function DemoReadOnlyNotice({ className = "" }: { className?: string }) {
+  return (
+    <div
+      className={`flex items-center gap-2 border border-border bg-muted p-3 text-sm text-muted-foreground ${className}`}
+    >
+      <RiEyeLine className="h-4 w-4 shrink-0" />
+      <span>
+        You&apos;re exploring the demo account. Settings are read-only — changes
+        are disabled.
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/settings/household-tab.tsx
+++ b/frontend/components/settings/household-tab.tsx
@@ -8,7 +8,13 @@ type Person = {
   avatarUrl?: string | null;
 };
 
-export function HouseholdTab({ people }: { people: Person[] }) {
+export function HouseholdTab({
+  people,
+  isDemoUser = false,
+}: {
+  people: Person[];
+  isDemoUser?: boolean;
+}) {
   return (
     <div className="max-w-2xl space-y-6">
       <div>
@@ -17,7 +23,7 @@ export function HouseholdTab({ people }: { people: Person[] }) {
           Track who owns what — useful for joint accounts and household-level reports.
         </p>
       </div>
-      <PeopleList initialPeople={people} />
+      <PeopleList initialPeople={people} readOnly={isDemoUser} />
     </div>
   );
 }

--- a/frontend/components/settings/profile-editor.tsx
+++ b/frontend/components/settings/profile-editor.tsx
@@ -15,14 +15,16 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ProfilePhotoUpload } from "@/components/onboarding/profile-photo-upload";
+import { DemoReadOnlyNotice } from "@/components/settings/demo-readonly-notice";
 import { updateUserProfile } from "@/lib/actions/settings";
 import type { User } from "@/lib/db/schema";
 
 interface ProfileEditorProps {
   user: User;
+  isDemoUser?: boolean;
 }
 
-export function ProfileEditor({ user }: ProfileEditorProps) {
+export function ProfileEditor({ user, isDemoUser = false }: ProfileEditorProps) {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [name, setName] = useState(user.name || "");
@@ -30,6 +32,8 @@ export function ProfileEditor({ user }: ProfileEditorProps) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (isDemoUser) return;
 
     if (!name.trim()) {
       toast.error("Please enter your name");
@@ -71,11 +75,13 @@ export function ProfileEditor({ user }: ProfileEditorProps) {
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-6 pb-6">
+          {isDemoUser && <DemoReadOnlyNotice />}
           <ProfilePhotoUpload
             value={profilePhoto}
             onChange={setProfilePhoto}
             defaultImage={user.profilePhotoPath || user.image}
             name={name}
+            disabled={isDemoUser}
           />
 
           <div className="space-y-2">
@@ -86,6 +92,7 @@ export function ProfileEditor({ user }: ProfileEditorProps) {
               onChange={(e) => setName(e.target.value)}
               placeholder="Your name"
               className="w-fit min-w-[200px]"
+              disabled={isDemoUser}
             />
           </div>
 
@@ -116,7 +123,7 @@ export function ProfileEditor({ user }: ProfileEditorProps) {
           </div>
         </CardContent>
         <CardFooter>
-          <Button type="submit" disabled={isLoading}>
+          <Button type="submit" disabled={isLoading || isDemoUser}>
             {isLoading ? "Saving..." : "Save Changes"}
           </Button>
         </CardFooter>

--- a/frontend/components/settings/settings-tabs.tsx
+++ b/frontend/components/settings/settings-tabs.tsx
@@ -81,12 +81,10 @@ export function SettingsTabs({
           <RiUploadLine className="mr-1.5 h-4 w-4" />
           Import History
         </TabsTrigger>
-        {!isDemoUser && (
-          <TabsTrigger value="bank-connections">
-            <RiBankLine className="mr-1.5 h-4 w-4" />
-            Bank Connections
-          </TabsTrigger>
-        )}
+        <TabsTrigger value="bank-connections">
+          <RiBankLine className="mr-1.5 h-4 w-4" />
+          Bank Connections
+        </TabsTrigger>
         <TabsTrigger value="household">
           <RiGroupLine className="mr-1.5 h-4 w-4" />
           Household
@@ -94,11 +92,11 @@ export function SettingsTabs({
       </TabsList>
 
       <TabsContent value="profile">
-        <ProfileEditor user={user} />
+        <ProfileEditor user={user} isDemoUser={isDemoUser} />
       </TabsContent>
 
       <TabsContent value="categories">
-        <CategoryManager initialCategories={categories} />
+        <CategoryManager initialCategories={categories} isDemoUser={isDemoUser} />
       </TabsContent>
 
       <TabsContent value="api-keys">
@@ -113,14 +111,12 @@ export function SettingsTabs({
         <ImportHistoryManager initialImports={csvImports} canDelete={canDelete} />
       </TabsContent>
 
-      {!isDemoUser && (
-        <TabsContent value="bank-connections">
-          <BankConnectionsManager connections={bankConnections} />
-        </TabsContent>
-      )}
+      <TabsContent value="bank-connections">
+        <BankConnectionsManager connections={bankConnections} isDemoUser={isDemoUser} />
+      </TabsContent>
 
       <TabsContent value="household">
-        <HouseholdTab people={people} />
+        <HouseholdTab people={people} isDemoUser={isDemoUser} />
       </TabsContent>
     </Tabs>
   );

--- a/frontend/lib/actions/api-keys.ts
+++ b/frontend/lib/actions/api-keys.ts
@@ -4,7 +4,7 @@ import crypto from "crypto";
 import bcrypt from "bcryptjs";
 import { db } from "@/lib/db";
 import { apiKeys } from "@/lib/db/schema";
-import { getAuthenticatedSession, requireAuth } from "@/lib/auth-helpers";
+import { getAuthenticatedSession, isDemoRestrictedSession, requireAuth } from "@/lib/auth-helpers";
 import {
   DEMO_RESTRICTED_ACTION_ERROR,
   isDemoRestrictedUserEmail,
@@ -132,6 +132,10 @@ export async function deleteApiKey(keyId: string): Promise<{
   const userId = await requireAuth();
   if (!userId) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isDemoRestrictedSession()) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
   }
 
   try {

--- a/frontend/lib/actions/categories.ts
+++ b/frontend/lib/actions/categories.ts
@@ -4,7 +4,8 @@ import { revalidatePath, updateTag } from "next/cache";
 import { eq, and, count } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { categories, transactions, type Category, type NewCategory } from "@/lib/db/schema";
-import { requireAuth } from "@/lib/auth-helpers";
+import { isDemoRestrictedSession, requireAuth } from "@/lib/auth-helpers";
+import { DEMO_RESTRICTED_ACTION_ERROR } from "@/lib/demo-access";
 import { getCachedUserCategories, CACHE_TAGS } from "@/lib/data/cached";
 
 export interface CategoryCreateInput {
@@ -42,6 +43,10 @@ export async function createCategory(
 
   if (!userId) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isDemoRestrictedSession()) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
   }
 
   try {
@@ -89,6 +94,10 @@ export async function updateCategory(
 
   if (!userId) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isDemoRestrictedSession()) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
   }
 
   try {
@@ -319,6 +328,10 @@ export async function deleteCategoryWithReassignment(
 
   if (!userId) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isDemoRestrictedSession()) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
   }
 
   try {

--- a/frontend/lib/actions/settings.ts
+++ b/frontend/lib/actions/settings.ts
@@ -4,7 +4,8 @@ import { revalidatePath } from "next/cache";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { users, categories, transactions, accounts, type User } from "@/lib/db/schema";
-import { getAuthenticatedSession, requireAuth } from "@/lib/auth-helpers";
+import { getAuthenticatedSession, isDemoRestrictedSession, requireAuth } from "@/lib/auth-helpers";
+import { isDemoRestrictedUserEmail, DEMO_RESTRICTED_ACTION_ERROR } from "@/lib/demo-access";
 import { storage } from "@/lib/storage";
 
 /**
@@ -42,6 +43,10 @@ export async function updateUserProfile(
 
   if (!session?.user?.id) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (isDemoRestrictedUserEmail(session.user.email)) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
   }
 
   try {
@@ -102,6 +107,10 @@ export async function deleteAllTransactionsAndResetBalances(): Promise<{
 
   if (!userId) {
     return { success: false, error: "Not authenticated" };
+  }
+
+  if (await isDemoRestrictedSession()) {
+    return { success: false, error: DEMO_RESTRICTED_ACTION_ERROR };
   }
 
   try {

--- a/frontend/lib/auth-helpers.ts
+++ b/frontend/lib/auth-helpers.ts
@@ -2,12 +2,22 @@
 
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
+import { isDemoRestrictedUserEmail } from "@/lib/demo-access";
 
 /**
  * Get the authenticated session from BetterAuth
  */
 export async function getAuthenticatedSession() {
   return auth.api.getSession({ headers: await headers() });
+}
+
+/**
+ * Returns true when the current session belongs to the restricted demo account.
+ * Use to block mutating server actions / route handlers for the demo user.
+ */
+export async function isDemoRestrictedSession(): Promise<boolean> {
+  const session = await getAuthenticatedSession();
+  return isDemoRestrictedUserEmail(session?.user?.email);
 }
 
 /**


### PR DESCRIPTION
## Summary

Demo users can now **view every Settings panel** but **cannot change anything**. The Bank Connections tab — previously hidden for demo — is now shown read-only, per request ("access every setting as they do now, but prevent them from making changes").

### Security (the real lockdown — server-enforced)
Added demo guards (`isDemoRestrictedUserEmail` / new `isDemoRestrictedSession()` helper → `DEMO_RESTRICTED_ACTION_ERROR`) to the 9 previously-unguarded mutations:
- `lib/actions/settings.ts`: `updateUserProfile`, `deleteAllTransactionsAndResetBalances`
- `lib/actions/categories.ts`: `createCategory`, `updateCategory`, `deleteCategoryWithReassignment`
- `lib/actions/api-keys.ts`: `deleteApiKey`
- `app/api/people/route.ts` (POST) and `app/api/people/[id]/route.ts` (PATCH, DELETE) — return 403 for demo

`GET`/read paths are untouched, so everything stays viewable.

### UX (disabled controls + "read-only" notice)
- New `DemoReadOnlyNotice` banner shown on each panel for demo.
- **ProfileEditor**: name input, photo upload, and Save disabled (`ProfilePhotoUpload` gains a `disabled` prop).
- **CategoryManager**: Add button hidden, row Edit/Delete hidden (`CategoryRow` gains `readOnly`).
- **Household / PeopleList**: Add/Edit/Delete hidden.
- **BankConnectionsManager**: un-hidden; Connect disabled, per-connection Sync/Fix Categories/Disconnect hidden.
- `settings-tabs.tsx`: Bank Connections tab always rendered; `isDemoUser` threaded through.

## Notes
- API-key **create** was already hidden for demo (`canCreateApiKeys`); **delete** is now server-guarded (button still visible — minor follow-up to hide it).
- Existing demo guards (bank actions, CSV revert, API-key create) were already present and are unchanged.

## Test plan
- [ ] `pnpm exec tsc --noEmit` / `pnpm lint` in an installed checkout (couldn't run here — worktree has no `node_modules`).
- [ ] As the demo account: every Settings tab is viewable incl. Bank Connections; no Save/Add/Edit/Delete/Connect controls are actionable; read-only banner shows.
- [ ] As a normal account: Settings behave exactly as before.
- [ ] Verify server guards: direct calls to the guarded actions/routes as demo return the demo error / 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes all Settings read-only for the demo account and un-hides Bank Connections. Previously demo users had partial client-only guards and the Bank Connections tab was hidden; now they can view every panel while every mutation is disabled in the UI and blocked server-side.

- Server guards now block: profile update, delete-all-data, categories create/update/delete, API key delete, and `/api/people` POST/PATCH/DELETE (403 with `DEMO_RESTRICTED_ACTION_ERROR`). Adds `isDemoRestrictedSession()` for consistent checks.
- UI read-only state: shows `DemoReadOnlyNotice` and disables or hides mutating controls across Profile (name, photo upload; `ProfilePhotoUpload` gains `disabled`), Categories (`CategoryRow` gains `readOnly`; Add/Edit/Delete hidden), Household (`PeopleList` gets `readOnly`), and Bank Connections (tab always visible; Connect disabled; Sync/Recategorize/Disconnect hidden).
- Props threading: `isDemoUser` passed from `SettingsTabs` into `ProfileEditor`, `CategoryManager`, `BankConnectionsManager`, and `HouseholdTab` (which passes to `PeopleList`).
- Non-demo behavior is unchanged; read endpoints remain intact for all users.

<sup>Written for commit 3bdd9ef564f7a66327556dc31723addb140c064f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

