### PR TITLE
Add newsletter reports: scheduled email digests of balances and transactions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -56,6 +56,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # backend/Dockerfile's frontend-deps stage renders report
+          # newsletters (npx tsx frontend/emails/render-report.ts, invoked
+          # from backend/tasks/report_tasks.py) and needs frontend/ as a
+          # named additional context since the primary context stays
+          # ./backend. No-op for the frontend matrix entry.
+          build-contexts: |
+            ${{ matrix.service == 'backend' && 'frontend=./frontend' || '' }}
           build-args: |
             NEXT_PUBLIC_DISABLE_SIGN_UPS=${{ vars.NEXT_PUBLIC_DISABLE_SIGN_UPS || 'false' }}
             NEXT_PUBLIC_DEMO_EMAIL=${{ vars.NEXT_PUBLIC_DEMO_EMAIL || '' }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,40 @@ RUN pip install --upgrade pip \
   && pip install --no-cache-dir -r requirements.txt
 
 
+##
+# Frontend render-script dependencies.
+# - `send_report_run` (backend/tasks/report_tasks.py) shells out to
+#   `npx tsx frontend/emails/render-report.ts` to render the newsletter
+#   HTML/text via React Email. That script lives in the frontend/ package
+#   and needs its node_modules (@react-email/*, react, react-dom, tsx, ...)
+#   resolvable at runtime.
+# - This stage runs `pnpm install` against the frontend workspace so the
+#   resulting node_modules can be baked into the runner image below,
+#   independent of whatever's on the host.
+# - This backend Dockerfile's primary build context stays `./backend`
+#   (unchanged, so existing Railway/CI/compose configs that build with
+#   context=./backend keep working). frontend/ is supplied as a separate
+#   *named* BuildKit context called "frontend" -- see the `additional_contexts`
+#   entries in docker-compose.yml / deploy/compose/docker-compose.local.yml
+#   and the `build-contexts` input in .github/workflows/docker-build.yml.
+#   Any build invocation that does NOT pass that named context (e.g. a bare
+#   `docker build ./backend` or an unmodified Railway service) will fail this
+#   stage -- see final-review-fix-report.md for what's covered vs. not.
+##
+FROM node:20-bookworm-slim AS frontend-deps
+
+WORKDIR /frontend
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+COPY --from=frontend package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY --from=frontend xlsx-0.20.3.tgz ./xlsx-0.20.3.tgz
+
+RUN pnpm install --frozen-lockfile
+
+
 FROM python:3.11-slim AS runner
 
 WORKDIR /app
@@ -37,18 +71,35 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 ENV PATH="/opt/venv/bin:$PATH"
 ENV PROCESS_TYPE=api
+# Sibling directory the render subprocess uses to find render-report.ts and
+# its node_modules. Locally (outside Docker) report_tasks.py computes this
+# from __file__ since backend/ and frontend/ are checkout siblings; inside
+# the container we bake/copy frontend's render assets to this fixed path
+# and point the task at it explicitly.
+ENV FRONTEND_EMAILS_DIR=/frontend/emails
 
-# Runtime deps (libpq for Postgres connectivity)
+# Runtime deps: libpq for Postgres connectivity, Node.js/npm for the
+# render-report.ts subprocess invoked by tasks/report_tasks.py.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq5 \
+    nodejs \
+    npm \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/venv /opt/venv
 COPY . .
 
+# Render script + its dependencies (see frontend-deps stage above). Only
+# frontend/emails/** is needed at runtime -- render-report.ts and everything
+# it imports (report-newsletter.tsx + emails/components/*) is self-contained
+# there and only reaches into @react-email/components from node_modules.
+COPY --from=frontend-deps /frontend/node_modules /frontend/node_modules
+COPY --from=frontend emails /frontend/emails
+COPY --from=frontend tsconfig.json package.json /frontend/
+
 # Non-root user for production hardening
 RUN useradd --create-home --uid 10001 app \
-  && chown -R app:app /app
+  && chown -R app:app /app /frontend
 USER app
 
 EXPOSE 8000

--- a/backend/app/integrations/mail_adapter.py
+++ b/backend/app/integrations/mail_adapter.py
@@ -23,12 +23,21 @@ class MailAdapter(Protocol):
 
 
 class SmtpMailAdapter:
-    def __init__(self, host: str, port: int, username: str, password: str, from_addr: str):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        from_addr: str,
+        timeout: float = 30,
+    ):
         self.host = host
         self.port = port
         self.username = username
         self.password = password
         self.from_addr = from_addr
+        self.timeout = timeout
 
     def send(self, to: list[str], subject: str, html: str, text: str) -> None:
         msg = MIMEMultipart("alternative")
@@ -38,10 +47,17 @@ class SmtpMailAdapter:
         msg.attach(MIMEText(text, "plain"))
         msg.attach(MIMEText(html, "html"))
 
-        with smtplib.SMTP(self.host, self.port) as conn:
-            conn.starttls()
-            conn.login(self.username, self.password)
-            conn.sendmail(self.from_addr, to, msg.as_string())
+        # Port 465 is implicit TLS (SMTPS) — connecting with plain SMTP +
+        # starttls() on that port hangs/fails against most providers.
+        smtp_cls = smtplib.SMTP_SSL if self.port == 465 else smtplib.SMTP
+        with smtp_cls(self.host, self.port, timeout=self.timeout) as conn:
+            if smtp_cls is smtplib.SMTP:
+                conn.starttls()
+            if self.username and self.password:
+                conn.login(self.username, self.password)
+            refused = conn.sendmail(self.from_addr, to, msg.as_string())
+            if refused:
+                raise RuntimeError(f"SMTP refused recipients: {refused}")
 
 
 class ResendMailAdapter:
@@ -75,6 +91,17 @@ class UsesendMailAdapter:
         response.raise_for_status()
 
 
+def _require_from_addr(env_var: str) -> str:
+    value = os.getenv(env_var, "")
+    if not value:
+        raise RuntimeError(
+            f"{env_var} must be set to a verified sender address — no default is used "
+            "since an unverified 'reports@localhost'-style address is silently rejected "
+            "or spoofable depending on provider."
+        )
+    return value
+
+
 def get_mail_adapter() -> MailAdapter:
     smtp_host = os.getenv("SMTP_HOST")
     if smtp_host:
@@ -83,18 +110,19 @@ def get_mail_adapter() -> MailAdapter:
             port=int(os.getenv("SMTP_PORT", "587")),
             username=os.getenv("SMTP_USERNAME", ""),
             password=os.getenv("SMTP_PASSWORD", ""),
-            from_addr=os.getenv("SMTP_FROM", "reports@localhost"),
+            from_addr=_require_from_addr("SMTP_FROM"),
+            timeout=float(os.getenv("SMTP_TIMEOUT", "30")),
         )
 
     resend_key = os.getenv("RESEND_API_KEY")
     if resend_key:
-        return ResendMailAdapter(api_key=resend_key, from_addr=os.getenv("RESEND_FROM", "reports@localhost"))
+        return ResendMailAdapter(api_key=resend_key, from_addr=_require_from_addr("RESEND_FROM"))
 
     usesend_key = os.getenv("USESEND_API_KEY")
     if usesend_key:
         return UsesendMailAdapter(
             api_key=usesend_key,
-            from_addr=os.getenv("USESEND_FROM", "reports@localhost"),
+            from_addr=_require_from_addr("USESEND_FROM"),
             base_url=os.getenv("USESEND_BASE_URL", "https://app.usesend.com/api"),
         )
 

--- a/backend/app/integrations/mail_adapter.py
+++ b/backend/app/integrations/mail_adapter.py
@@ -1,0 +1,103 @@
+"""Provider-agnostic mail sending adapter.
+
+Provider is chosen once from process environment variables, in this
+precedence order: SMTP (if SMTP_HOST is set) > Resend (if RESEND_API_KEY
+is set) > usesend (if USESEND_API_KEY is set). If none are configured,
+get_mail_adapter() raises rather than silently no-op-ing.
+"""
+from __future__ import annotations
+
+import os
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Protocol
+
+import requests
+import resend
+
+
+class MailAdapter(Protocol):
+    def send(self, to: list[str], subject: str, html: str, text: str) -> None:
+        ...
+
+
+class SmtpMailAdapter:
+    def __init__(self, host: str, port: int, username: str, password: str, from_addr: str):
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.from_addr = from_addr
+
+    def send(self, to: list[str], subject: str, html: str, text: str) -> None:
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = self.from_addr
+        msg["To"] = ", ".join(to)
+        msg.attach(MIMEText(text, "plain"))
+        msg.attach(MIMEText(html, "html"))
+
+        with smtplib.SMTP(self.host, self.port) as conn:
+            conn.starttls()
+            conn.login(self.username, self.password)
+            conn.sendmail(self.from_addr, to, msg.as_string())
+
+
+class ResendMailAdapter:
+    def __init__(self, api_key: str, from_addr: str):
+        self.from_addr = from_addr
+        resend.api_key = api_key
+
+    def send(self, to: list[str], subject: str, html: str, text: str) -> None:
+        resend.Emails.send({
+            "from": self.from_addr,
+            "to": to,
+            "subject": subject,
+            "html": html,
+            "text": text,
+        })
+
+
+class UsesendMailAdapter:
+    def __init__(self, api_key: str, from_addr: str, base_url: str = "https://app.usesend.com/api"):
+        self.api_key = api_key
+        self.from_addr = from_addr
+        self.base_url = base_url.rstrip("/")
+
+    def send(self, to: list[str], subject: str, html: str, text: str) -> None:
+        response = requests.post(
+            f"{self.base_url}/v1/emails",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json={"from": self.from_addr, "to": to, "subject": subject, "html": html, "text": text},
+            timeout=30,
+        )
+        response.raise_for_status()
+
+
+def get_mail_adapter() -> MailAdapter:
+    smtp_host = os.getenv("SMTP_HOST")
+    if smtp_host:
+        return SmtpMailAdapter(
+            host=smtp_host,
+            port=int(os.getenv("SMTP_PORT", "587")),
+            username=os.getenv("SMTP_USERNAME", ""),
+            password=os.getenv("SMTP_PASSWORD", ""),
+            from_addr=os.getenv("SMTP_FROM", "reports@localhost"),
+        )
+
+    resend_key = os.getenv("RESEND_API_KEY")
+    if resend_key:
+        return ResendMailAdapter(api_key=resend_key, from_addr=os.getenv("RESEND_FROM", "reports@localhost"))
+
+    usesend_key = os.getenv("USESEND_API_KEY")
+    if usesend_key:
+        return UsesendMailAdapter(
+            api_key=usesend_key,
+            from_addr=os.getenv("USESEND_FROM", "reports@localhost"),
+            base_url=os.getenv("USESEND_BASE_URL", "https://app.usesend.com/api"),
+        )
+
+    raise RuntimeError(
+        "No mail provider configured — set SMTP_HOST, or RESEND_API_KEY, or USESEND_API_KEY."
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -228,7 +228,7 @@ class Report(Base):
     __tablename__ = "reports"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     name = Column(String(255), nullable=False)
     account_ids = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     transaction_mode = Column(String(20), nullable=False, default="RECENT")
@@ -241,7 +241,7 @@ class Report(Base):
     timezone = Column(String(64), nullable=False, default="UTC")
     recipient_emails = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
     is_active = Column(Boolean, default=True, nullable=False)
-    next_run_at = Column(DateTime, nullable=True, index=True)
+    next_run_at = Column(DateTime, nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -259,7 +259,7 @@ class ReportRun(Base):
     __tablename__ = "report_runs"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    report_id = Column(UUID(as_uuid=True), ForeignKey("reports.id", ondelete="CASCADE"), nullable=False, index=True)
+    report_id = Column(UUID(as_uuid=True), ForeignKey("reports.id", ondelete="CASCADE"), nullable=False)
     scheduled_for = Column(DateTime, nullable=True)
     is_test = Column(Boolean, default=False, nullable=False)
     started_at = Column(DateTime, nullable=True)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -3,13 +3,14 @@ SQLAlchemy models matching the Drizzle schema.ts structure.
 These models mirror the frontend Drizzle schema for consistency.
 """
 import uuid
-from datetime import datetime
+from datetime import datetime, time
 from sqlalchemy import (
     Column,
     String,
     Boolean,
     Date,
     DateTime,
+    Time,
     Numeric,
     Text,
     Integer,
@@ -219,6 +220,60 @@ class Transaction(Base):
         Index("idx_transactions_csv_import", "csv_import_id"),
         UniqueConstraint("account_id", "external_id", name="transactions_account_external_id"),
         Index("idx_transactions_user_counterparty_iban", "user_id", "counterparty_iban_hash"),
+    )
+
+
+class Report(Base):
+    """Newsletter report configuration."""
+    __tablename__ = "reports"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String(255), nullable=False)
+    account_ids = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    transaction_mode = Column(String(20), nullable=False, default="RECENT")
+    transaction_count = Column(Integer, nullable=False, default=10)
+    transaction_direction = Column(String(20), nullable=False, default="ALL")
+    frequency = Column(String(20), nullable=False)
+    send_time = Column(Time, nullable=False, default=time(8, 0))
+    send_day_of_week = Column(Integer, nullable=True)
+    send_day_of_month = Column(Integer, nullable=True)
+    timezone = Column(String(64), nullable=False, default="UTC")
+    recipient_emails = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    is_active = Column(Boolean, default=True, nullable=False)
+    next_run_at = Column(DateTime, nullable=True, index=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    user = relationship("User")
+    runs = relationship("ReportRun", back_populates="report", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        Index("idx_reports_user", "user_id"),
+        Index("idx_reports_next_run_at", "next_run_at"),
+    )
+
+
+class ReportRun(Base):
+    """Single scheduled or ad-hoc execution of a Report."""
+    __tablename__ = "report_runs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    report_id = Column(UUID(as_uuid=True), ForeignKey("reports.id", ondelete="CASCADE"), nullable=False, index=True)
+    scheduled_for = Column(DateTime, nullable=True)
+    is_test = Column(Boolean, default=False, nullable=False)
+    started_at = Column(DateTime, nullable=True)
+    finished_at = Column(DateTime, nullable=True)
+    status = Column(String(20), nullable=False, default="SCHEDULED")
+    error_message = Column(Text, nullable=True)
+    recipient_emails = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    report = relationship("Report", back_populates="runs")
+
+    __table_args__ = (
+        Index("idx_report_runs_report", "report_id"),
+        Index("idx_report_runs_status", "status"),
     )
 
 

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.routes import accounts, categories, transactions, analytics, sync, transaction_import, subscriptions, events, csv_import, health, enable_banking, investments
+from app.routes import accounts, categories, transactions, analytics, sync, transaction_import, subscriptions, events, csv_import, health, enable_banking, investments, reports
 
 api_router = APIRouter()
 
@@ -15,3 +15,4 @@ api_router.include_router(events.router, prefix="/events", tags=["events"])
 api_router.include_router(csv_import.router, prefix="/csv-import", tags=["csv-import"])
 api_router.include_router(enable_banking.router, prefix="/enable-banking", tags=["enable-banking"])
 api_router.include_router(investments.router, prefix="/investments", tags=["investments"])
+api_router.include_router(reports.router, prefix="/reports", tags=["reports"])

--- a/backend/app/routes/accounts.py
+++ b/backend/app/routes/accounts.py
@@ -185,7 +185,7 @@ def _serialize_account(account: Account) -> AccountResponse:
     )
 
 
-@router.get("/", response_model=List[AccountResponse])
+@router.get("", response_model=List[AccountResponse])
 def list_accounts(
     include_inactive: bool = Query(True, description="Include inactive accounts"),
     user_id: Optional[str] = None,

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -101,6 +101,19 @@ def get_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session
 def update_report(report_id: UUID, payload: ReportUpdate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
     report = _get_owned_report(report_id, user_id, db)
     data = payload.model_dump(exclude_unset=True)
+
+    # These columns are NOT NULL in the DB. exclude_unset=True keeps an
+    # explicit `"field": null` in the payload (distinct from omitting the
+    # key entirely), which would otherwise reach setattr() below and only
+    # fail later as an uncaught IntegrityError/500 on commit.
+    _NON_NULLABLE_FIELDS = ("name", "account_ids", "recipient_emails", "frequency", "is_active", "timezone")
+    null_fields = [f for f in _NON_NULLABLE_FIELDS if f in data and data[f] is None]
+    if null_fields:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Field(s) cannot be null: {', '.join(null_fields)}",
+        )
+
     if "account_ids" in data and data["account_ids"] is not None:
         _validate_account_ids(data["account_ids"], user_id, db)
     if "send_time" in data and data["send_time"] is not None:

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.db_helpers import get_user_id
-from app.models import Report, ReportRun
+from app.models import Account, Report, ReportRun
 from app.schemas import ReportCreate, ReportResponse, ReportRunResponse, ReportUpdate
 from app.services.report_schedule_service import compute_next_run_at
 from tasks.report_tasks import send_report_run
@@ -18,6 +18,30 @@ def _parse_time(value: str) -> time_cls:
     hh, mm, *rest = value.split(":")
     ss = int(rest[0]) if rest else 0
     return time_cls(int(hh), int(mm), ss)
+
+
+def _validate_account_ids(account_ids: list[str], user_id: str, db: Session) -> None:
+    if not account_ids:
+        return
+    parsed_ids = []
+    for raw_id in account_ids:
+        try:
+            parsed_ids.append(UUID(raw_id))
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail="One or more account_ids are invalid or not owned by this user",
+            )
+    owned_count = (
+        db.query(Account)
+        .filter(Account.user_id == user_id, Account.id.in_(parsed_ids))
+        .count()
+    )
+    if owned_count != len(set(parsed_ids)):
+        raise HTTPException(
+            status_code=422,
+            detail="One or more account_ids are invalid or not owned by this user",
+        )
 
 
 def _recompute_next_run(report: Report) -> None:
@@ -33,6 +57,7 @@ def _recompute_next_run(report: Report) -> None:
 
 @router.post("", response_model=ReportResponse)
 def create_report(payload: ReportCreate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    _validate_account_ids(payload.account_ids, user_id, db)
     report = Report(
         user_id=user_id,
         name=payload.name,
@@ -76,10 +101,24 @@ def get_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session
 def update_report(report_id: UUID, payload: ReportUpdate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
     report = _get_owned_report(report_id, user_id, db)
     data = payload.model_dump(exclude_unset=True)
+    if "account_ids" in data and data["account_ids"] is not None:
+        _validate_account_ids(data["account_ids"], user_id, db)
     if "send_time" in data and data["send_time"] is not None:
         data["send_time"] = _parse_time(data["send_time"])
     for field, value in data.items():
         setattr(report, field, value)
+
+    if (report.frequency in ("WEEKLY", "BIWEEKLY") and report.send_day_of_week is None) or (
+        report.frequency == "MONTHLY" and report.send_day_of_month is None
+    ):
+        # setattr() above already mutated the in-session ORM object; roll
+        # back so no partial state is ever committed.
+        db.rollback()
+        raise HTTPException(
+            status_code=422,
+            detail="send_day_of_week/send_day_of_month is required for the selected frequency",
+        )
+
     _recompute_next_run(report)
     db.commit()
     db.refresh(report)

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -1,0 +1,122 @@
+from datetime import datetime, time as time_cls
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.db_helpers import get_user_id
+from app.models import Report, ReportRun
+from app.schemas import ReportCreate, ReportResponse, ReportRunResponse, ReportUpdate
+from app.services.report_schedule_service import compute_next_run_at
+from tasks.report_tasks import send_report_run
+
+router = APIRouter()
+
+
+def _parse_time(value: str) -> time_cls:
+    hh, mm, *rest = value.split(":")
+    ss = int(rest[0]) if rest else 0
+    return time_cls(int(hh), int(mm), ss)
+
+
+def _recompute_next_run(report: Report) -> None:
+    report.next_run_at = compute_next_run_at(
+        frequency=report.frequency,
+        send_time=report.send_time,
+        timezone=report.timezone,
+        send_day_of_week=report.send_day_of_week,
+        send_day_of_month=report.send_day_of_month,
+        after=datetime.utcnow(),
+    )
+
+
+@router.post("", response_model=ReportResponse)
+def create_report(payload: ReportCreate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    report = Report(
+        user_id=user_id,
+        name=payload.name,
+        account_ids=payload.account_ids,
+        transaction_mode=payload.transaction_mode,
+        transaction_count=payload.transaction_count,
+        transaction_direction=payload.transaction_direction,
+        frequency=payload.frequency,
+        send_time=_parse_time(payload.send_time),
+        send_day_of_week=payload.send_day_of_week,
+        send_day_of_month=payload.send_day_of_month,
+        timezone=payload.timezone,
+        recipient_emails=payload.recipient_emails,
+        is_active=payload.is_active,
+    )
+    _recompute_next_run(report)
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+@router.get("", response_model=list[ReportResponse])
+def list_reports(user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    return db.query(Report).filter(Report.user_id == user_id).order_by(Report.created_at.desc()).all()
+
+
+def _get_owned_report(report_id: UUID, user_id: str, db: Session) -> Report:
+    report = db.query(Report).filter(Report.id == report_id, Report.user_id == user_id).first()
+    if not report:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
+    return report
+
+
+@router.get("/{report_id}", response_model=ReportResponse)
+def get_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    return _get_owned_report(report_id, user_id, db)
+
+
+@router.patch("/{report_id}", response_model=ReportResponse)
+def update_report(report_id: UUID, payload: ReportUpdate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    report = _get_owned_report(report_id, user_id, db)
+    data = payload.model_dump(exclude_unset=True)
+    if "send_time" in data and data["send_time"] is not None:
+        data["send_time"] = _parse_time(data["send_time"])
+    for field, value in data.items():
+        setattr(report, field, value)
+    _recompute_next_run(report)
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+@router.delete("/{report_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    report = _get_owned_report(report_id, user_id, db)
+    db.delete(report)
+    db.commit()
+
+
+@router.post("/{report_id}/send-test", response_model=ReportRunResponse)
+def send_test_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    report = _get_owned_report(report_id, user_id, db)
+    run = ReportRun(
+        report_id=report.id,
+        scheduled_for=None,
+        is_test=True,
+        status="SCHEDULED",
+        recipient_emails=report.recipient_emails,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+    send_report_run.delay(str(run.id))
+    return run
+
+
+@router.get("/{report_id}/runs", response_model=list[ReportRunResponse])
+def list_report_runs(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    _get_owned_report(report_id, user_id, db)
+    return (
+        db.query(ReportRun)
+        .filter(ReportRun.report_id == report_id)
+        .order_by(ReportRun.created_at.desc())
+        .limit(100)
+        .all()
+    )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -397,21 +397,28 @@ class ReportBase(BaseModel):
     send_day_of_week: Optional[int] = Field(default=None, ge=0, le=6)
     send_day_of_month: Optional[int] = Field(default=None, ge=1, le=28)
     timezone: str = "UTC"
-    recipient_emails: list[str] = Field(default_factory=list)
+    recipient_emails: list[str]
     is_active: bool = True
 
     _check_timezone = field_validator("timezone")(_validate_timezone)
-    _check_recipient_emails = field_validator("recipient_emails")(_validate_recipient_emails)
-    # NOTE: send_time is intentionally NOT validated here — ReportResponse
-    # also inherits ReportBase but overrides send_time's type to
-    # datetime.time (the ORM-loaded value), and pydantic v2 field_validators
-    # are inherited by subclasses even when the field is overridden, which
-    # would break response serialization. Validated on ReportCreate/
-    # ReportUpdate individually instead, where the field stays a str.
+    # NOTE: send_time and recipient_emails are intentionally NOT validated
+    # here — ReportResponse also inherits ReportBase, and pydantic v2 field
+    # validators are inherited by subclasses even when the field type is
+    # overridden (send_time) or the value comes from the ORM (recipient_emails
+    # legacy rows could in principle be []), which would break response
+    # serialization / reads with a 500 instead of just rejecting bad writes.
+    # Validated on ReportCreate/ReportUpdate individually instead, so reads
+    # are never blocked by a write-side validation rule. recipient_emails
+    # also has no default here so that omitting it on create is itself a
+    # 422 "field required" instead of silently defaulting to [] and only
+    # failing later (previously: default_factory=list bypassed pydantic v2's
+    # skip-validation-on-default behavior, letting an empty list reach the
+    # DB unvalidated on create).
 
 
 class ReportCreate(ReportBase):
     _check_send_time = field_validator("send_time")(_validate_send_time)
+    _check_recipient_emails = field_validator("recipient_emails")(_validate_recipient_emails)
 
     @model_validator(mode="after")
     def _validate_required_day_fields(self) -> "ReportCreate":

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime
+from datetime import time as _time_type
 from decimal import Decimal
 from typing import Optional, List
 from uuid import UUID
@@ -343,3 +344,62 @@ class SymbolSearchResult(BaseModel):
     name: str
     exchange: Optional[str] = None
     currency: Optional[str] = None
+
+
+# Report Schemas
+class ReportBase(BaseModel):
+    name: str
+    account_ids: list[str] = Field(default_factory=list)
+    transaction_mode: str = "RECENT"  # RECENT, TOP_N
+    transaction_count: int = 10
+    transaction_direction: str = "ALL"  # ALL, EXPENSE, INCOME, INFLOW, OUTFLOW
+    frequency: str  # DAILY, WEEKLY, BIWEEKLY, MONTHLY
+    send_time: str = "08:00:00"  # HH:MM:SS
+    send_day_of_week: Optional[int] = None
+    send_day_of_month: Optional[int] = None
+    timezone: str = "UTC"
+    recipient_emails: list[str] = Field(default_factory=list)
+    is_active: bool = True
+
+
+class ReportCreate(ReportBase):
+    pass
+
+
+class ReportUpdate(BaseModel):
+    name: Optional[str] = None
+    account_ids: Optional[list[str]] = None
+    transaction_mode: Optional[str] = None
+    transaction_count: Optional[int] = None
+    transaction_direction: Optional[str] = None
+    frequency: Optional[str] = None
+    send_time: Optional[str] = None
+    send_day_of_week: Optional[int] = None
+    send_day_of_month: Optional[int] = None
+    timezone: Optional[str] = None
+    recipient_emails: Optional[list[str]] = None
+    is_active: Optional[bool] = None
+
+
+class ReportResponse(ReportBase):
+    id: UUID
+    send_time: _time_type
+    next_run_at: Optional[datetime] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ReportRunResponse(BaseModel):
+    id: UUID
+    scheduled_for: Optional[datetime] = None
+    is_test: bool
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    status: str
+    error_message: Optional[str] = None
+    recipient_emails: list[str] = Field(default_factory=list)
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from datetime import datetime
 from datetime import time as _time_type
 from decimal import Decimal
@@ -347,13 +347,18 @@ class SymbolSearchResult(BaseModel):
 
 
 # Report Schemas
+ReportFrequency = Literal["DAILY", "WEEKLY", "BIWEEKLY", "MONTHLY"]
+ReportTransactionMode = Literal["RECENT", "TOP_N"]
+ReportTransactionDirection = Literal["ALL", "EXPENSE", "INCOME", "INFLOW", "OUTFLOW"]
+
+
 class ReportBase(BaseModel):
     name: str
     account_ids: list[str] = Field(default_factory=list)
-    transaction_mode: str = "RECENT"  # RECENT, TOP_N
-    transaction_count: int = 10
-    transaction_direction: str = "ALL"  # ALL, EXPENSE, INCOME, INFLOW, OUTFLOW
-    frequency: str  # DAILY, WEEKLY, BIWEEKLY, MONTHLY
+    transaction_mode: ReportTransactionMode = "RECENT"  # RECENT, TOP_N
+    transaction_count: int = Field(default=10, ge=1, le=100)
+    transaction_direction: ReportTransactionDirection = "ALL"  # ALL, EXPENSE, INCOME, INFLOW, OUTFLOW
+    frequency: ReportFrequency  # DAILY, WEEKLY, BIWEEKLY, MONTHLY
     send_time: str = "08:00:00"  # HH:MM:SS
     send_day_of_week: Optional[int] = None
     send_day_of_month: Optional[int] = None
@@ -363,22 +368,34 @@ class ReportBase(BaseModel):
 
 
 class ReportCreate(ReportBase):
-    pass
+    @model_validator(mode="after")
+    def _validate_required_day_fields(self) -> "ReportCreate":
+        if self.frequency in ("WEEKLY", "BIWEEKLY") and self.send_day_of_week is None:
+            raise ValueError("send_day_of_week is required when frequency is WEEKLY or BIWEEKLY")
+        if self.frequency == "MONTHLY" and self.send_day_of_month is None:
+            raise ValueError("send_day_of_month is required when frequency is MONTHLY")
+        return self
 
 
 class ReportUpdate(BaseModel):
     name: Optional[str] = None
     account_ids: Optional[list[str]] = None
-    transaction_mode: Optional[str] = None
-    transaction_count: Optional[int] = None
-    transaction_direction: Optional[str] = None
-    frequency: Optional[str] = None
+    transaction_mode: Optional[ReportTransactionMode] = None
+    transaction_count: Optional[int] = Field(default=None, ge=1, le=100)
+    transaction_direction: Optional[ReportTransactionDirection] = None
+    frequency: Optional[ReportFrequency] = None
     send_time: Optional[str] = None
     send_day_of_week: Optional[int] = None
     send_day_of_month: Optional[int] = None
     timezone: Optional[str] = None
     recipient_emails: Optional[list[str]] = None
     is_active: Optional[bool] = None
+    # Note: no cross-field "day field required" validator here — a PATCH may
+    # legitimately update only one field (e.g. recipient_emails) without
+    # touching frequency/day fields. The route handler's _recompute_next_run
+    # falls back to the already-persisted value for whichever field isn't in
+    # this payload, so ReportCreate (which always has full context) is the
+    # right place for that check.
 
 
 class ReportResponse(ReportBase):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -402,10 +402,17 @@ class ReportBase(BaseModel):
 
     _check_timezone = field_validator("timezone")(_validate_timezone)
     _check_recipient_emails = field_validator("recipient_emails")(_validate_recipient_emails)
-    _check_send_time = field_validator("send_time")(_validate_send_time)
+    # NOTE: send_time is intentionally NOT validated here — ReportResponse
+    # also inherits ReportBase but overrides send_time's type to
+    # datetime.time (the ORM-loaded value), and pydantic v2 field_validators
+    # are inherited by subclasses even when the field is overridden, which
+    # would break response serialization. Validated on ReportCreate/
+    # ReportUpdate individually instead, where the field stays a str.
 
 
 class ReportCreate(ReportBase):
+    _check_send_time = field_validator("send_time")(_validate_send_time)
+
     @model_validator(mode="after")
     def _validate_required_day_fields(self) -> "ReportCreate":
         if self.frequency in ("WEEKLY", "BIWEEKLY") and self.send_day_of_week is None:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,9 +1,11 @@
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+import re
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from datetime import datetime
 from datetime import time as _time_type
 from decimal import Decimal
 from typing import Optional, List
 from uuid import UUID
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 # Account Schemas
@@ -351,6 +353,38 @@ ReportFrequency = Literal["DAILY", "WEEKLY", "BIWEEKLY", "MONTHLY"]
 ReportTransactionMode = Literal["RECENT", "TOP_N"]
 ReportTransactionDirection = Literal["ALL", "EXPENSE", "INCOME", "INFLOW", "OUTFLOW"]
 
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_SEND_TIME_RE = re.compile(r"^([01]\d|2[0-3]):([0-5]\d)(:([0-5]\d))?$")
+
+
+def _validate_timezone(v: Optional[str]) -> Optional[str]:
+    if v is None:
+        return v
+    try:
+        ZoneInfo(v)
+    except ZoneInfoNotFoundError:
+        raise ValueError(f"Unknown timezone: {v}")
+    return v
+
+
+def _validate_recipient_emails(v: Optional[list[str]]) -> Optional[list[str]]:
+    if v is None:
+        return v
+    if len(v) < 1:
+        raise ValueError("recipient_emails must contain at least one email address")
+    for email in v:
+        if not _EMAIL_RE.match(email):
+            raise ValueError(f"Invalid email address: {email}")
+    return v
+
+
+def _validate_send_time(v: Optional[str]) -> Optional[str]:
+    if v is None:
+        return v
+    if not _SEND_TIME_RE.match(v):
+        raise ValueError(f"Invalid send_time format (expected HH:MM or HH:MM:SS): {v}")
+    return v
+
 
 class ReportBase(BaseModel):
     name: str
@@ -360,11 +394,15 @@ class ReportBase(BaseModel):
     transaction_direction: ReportTransactionDirection = "ALL"  # ALL, EXPENSE, INCOME, INFLOW, OUTFLOW
     frequency: ReportFrequency  # DAILY, WEEKLY, BIWEEKLY, MONTHLY
     send_time: str = "08:00:00"  # HH:MM:SS
-    send_day_of_week: Optional[int] = None
-    send_day_of_month: Optional[int] = None
+    send_day_of_week: Optional[int] = Field(default=None, ge=0, le=6)
+    send_day_of_month: Optional[int] = Field(default=None, ge=1, le=28)
     timezone: str = "UTC"
     recipient_emails: list[str] = Field(default_factory=list)
     is_active: bool = True
+
+    _check_timezone = field_validator("timezone")(_validate_timezone)
+    _check_recipient_emails = field_validator("recipient_emails")(_validate_recipient_emails)
+    _check_send_time = field_validator("send_time")(_validate_send_time)
 
 
 class ReportCreate(ReportBase):
@@ -385,8 +423,8 @@ class ReportUpdate(BaseModel):
     transaction_direction: Optional[ReportTransactionDirection] = None
     frequency: Optional[ReportFrequency] = None
     send_time: Optional[str] = None
-    send_day_of_week: Optional[int] = None
-    send_day_of_month: Optional[int] = None
+    send_day_of_week: Optional[int] = Field(default=None, ge=0, le=6)
+    send_day_of_month: Optional[int] = Field(default=None, ge=1, le=28)
     timezone: Optional[str] = None
     recipient_emails: Optional[list[str]] = None
     is_active: Optional[bool] = None
@@ -396,6 +434,10 @@ class ReportUpdate(BaseModel):
     # falls back to the already-persisted value for whichever field isn't in
     # this payload, so ReportCreate (which always has full context) is the
     # right place for that check.
+
+    _check_timezone = field_validator("timezone")(_validate_timezone)
+    _check_recipient_emails = field_validator("recipient_emails")(_validate_recipient_emails)
+    _check_send_time = field_validator("send_time")(_validate_send_time)
 
 
 class ReportResponse(ReportBase):

--- a/backend/app/services/report_data_service.py
+++ b/backend/app/services/report_data_service.py
@@ -1,0 +1,103 @@
+"""Builds the JSON payload consumed by the report newsletter email template.
+
+Reuses the same Account/Transaction ORM models the dashboard reads from,
+so report numbers match what the user sees in-app.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+
+from app.models import Account, Report, Transaction
+
+_DIRECTION_LABELS = {
+    "ALL": "transactions",
+    "EXPENSE": "expenses",
+    "INCOME": "income",
+    "INFLOW": "inflows",
+    "OUTFLOW": "outflows",
+}
+
+# transaction_type on Transaction is "debit" or "credit".
+# EXPENSE/OUTFLOW == debit, INCOME/INFLOW == credit, ALL == both.
+_DIRECTION_TYPES = {
+    "ALL": ("debit", "credit"),
+    "EXPENSE": ("debit",),
+    "OUTFLOW": ("debit",),
+    "INCOME": ("credit",),
+    "INFLOW": ("credit",),
+}
+
+
+def build_report_payload(db: Session, report: Report) -> dict:
+    accounts = _fetch_accounts(db, report)
+    transactions = _fetch_transactions(db, report)
+
+    return {
+        "report_name": report.name,
+        "generated_at": datetime.utcnow().isoformat(),
+        "accounts": accounts,
+        "transactions": transactions,
+    }
+
+
+def _fetch_accounts(db: Session, report: Report) -> list[dict]:
+    if not report.account_ids:
+        return []
+    account_uuids = [UUID(a) for a in report.account_ids]
+    rows = (
+        db.query(Account)
+        .filter(Account.user_id == report.user_id, Account.id.in_(account_uuids))
+        .all()
+    )
+    return [
+        {
+            "name": a.name,
+            "institution": a.institution,
+            "balance": str(a.functional_balance if a.functional_balance is not None else a.balance_available or 0),
+            "currency": a.currency or "EUR",
+        }
+        for a in rows
+    ]
+
+
+def _fetch_transactions(db: Session, report: Report) -> dict:
+    types = _DIRECTION_TYPES.get(report.transaction_direction, ("debit", "credit"))
+    query = db.query(Transaction).filter(
+        Transaction.user_id == report.user_id,
+        Transaction.transaction_type.in_(types),
+    )
+    if report.account_ids:
+        account_uuids = [UUID(a) for a in report.account_ids]
+        query = query.filter(Transaction.account_id.in_(account_uuids))
+
+    if report.transaction_mode == "RECENT":
+        query = query.order_by(Transaction.booked_at.desc())
+    else:  # TOP_N — order by absolute amount descending
+        query = query.order_by(Transaction.amount.desc() if types == ("credit",) else Transaction.amount.asc())
+
+    rows = query.limit(report.transaction_count).all()
+
+    direction_word = _DIRECTION_LABELS.get(report.transaction_direction, "transactions")
+    mode_label = (
+        f"Last {report.transaction_count} transactions"
+        if report.transaction_mode == "RECENT"
+        else f"Top {report.transaction_count} {direction_word}"
+    )
+
+    items = [
+        {
+            "description": t.merchant or t.description or "Transaction",
+            "category": None,
+            "date": t.booked_at.date().isoformat(),
+            "amount": str(abs(t.amount)),
+            "currency": t.currency or "EUR",
+            "direction": "out" if t.transaction_type == "debit" else "in",
+        }
+        for t in rows
+    ]
+
+    return {"mode_label": mode_label, "items": items}

--- a/backend/app/services/report_data_service.py
+++ b/backend/app/services/report_data_service.py
@@ -53,12 +53,22 @@ def _fetch_accounts(db: Session, report: Report) -> list[dict]:
         .filter(Account.user_id == report.user_id, Account.id.in_(account_uuids))
         .all()
     )
+    functional_currency = (report.user.functional_currency if report.user else None) or "EUR"
+
+    def _balance_and_currency(a: Account) -> tuple[str, str]:
+        if a.functional_balance is not None:
+            # functional_balance is already converted to the user's
+            # functional currency, so it must be labeled with that
+            # currency, not the account's native currency.
+            return str(a.functional_balance), functional_currency
+        return str(a.balance_available or 0), a.currency or "EUR"
+
     return [
         {
             "name": a.name,
             "institution": a.institution,
-            "balance": str(a.functional_balance if a.functional_balance is not None else a.balance_available or 0),
-            "currency": a.currency or "EUR",
+            "balance": _balance_and_currency(a)[0],
+            "currency": _balance_and_currency(a)[1],
         }
         for a in rows
     ]

--- a/backend/app/services/report_data_service.py
+++ b/backend/app/services/report_data_service.py
@@ -38,7 +38,10 @@ def build_report_payload(db: Session, report: Report) -> dict:
 
     return {
         "report_name": report.name,
-        "generated_at": datetime.utcnow().isoformat(),
+        # Trailing "Z" so the frontend's `new Date(generatedAt)` parses this
+        # as UTC rather than the worker container's local timezone (which
+        # would silently shift the displayed date/time otherwise).
+        "generated_at": datetime.utcnow().isoformat() + "Z",
         "accounts": accounts,
         "transactions": transactions,
     }

--- a/backend/app/services/report_data_service.py
+++ b/backend/app/services/report_data_service.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import and_
+from sqlalchemy import and_, func
 from sqlalchemy.orm import Session
 
 from app.models import Account, Report, Transaction
@@ -86,6 +86,11 @@ def _fetch_transactions(db: Session, report: Report) -> dict:
 
     if report.transaction_mode == "RECENT":
         query = query.order_by(Transaction.booked_at.desc())
+    elif types == ("debit", "credit"):
+        # direction == ALL: debits are negative, credits are positive, so
+        # neither .asc() nor .desc() alone gives "biggest transactions
+        # first" — order by absolute magnitude instead.
+        query = query.order_by(func.abs(Transaction.amount).desc())
     else:  # TOP_N — order by absolute amount descending
         query = query.order_by(Transaction.amount.desc() if types == ("credit",) else Transaction.amount.asc())
 

--- a/backend/app/services/report_schedule_service.py
+++ b/backend/app/services/report_schedule_service.py
@@ -1,0 +1,78 @@
+"""Computes the next scheduled send time for a Report.
+
+All persisted `next_run_at` values are naive UTC datetimes (matching the
+rest of this codebase's `DateTime` columns, which are naive-UTC by
+convention — see `Transaction.booked_at`).
+"""
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+_UTC = ZoneInfo("UTC")
+
+
+def compute_next_run_at(
+    frequency: str,
+    send_time: time,
+    timezone: str,
+    send_day_of_week: int | None,
+    send_day_of_month: int | None,
+    after: datetime,
+) -> datetime:
+    """Return the next UTC datetime a report is due, strictly after `after`.
+
+    `after` is a naive UTC datetime. `send_time` and the day fields are
+    interpreted in `timezone` (IANA name), then converted back to naive
+    UTC for storage/comparison.
+    """
+    tz = ZoneInfo(timezone)
+    after_local = after.replace(tzinfo=_UTC).astimezone(tz)
+
+    if frequency == "DAILY":
+        candidate_local = _combine(after_local.date(), send_time, tz)
+        if candidate_local <= after_local:
+            candidate_local = _combine(after_local.date() + timedelta(days=1), send_time, tz)
+        return _to_naive_utc(candidate_local)
+
+    if frequency in ("WEEKLY", "BIWEEKLY"):
+        if send_day_of_week is None:
+            raise ValueError("send_day_of_week is required for WEEKLY/BIWEEKLY")
+        days_ahead = (send_day_of_week - after_local.weekday()) % 7
+        candidate_date = after_local.date() + timedelta(days=days_ahead)
+        candidate_local = _combine(candidate_date, send_time, tz)
+        if candidate_local <= after_local:
+            candidate_local = _combine(candidate_date + timedelta(days=7), send_time, tz)
+        if frequency == "BIWEEKLY":
+            candidate_local = _combine(candidate_local.date() + timedelta(days=7), send_time, tz)
+        return _to_naive_utc(candidate_local)
+
+    if frequency == "MONTHLY":
+        if send_day_of_month is None:
+            raise ValueError("send_day_of_month is required for MONTHLY")
+        candidate_date = _safe_date(after_local.year, after_local.month, send_day_of_month)
+        candidate_local = _combine(candidate_date, send_time, tz)
+        if candidate_local <= after_local:
+            year, month = after_local.year, after_local.month + 1
+            if month > 12:
+                year, month = year + 1, 1
+            candidate_date = _safe_date(year, month, send_day_of_month)
+            candidate_local = _combine(candidate_date, send_time, tz)
+        return _to_naive_utc(candidate_local)
+
+    raise ValueError(f"Unknown frequency: {frequency}")
+
+
+def _combine(date_part, time_part: time, tz: ZoneInfo) -> datetime:
+    return datetime.combine(date_part, time_part, tzinfo=tz)
+
+
+def _to_naive_utc(dt: datetime) -> datetime:
+    return dt.astimezone(_UTC).replace(tzinfo=None)
+
+
+def _safe_date(year: int, month: int, day: int):
+    import calendar
+
+    last_day = calendar.monthrange(year, month)[1]
+    return datetime(year, month, min(day, last_day)).date()

--- a/backend/app/services/report_schedule_service.py
+++ b/backend/app/services/report_schedule_service.py
@@ -63,6 +63,12 @@ def compute_next_run_at(
     raise ValueError(f"Unknown frequency: {frequency}")
 
 
+# Known limitation: does not special-case DST transition gaps/ambiguous
+# local times — zoneinfo silently resolves them via its own PEP 495 default
+# behavior (a report scheduled inside a nonexistent local-time gap will be
+# interpreted using the post-transition UTC offset). Acceptable for v1;
+# revisit if reports need minute-precision reliability across DST
+# boundaries.
 def _combine(date_part, time_part: time, tz: ZoneInfo) -> datetime:
     return datetime.combine(date_part, time_part, tzinfo=tz)
 

--- a/backend/celery_app.py
+++ b/backend/celery_app.py
@@ -13,7 +13,7 @@ celery_app = Celery(
     "finance_tasks",
     broker=REDIS_URL,
     backend=REDIS_URL,
-    include=["tasks.csv_import_tasks", "tasks.demo_tasks", "tasks.enable_banking_tasks", "tasks.post_import_pipeline", "tasks.investment_tasks"],
+    include=["tasks.csv_import_tasks", "tasks.demo_tasks", "tasks.enable_banking_tasks", "tasks.post_import_pipeline", "tasks.investment_tasks", "tasks.report_tasks"],
     set_as_current=True,
 )
 # Ensure @shared_task instances bind to this Celery instance instead of any
@@ -84,6 +84,11 @@ def _build_beat_schedule() -> dict:
     schedule["daily-investment-sync-all"] = {
         "task": "tasks.investment_tasks.daily_investment_sync_all",
         "schedule": crontab(minute=0, hour=investment_hour),
+    }
+
+    schedule["check-due-reports"] = {
+        "task": "tasks.report_tasks.check_due_reports",
+        "schedule": crontab(minute="*/5"),
     }
 
     return schedule

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,5 @@ celery>=5.3.0
 cryptography>=41.0.0
 bcrypt>=4.0.0
 fastmcp>=2.14.0; python_version >= "3.10"
+resend>=2.0.0
+requests>=2.31.0

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -68,16 +68,18 @@ def check_due_reports() -> None:
 @celery_app.task(name="tasks.report_tasks.send_report_run")
 def send_report_run(report_run_id: str) -> None:
     db = SessionLocal()
+    run = None
     try:
-        run = db.query(ReportRun).filter(ReportRun.id == report_run_id).first()
-        if run is None:
-            return
-        run.status = "RUNNING"
-        run.started_at = datetime.utcnow()
-        db.commit()
-
-        report = db.query(Report).filter(Report.id == run.report_id).first()
         try:
+            run = db.query(ReportRun).filter(ReportRun.id == report_run_id).first()
+            if run is None:
+                return
+            run.status = "RUNNING"
+            run.started_at = datetime.utcnow()
+            db.commit()
+
+            report = db.query(Report).filter(Report.id == run.report_id).first()
+
             payload = build_report_payload(db, report)
             payload["manage_url"] = None
 
@@ -102,11 +104,38 @@ def send_report_run(report_run_id: str) -> None:
             )
 
             run.status = "SUCCEEDED"
-        except Exception as exc:  # noqa: BLE001 - must never break the Beat loop
-            run.status = "FAILED"
-            run.error_message = str(exc)
-        finally:
             run.finished_at = datetime.utcnow()
             db.commit()
+        except Exception as exc:  # noqa: BLE001 - must never break the Beat loop
+            _mark_run_failed(db, run, report_run_id, exc)
     finally:
         db.close()
+
+
+def _mark_run_failed(db, run, report_run_id: str, exc: Exception) -> None:
+    """Best-effort attempt to mark a ReportRun as FAILED after any failure.
+
+    The session/transaction may be in an unusable state (e.g. if the failure
+    happened during the initial commit), so we roll back first and, if the
+    in-memory `run` object is unusable, re-query it by id on a fresh
+    transaction before giving up.
+    """
+    try:
+        db.rollback()
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        if run is None:
+            run = db.query(ReportRun).filter(ReportRun.id == report_run_id).first()
+        if run is None:
+            return
+        run.status = "FAILED"
+        run.error_message = str(exc)
+        run.finished_at = datetime.utcnow()
+        db.commit()
+    except Exception:  # noqa: BLE001 - never let the failure handler itself raise
+        try:
+            db.rollback()
+        except Exception:  # noqa: BLE001
+            pass

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -7,6 +7,8 @@ import subprocess
 from datetime import datetime
 from pathlib import Path
 
+from sqlalchemy import update
+
 from celery_app import celery_app
 
 from app.database import SessionLocal
@@ -88,13 +90,36 @@ def send_report_run(report_run_id: str) -> None:
     run = None
     try:
         try:
+            # Atomically claim the run: only the invocation whose UPDATE
+            # actually flips a row from SCHEDULED -> RUNNING proceeds to
+            # send. A separate "read status, then commit RUNNING" sequence
+            # has a race window where two concurrent deliveries of the same
+            # report_run_id (Celery's at-least-once delivery, a retry, or
+            # overlapping check_due_reports invocations) could both pass the
+            # status check before either commits, double-sending. A single
+            # conditional UPDATE is an atomic compare-and-swap at the
+            # database level, closing that window.
+            #
+            # Known residual limitation (not addressed here): if a worker
+            # crashes mid-send after this claim commits, the run is left
+            # permanently RUNNING with no automatic recovery/requeue. A
+            # stale-RUNNING reaper (e.g. a periodic task that re-queues runs
+            # RUNNING for longer than the render+send timeout) would close
+            # this gap; out of scope for this fix, v1 accepts it.
+            claim_result = db.execute(
+                update(ReportRun)
+                .where(ReportRun.id == report_run_id, ReportRun.status == "SCHEDULED")
+                .values(status="RUNNING", started_at=datetime.utcnow())
+            )
+            db.commit()
+            if claim_result.rowcount == 0:
+                # Already RUNNING/SUCCEEDED/FAILED, or doesn't exist — some
+                # other invocation claimed it first, or there's nothing to
+                # claim. Do not re-send.
+                return
+
             run = db.query(ReportRun).filter(ReportRun.id == report_run_id).first()
             if run is None:
-                return
-            if run.status != "SCHEDULED":
-                # Already RUNNING/SUCCEEDED/FAILED — do not re-send. Guards
-                # against duplicate Celery deliveries (at-least-once
-                # delivery, retried tasks, etc.) causing double sends.
                 return
             report = db.query(Report).filter(Report.id == run.report_id).first()
 
@@ -103,8 +128,6 @@ def send_report_run(report_run_id: str) -> None:
             # time (not whatever was configured when the run row was
             # created, potentially much earlier for scheduled runs).
             run.recipient_emails = report.recipient_emails
-            run.status = "RUNNING"
-            run.started_at = datetime.utcnow()
             db.commit()
 
             payload = build_report_payload(db, report)

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -1,0 +1,6 @@
+from celery_app import celery_app
+
+
+@celery_app.task
+def send_report_run(report_run_id: str):
+    pass

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -96,11 +96,16 @@ def send_report_run(report_run_id: str) -> None:
                 # against duplicate Celery deliveries (at-least-once
                 # delivery, retried tasks, etc.) causing double sends.
                 return
+            report = db.query(Report).filter(Report.id == run.report_id).first()
+
+            # Refresh the run's recipient snapshot from the live Report
+            # right before sending, so it reflects recipients as of send
+            # time (not whatever was configured when the run row was
+            # created, potentially much earlier for scheduled runs).
+            run.recipient_emails = report.recipient_emails
             run.status = "RUNNING"
             run.started_at = datetime.utcnow()
             db.commit()
-
-            report = db.query(Report).filter(Report.id == run.report_id).first()
 
             payload = build_report_payload(db, report)
             payload["manage_url"] = None

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -91,6 +91,11 @@ def send_report_run(report_run_id: str) -> None:
             run = db.query(ReportRun).filter(ReportRun.id == report_run_id).first()
             if run is None:
                 return
+            if run.status != "SCHEDULED":
+                # Already RUNNING/SUCCEEDED/FAILED — do not re-send. Guards
+                # against duplicate Celery deliveries (at-least-once
+                # delivery, retried tasks, etc.) causing double sends.
+                return
             run.status = "RUNNING"
             run.started_at = datetime.utcnow()
             db.commit()

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -1,6 +1,112 @@
+"""Celery tasks for scheduled and ad-hoc report newsletter sends."""
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
 from celery_app import celery_app
 
+from app.database import SessionLocal
+from app.integrations.mail_adapter import get_mail_adapter
+from app.models import Report, ReportRun
+from app.services.report_data_service import build_report_payload
+from app.services.report_schedule_service import compute_next_run_at
 
-@celery_app.task
-def send_report_run(report_run_id: str):
-    pass
+_RENDER_SCRIPT = Path(__file__).resolve().parent.parent.parent / "frontend" / "emails" / "render-report.ts"
+
+
+@celery_app.task(name="tasks.report_tasks.check_due_reports")
+def check_due_reports() -> None:
+    db = SessionLocal()
+    try:
+        now = datetime.utcnow()
+        due_reports = (
+            db.query(Report)
+            .filter(Report.is_active.is_(True), Report.next_run_at <= now)
+            .all()
+        )
+        for report in due_reports:
+            run = (
+                db.query(ReportRun)
+                .filter(ReportRun.report_id == report.id, ReportRun.status == "SCHEDULED", ReportRun.scheduled_for <= now)
+                .order_by(ReportRun.scheduled_for.asc())
+                .first()
+            )
+            if run is None:
+                run = ReportRun(
+                    report_id=report.id,
+                    scheduled_for=report.next_run_at,
+                    status="SCHEDULED",
+                    recipient_emails=report.recipient_emails,
+                )
+                db.add(run)
+                db.flush()
+
+            send_report_run.delay(str(run.id))
+
+            report.next_run_at = compute_next_run_at(
+                frequency=report.frequency,
+                send_time=report.send_time,
+                timezone=report.timezone,
+                send_day_of_week=report.send_day_of_week,
+                send_day_of_month=report.send_day_of_month,
+                after=now,
+            )
+            db.add(ReportRun(
+                report_id=report.id,
+                scheduled_for=report.next_run_at,
+                status="SCHEDULED",
+                recipient_emails=report.recipient_emails,
+            ))
+        db.commit()
+    finally:
+        db.close()
+
+
+@celery_app.task(name="tasks.report_tasks.send_report_run")
+def send_report_run(report_run_id: str) -> None:
+    db = SessionLocal()
+    try:
+        run = db.query(ReportRun).filter(ReportRun.id == report_run_id).first()
+        if run is None:
+            return
+        run.status = "RUNNING"
+        run.started_at = datetime.utcnow()
+        db.commit()
+
+        report = db.query(Report).filter(Report.id == run.report_id).first()
+        try:
+            payload = build_report_payload(db, report)
+            payload["manage_url"] = None
+
+            result = subprocess.run(
+                ["npx", "tsx", str(_RENDER_SCRIPT)],
+                input=json.dumps(payload),
+                capture_output=True,
+                text=True,
+                timeout=60,
+                cwd=str(_RENDER_SCRIPT.parent.parent),
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"render-report.ts failed: {result.stderr}")
+            rendered = json.loads(result.stdout)
+
+            adapter = get_mail_adapter()
+            adapter.send(
+                to=run.recipient_emails,
+                subject=f"{report.name} — {datetime.utcnow().date().isoformat()}",
+                html=rendered["html"],
+                text=rendered["text"],
+            )
+
+            run.status = "SUCCEEDED"
+        except Exception as exc:  # noqa: BLE001 - must never break the Beat loop
+            run.status = "FAILED"
+            run.error_message = str(exc)
+        finally:
+            run.finished_at = datetime.utcnow()
+            db.commit()
+    finally:
+        db.close()

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -42,7 +42,15 @@ def check_due_reports() -> None:
                     recipient_emails=report.recipient_emails,
                 )
                 db.add(run)
-                db.flush()
+
+            # Commit the due run BEFORE enqueueing so the worker (which may
+            # start executing almost immediately with a warm Celery worker
+            # and Redis broker) can always find the row by id. Enqueueing
+            # before this commit lands is a data-loss race: the task would
+            # query for a run that doesn't exist yet, return early, and the
+            # send would be silently lost with no FAILED record.
+            db.commit()
+            db.refresh(run)
 
             send_report_run.delay(str(run.id))
 
@@ -60,7 +68,7 @@ def check_due_reports() -> None:
                 status="SCHEDULED",
                 recipient_emails=report.recipient_emails,
             ))
-        db.commit()
+            db.commit()
     finally:
         db.close()
 

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -108,7 +108,8 @@ def send_report_run(report_run_id: str) -> None:
             db.commit()
 
             payload = build_report_payload(db, report)
-            payload["manage_url"] = None
+            frontend_base_url = (os.environ.get("FRONTEND_URL") or os.environ.get("APP_URL", "http://localhost:3000")).rstrip("/")
+            payload["manage_url"] = f"{frontend_base_url}/reports/{report.id}"
 
             result = subprocess.run(
                 ["npx", "tsx", str(_RENDER_SCRIPT)],

--- a/backend/tasks/report_tasks.py
+++ b/backend/tasks/report_tasks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -14,7 +15,15 @@ from app.models import Report, ReportRun
 from app.services.report_data_service import build_report_payload
 from app.services.report_schedule_service import compute_next_run_at
 
-_RENDER_SCRIPT = Path(__file__).resolve().parent.parent.parent / "frontend" / "emails" / "render-report.ts"
+# In a local checkout, backend/ and frontend/ are siblings, so this resolves
+# correctly by default. Inside the celery-worker/celery-beat containers
+# (backend/Dockerfile), the frontend render assets + node_modules are baked
+# in at /frontend/emails and FRONTEND_EMAILS_DIR is set accordingly in
+# docker-compose.yml -- see that file and backend/Dockerfile's frontend-deps
+# stage.
+_DEFAULT_FRONTEND_EMAILS_DIR = Path(__file__).resolve().parent.parent.parent / "frontend" / "emails"
+_FRONTEND_EMAILS_DIR = Path(os.environ.get("FRONTEND_EMAILS_DIR", str(_DEFAULT_FRONTEND_EMAILS_DIR)))
+_RENDER_SCRIPT = _FRONTEND_EMAILS_DIR / "render-report.ts"
 
 
 @celery_app.task(name="tasks.report_tasks.check_due_reports")

--- a/backend/tests/test_mail_adapter.py
+++ b/backend/tests/test_mail_adapter.py
@@ -1,0 +1,88 @@
+"""Tests for mail provider selection and send adapters.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_mail_adapter.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.integrations.mail_adapter import (  # noqa: E402
+    ResendMailAdapter,
+    SmtpMailAdapter,
+    UsesendMailAdapter,
+    get_mail_adapter,
+)
+
+
+def test_smtp_takes_precedence_when_all_configured(monkeypatch):
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_USERNAME", "user")
+    monkeypatch.setenv("SMTP_PASSWORD", "pass")
+    monkeypatch.setenv("SMTP_FROM", "reports@example.com")
+    monkeypatch.setenv("RESEND_API_KEY", "re_123")
+    monkeypatch.setenv("USESEND_API_KEY", "us_123")
+    adapter = get_mail_adapter()
+    assert isinstance(adapter, SmtpMailAdapter)
+
+
+def test_resend_used_when_smtp_absent(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.setenv("RESEND_API_KEY", "re_123")
+    monkeypatch.setenv("RESEND_FROM", "reports@example.com")
+    monkeypatch.setenv("USESEND_API_KEY", "us_123")
+    adapter = get_mail_adapter()
+    assert isinstance(adapter, ResendMailAdapter)
+
+
+def test_usesend_used_when_only_usesend_configured(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setenv("USESEND_API_KEY", "us_123")
+    monkeypatch.setenv("USESEND_FROM", "reports@example.com")
+    adapter = get_mail_adapter()
+    assert isinstance(adapter, UsesendMailAdapter)
+
+
+def test_raises_when_nothing_configured(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.delenv("USESEND_API_KEY", raising=False)
+    try:
+        get_mail_adapter()
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert "mail provider" in str(e).lower()
+
+
+def test_smtp_adapter_calls_smtplib():
+    with patch("app.integrations.mail_adapter.smtplib.SMTP") as mock_smtp_cls:
+        mock_conn = MagicMock()
+        mock_smtp_cls.return_value.__enter__.return_value = mock_conn
+        adapter = SmtpMailAdapter(
+            host="smtp.example.com", port=587, username="u", password="p", from_addr="reports@example.com"
+        )
+        adapter.send(["dest@example.com"], "Subject", "<p>hi</p>", "hi")
+        mock_conn.starttls.assert_called_once()
+        mock_conn.login.assert_called_once_with("u", "p")
+        assert mock_conn.sendmail.called
+
+
+def test_resend_adapter_calls_resend_client():
+    with patch("app.integrations.mail_adapter.resend") as mock_resend:
+        adapter = ResendMailAdapter(api_key="re_123", from_addr="reports@example.com")
+        adapter.send(["dest@example.com"], "Subject", "<p>hi</p>", "hi")
+        mock_resend.Emails.send.assert_called_once()
+
+
+def test_usesend_adapter_calls_http_post():
+    with patch("app.integrations.mail_adapter.requests.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=200, ok=True)
+        adapter = UsesendMailAdapter(api_key="us_123", from_addr="reports@example.com", base_url="https://usesend.example.com")
+        adapter.send(["dest@example.com"], "Subject", "<p>hi</p>", "hi")
+        mock_post.assert_called_once()

--- a/backend/tests/test_mail_adapter.py
+++ b/backend/tests/test_mail_adapter.py
@@ -60,9 +60,43 @@ def test_raises_when_nothing_configured(monkeypatch):
         assert "mail provider" in str(e).lower()
 
 
+def test_smtp_fails_fast_when_from_missing(monkeypatch):
+    monkeypatch.setenv("SMTP_HOST", "smtp.example.com")
+    monkeypatch.delenv("SMTP_FROM", raising=False)
+    try:
+        get_mail_adapter()
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert "SMTP_FROM" in str(e)
+
+
+def test_resend_fails_fast_when_from_missing(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.setenv("RESEND_API_KEY", "re_123")
+    monkeypatch.delenv("RESEND_FROM", raising=False)
+    try:
+        get_mail_adapter()
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert "RESEND_FROM" in str(e)
+
+
+def test_usesend_fails_fast_when_from_missing(monkeypatch):
+    monkeypatch.delenv("SMTP_HOST", raising=False)
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.setenv("USESEND_API_KEY", "us_123")
+    monkeypatch.delenv("USESEND_FROM", raising=False)
+    try:
+        get_mail_adapter()
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert "USESEND_FROM" in str(e)
+
+
 def test_smtp_adapter_calls_smtplib():
     with patch("app.integrations.mail_adapter.smtplib.SMTP") as mock_smtp_cls:
         mock_conn = MagicMock()
+        mock_conn.sendmail.return_value = {}
         mock_smtp_cls.return_value.__enter__.return_value = mock_conn
         adapter = SmtpMailAdapter(
             host="smtp.example.com", port=587, username="u", password="p", from_addr="reports@example.com"
@@ -71,6 +105,74 @@ def test_smtp_adapter_calls_smtplib():
         mock_conn.starttls.assert_called_once()
         mock_conn.login.assert_called_once_with("u", "p")
         assert mock_conn.sendmail.called
+
+
+def test_smtp_adapter_uses_connect_timeout():
+    with patch("app.integrations.mail_adapter.smtplib.SMTP") as mock_smtp_cls:
+        mock_conn = MagicMock()
+        mock_conn.sendmail.return_value = {}
+        mock_smtp_cls.return_value.__enter__.return_value = mock_conn
+        adapter = SmtpMailAdapter(
+            host="smtp.example.com", port=587, username="u", password="p", from_addr="reports@example.com",
+            timeout=5,
+        )
+        adapter.send(["dest@example.com"], "Subject", "<p>hi</p>", "hi")
+        mock_smtp_cls.assert_called_once_with("smtp.example.com", 587, timeout=5)
+
+
+def test_smtp_adapter_default_timeout_is_30():
+    with patch("app.integrations.mail_adapter.smtplib.SMTP") as mock_smtp_cls:
+        mock_conn = MagicMock()
+        mock_conn.sendmail.return_value = {}
+        mock_smtp_cls.return_value.__enter__.return_value = mock_conn
+        adapter = SmtpMailAdapter(
+            host="smtp.example.com", port=587, username="u", password="p", from_addr="reports@example.com",
+        )
+        adapter.send(["dest@example.com"], "Subject", "<p>hi</p>", "hi")
+        mock_smtp_cls.assert_called_once_with("smtp.example.com", 587, timeout=30)
+
+
+def test_smtp_adapter_uses_ssl_on_port_465():
+    with patch("app.integrations.mail_adapter.smtplib.SMTP_SSL") as mock_ssl_cls, \
+         patch("app.integrations.mail_adapter.smtplib.SMTP") as mock_smtp_cls:
+        mock_conn = MagicMock()
+        mock_conn.sendmail.return_value = {}
+        mock_ssl_cls.return_value.__enter__.return_value = mock_conn
+        adapter = SmtpMailAdapter(
+            host="smtp.example.com", port=465, username="u", password="p", from_addr="reports@example.com",
+        )
+        adapter.send(["dest@example.com"], "Subject", "<p>hi</p>", "hi")
+        mock_ssl_cls.assert_called_once_with("smtp.example.com", 465, timeout=30)
+        mock_smtp_cls.assert_not_called()
+        mock_conn.starttls.assert_not_called()
+        mock_conn.login.assert_called_once_with("u", "p")
+
+
+def test_smtp_adapter_skips_login_when_no_credentials():
+    with patch("app.integrations.mail_adapter.smtplib.SMTP") as mock_smtp_cls:
+        mock_conn = MagicMock()
+        mock_conn.sendmail.return_value = {}
+        mock_smtp_cls.return_value.__enter__.return_value = mock_conn
+        adapter = SmtpMailAdapter(
+            host="smtp.example.com", port=587, username="", password="", from_addr="reports@example.com",
+        )
+        adapter.send(["dest@example.com"], "Subject", "<p>hi</p>", "hi")
+        mock_conn.login.assert_not_called()
+
+
+def test_smtp_adapter_raises_on_refused_recipients():
+    with patch("app.integrations.mail_adapter.smtplib.SMTP") as mock_smtp_cls:
+        mock_conn = MagicMock()
+        mock_conn.sendmail.return_value = {"bad@example.com": (550, b"No such user")}
+        mock_smtp_cls.return_value.__enter__.return_value = mock_conn
+        adapter = SmtpMailAdapter(
+            host="smtp.example.com", port=587, username="u", password="p", from_addr="reports@example.com",
+        )
+        try:
+            adapter.send(["dest@example.com", "bad@example.com"], "Subject", "<p>hi</p>", "hi")
+            assert False, "expected RuntimeError"
+        except RuntimeError as e:
+            assert "refused" in str(e).lower()
 
 
 def test_resend_adapter_calls_resend_client():

--- a/backend/tests/test_report_data_service.py
+++ b/backend/tests/test_report_data_service.py
@@ -88,6 +88,45 @@ def test_build_report_payload_recent_all():
         db.close()
 
 
+def test_build_report_payload_top_n_all_orders_by_absolute_magnitude():
+    db = SessionLocal()
+    try:
+        user, account = _seed_user_with_account_and_transactions(db)
+        now = datetime.utcnow()
+        # Mixed large debit/credit on top of the -50/-20/+2000 seeded above.
+        db.add(Transaction(
+            user_id=user.id,
+            account_id=account.id,
+            transaction_type="debit",
+            amount=Decimal("-5000.00"),
+            currency="EUR",
+            description="Big rent",
+            booked_at=now - timedelta(days=5),
+        ))
+        db.flush()
+
+        report = Report(
+            user_id=user.id,
+            name="Test report",
+            account_ids=[str(account.id)],
+            transaction_mode="TOP_N",
+            transaction_count=2,
+            transaction_direction="ALL",
+            frequency="DAILY",
+        )
+        db.add(report)
+        db.flush()
+
+        payload = build_report_payload(db, report)
+        items = payload["transactions"]["items"]
+        assert len(items) == 2
+        assert items[0]["description"] == "Big rent"  # abs(5000) largest
+        assert items[1]["description"] == "Salary"  # abs(2000) next largest
+    finally:
+        db.rollback()
+        db.close()
+
+
 def test_build_report_payload_functional_balance_uses_user_functional_currency():
     db = SessionLocal()
     try:

--- a/backend/tests/test_report_data_service.py
+++ b/backend/tests/test_report_data_service.py
@@ -1,0 +1,115 @@
+"""Tests for report data aggregation.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_report_data_service.py -v
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-report-data"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Account, Report, Transaction, User  # noqa: E402
+from app.services.report_data_service import build_report_payload  # noqa: E402
+
+
+def _seed_user_with_account_and_transactions(db):
+    user = User(id=f"test-user-{uuid.uuid4()}", email=f"{uuid.uuid4()}@example.com", name="Test User")
+    db.add(user)
+    db.flush()
+
+    account = Account(
+        user_id=user.id,
+        name="Checking",
+        account_type="checking",
+        currency="EUR",
+        functional_balance=Decimal("1234.56"),
+    )
+    db.add(account)
+    db.flush()
+
+    now = datetime.utcnow()
+    for i, (amount, ttype, desc) in enumerate([
+        (Decimal("-50.00"), "debit", "Groceries"),
+        (Decimal("-20.00"), "debit", "Coffee"),
+        (Decimal("2000.00"), "credit", "Salary"),
+    ]):
+        db.add(Transaction(
+            user_id=user.id,
+            account_id=account.id,
+            transaction_type=ttype,
+            amount=amount,
+            currency="EUR",
+            description=desc,
+            booked_at=now - timedelta(days=i),
+        ))
+    db.flush()
+    return user, account
+
+
+def test_build_report_payload_recent_all():
+    db = SessionLocal()
+    try:
+        user, account = _seed_user_with_account_and_transactions(db)
+        report = Report(
+            user_id=user.id,
+            name="Test report",
+            account_ids=[str(account.id)],
+            transaction_mode="RECENT",
+            transaction_count=2,
+            transaction_direction="ALL",
+            frequency="DAILY",
+        )
+        db.add(report)
+        db.flush()
+
+        payload = build_report_payload(db, report)
+        assert payload["accounts"][0]["balance"] == "1234.56"
+        assert payload["transactions"]["mode_label"] == "Last 2 transactions"
+        assert len(payload["transactions"]["items"]) == 2
+    finally:
+        db.rollback()
+        db.close()
+
+
+def test_build_report_payload_top_n_expenses():
+    db = SessionLocal()
+    try:
+        user, account = _seed_user_with_account_and_transactions(db)
+        report = Report(
+            user_id=user.id,
+            name="Test report",
+            account_ids=[str(account.id)],
+            transaction_mode="TOP_N",
+            transaction_count=1,
+            transaction_direction="EXPENSE",
+            frequency="DAILY",
+        )
+        db.add(report)
+        db.flush()
+
+        payload = build_report_payload(db, report)
+        assert payload["transactions"]["mode_label"] == "Top 1 expenses"
+        items = payload["transactions"]["items"]
+        assert len(items) == 1
+        assert items[0]["description"] == "Groceries"  # largest debit amount
+        assert items[0]["direction"] == "out"
+    finally:
+        db.rollback()
+        db.close()

--- a/backend/tests/test_report_data_service.py
+++ b/backend/tests/test_report_data_service.py
@@ -88,6 +88,33 @@ def test_build_report_payload_recent_all():
         db.close()
 
 
+def test_build_report_payload_functional_balance_uses_user_functional_currency():
+    db = SessionLocal()
+    try:
+        user, account = _seed_user_with_account_and_transactions(db)
+        user.functional_currency = "GBP"
+        db.flush()
+
+        report = Report(
+            user_id=user.id,
+            name="Test report",
+            account_ids=[str(account.id)],
+            transaction_mode="RECENT",
+            transaction_count=2,
+            transaction_direction="ALL",
+            frequency="DAILY",
+        )
+        db.add(report)
+        db.flush()
+
+        payload = build_report_payload(db, report)
+        assert payload["accounts"][0]["balance"] == "1234.56"
+        assert payload["accounts"][0]["currency"] == "GBP"
+    finally:
+        db.rollback()
+        db.close()
+
+
 def test_build_report_payload_top_n_expenses():
     db = SessionLocal()
     try:

--- a/backend/tests/test_report_models.py
+++ b/backend/tests/test_report_models.py
@@ -38,10 +38,11 @@ def test_create_report_and_run_round_trip():
     db = SessionLocal()
     try:
         user = _make_user(db)
+        account_id = str(uuid.uuid4())
         report = Report(
             user_id=user.id,
             name="Weekly summary",
-            account_ids=[],
+            account_ids=[account_id],
             transaction_mode="TOP_N",
             transaction_count=5,
             transaction_direction="EXPENSE",
@@ -65,8 +66,14 @@ def test_create_report_and_run_round_trip():
 
         fetched = db.query(Report).filter(Report.id == report.id).one()
         assert fetched.transaction_direction == "EXPENSE"
+        # JSONB list columns must round-trip exactly, not e.g. degrade to a
+        # string or drop entries.
+        assert fetched.recipient_emails == ["me@example.com"]
+        assert fetched.account_ids == [account_id]
+
         fetched_run = db.query(ReportRun).filter(ReportRun.report_id == report.id).one()
         assert fetched_run.status == "SCHEDULED"
+        assert fetched_run.recipient_emails == ["me@example.com"]
     finally:
         db.rollback()
         db.close()

--- a/backend/tests/test_report_models.py
+++ b/backend/tests/test_report_models.py
@@ -1,0 +1,72 @@
+"""Tests for Report / ReportRun models.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_report_models.py -v
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+import uuid
+from datetime import datetime, time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-report-models"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Report, ReportRun, User  # noqa: E402
+
+
+def _make_user(db) -> User:
+    user = User(id=f"test-user-{uuid.uuid4()}", email=f"{uuid.uuid4()}@example.com", name="Test User")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def test_create_report_and_run_round_trip():
+    db = SessionLocal()
+    try:
+        user = _make_user(db)
+        report = Report(
+            user_id=user.id,
+            name="Weekly summary",
+            account_ids=[],
+            transaction_mode="TOP_N",
+            transaction_count=5,
+            transaction_direction="EXPENSE",
+            frequency="WEEKLY",
+            send_time=time(8, 0),
+            send_day_of_week=0,
+            timezone="Europe/Brussels",
+            recipient_emails=["me@example.com"],
+        )
+        db.add(report)
+        db.flush()
+
+        run = ReportRun(
+            report_id=report.id,
+            scheduled_for=datetime(2026, 7, 20, 8, 0),
+            status="SCHEDULED",
+            recipient_emails=["me@example.com"],
+        )
+        db.add(run)
+        db.flush()
+
+        fetched = db.query(Report).filter(Report.id == report.id).one()
+        assert fetched.transaction_direction == "EXPENSE"
+        fetched_run = db.query(ReportRun).filter(ReportRun.report_id == report.id).one()
+        assert fetched_run.status == "SCHEDULED"
+    finally:
+        db.rollback()
+        db.close()

--- a/backend/tests/test_report_routes.py
+++ b/backend/tests/test_report_routes.py
@@ -174,3 +174,212 @@ def test_create_report_weekly_requires_send_day_of_week():
         db.rollback()
         db.close()
         app.dependency_overrides.pop(get_user_id, None)
+
+
+def _base_report_payload(**overrides):
+    payload = {
+        "name": "Weekly summary",
+        "frequency": "WEEKLY",
+        "send_day_of_week": 0,
+        "recipient_emails": ["me@example.com"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_create_report_rejects_out_of_bounds_send_day_of_week():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post("/api/reports", json=_base_report_payload(send_day_of_week=7))
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_out_of_bounds_send_day_of_month():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post(
+            "/api/reports",
+            json=_base_report_payload(frequency="MONTHLY", send_day_of_week=None, send_day_of_month=29),
+        )
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_invalid_timezone():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post("/api/reports", json=_base_report_payload(timezone="Not/AZone"))
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_empty_recipient_emails():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post("/api/reports", json=_base_report_payload(recipient_emails=[]))
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_invalid_recipient_email():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post("/api/reports", json=_base_report_payload(recipient_emails=["not-an-email"]))
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_malformed_send_time():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post("/api/reports", json=_base_report_payload(send_time="25:99"))
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_foreign_account_id():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post(
+            "/api/reports", json=_base_report_payload(account_ids=[str(uuid.uuid4())])
+        )
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_malformed_account_id():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        resp = client.post("/api/reports", json=_base_report_payload(account_ids=["not-a-uuid"]))
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_patch_report_to_weekly_without_send_day_of_week_rejected():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+
+        create_resp = client.post(
+            "/api/reports",
+            json={
+                "name": "Daily summary",
+                "frequency": "DAILY",
+                "recipient_emails": ["me@example.com"],
+            },
+        )
+        assert create_resp.status_code == 200, create_resp.text
+        report_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(f"/api/reports/{report_id}", json={"frequency": "WEEKLY"})
+        assert patch_resp.status_code == 422, patch_resp.text
+
+        # Report must remain unaffected by the rejected PATCH.
+        get_resp = client.get(f"/api/reports/{report_id}")
+        assert get_resp.json()["frequency"] == "DAILY"
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_patch_report_is_active_only_still_works():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+
+        create_resp = client.post("/api/reports", json=_base_report_payload())
+        report_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(f"/api/reports/{report_id}", json={"is_active": False})
+        assert patch_resp.status_code == 200, patch_resp.text
+        assert patch_resp.json()["is_active"] is False
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_patch_report_recipient_emails_only_still_works():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+
+        create_resp = client.post("/api/reports", json=_base_report_payload())
+        report_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(
+            f"/api/reports/{report_id}", json={"recipient_emails": ["someone-else@example.com"]}
+        )
+        assert patch_resp.status_code == 200, patch_resp.text
+        assert patch_resp.json()["recipient_emails"] == ["someone-else@example.com"]
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)

--- a/backend/tests/test_report_routes.py
+++ b/backend/tests/test_report_routes.py
@@ -250,6 +250,28 @@ def test_create_report_rejects_empty_recipient_emails():
         app.dependency_overrides.pop(get_user_id, None)
 
 
+def test_create_report_rejects_missing_recipient_emails_key():
+    # Omitting the key entirely (not just passing []) previously bypassed
+    # validation because pydantic v2 skips field validators on default
+    # values, letting an empty list reach the DB and only fail later when
+    # ReportResponse re-serialized it. recipient_emails now has no default,
+    # so omission is itself a 422 "field required".
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+        payload = _base_report_payload()
+        del payload["recipient_emails"]
+        resp = client.post("/api/reports", json=payload)
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
 def test_create_report_rejects_invalid_recipient_email():
     db = SessionLocal()
     try:
@@ -377,6 +399,29 @@ def test_patch_report_recipient_emails_only_still_works():
         )
         assert patch_resp.status_code == 200, patch_resp.text
         assert patch_resp.json()["recipient_emails"] == ["someone-else@example.com"]
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_patch_report_rejects_explicit_null_account_ids():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+
+        create_resp = client.post("/api/reports", json=_base_report_payload())
+        report_id = create_resp.json()["id"]
+
+        patch_resp = client.patch(f"/api/reports/{report_id}", json={"account_ids": None})
+        assert patch_resp.status_code == 422, patch_resp.text
+
+        # Confirm the report was left untouched, not partially mutated.
+        get_resp = client.get(f"/api/reports/{report_id}")
+        assert get_resp.json()["account_ids"] == []
     finally:
         db.query(User).filter(User.id == user.id).delete()
         db.commit()

--- a/backend/tests/test_report_routes.py
+++ b/backend/tests/test_report_routes.py
@@ -128,3 +128,49 @@ def test_create_list_update_delete_report():
         db.rollback()
         db.close()
         app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_rejects_invalid_frequency():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+
+        resp = client.post(
+            "/api/reports",
+            json={
+                "name": "Yearly summary",
+                "frequency": "YEARLY",
+                "recipient_emails": ["me@example.com"],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)
+
+
+def test_create_report_weekly_requires_send_day_of_week():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+
+        resp = client.post(
+            "/api/reports",
+            json={
+                "name": "Weekly summary",
+                "frequency": "WEEKLY",
+                "recipient_emails": ["me@example.com"],
+            },
+        )
+        assert resp.status_code == 422, resp.text
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)

--- a/backend/tests/test_report_routes.py
+++ b/backend/tests/test_report_routes.py
@@ -1,0 +1,130 @@
+"""Tests for /api/reports routes.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_report_routes.py -v
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import sys
+import time
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-report-routes"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+    os.environ.setdefault("INTERNAL_AUTH_SECRET", "test-internal-secret")
+
+
+_set_test_env()
+
+INTERNAL_AUTH_SECRET = os.environ["INTERNAL_AUTH_SECRET"]
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.database import SessionLocal  # noqa: E402
+from app.db_helpers import get_user_id  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models import User  # noqa: E402
+
+
+def _seed_user(db) -> User:
+    user = User(id=f"test-user-{uuid.uuid4()}", email=f"{uuid.uuid4()}@example.com", name="Test User")
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _signed_headers(method: str, path_with_query: str, user_id: str) -> dict:
+    timestamp = str(int(time.time()))
+    payload = "\n".join([method.upper(), path_with_query, user_id, timestamp])
+    signature = hmac.new(
+        INTERNAL_AUTH_SECRET.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return {
+        "x-syllogic-user-id": user_id,
+        "x-syllogic-timestamp": timestamp,
+        "x-syllogic-signature": signature,
+    }
+
+
+class _SigningClient:
+    """Wraps TestClient to attach signed internal-auth headers (required by
+    app.main's internal_auth_middleware) in addition to overriding
+    get_user_id for the route-level dependency."""
+
+    def __init__(self, client: TestClient, user_id: str):
+        self._client = client
+        self._user_id = user_id
+
+    def request(self, method: str, url: str, **kwargs):
+        headers = dict(kwargs.pop("headers", {}) or {})
+        headers.update(_signed_headers(method, url, self._user_id))
+        return self._client.request(method, url, headers=headers, **kwargs)
+
+    def get(self, url, **kw):
+        return self.request("GET", url, **kw)
+
+    def post(self, url, **kw):
+        return self.request("POST", url, **kw)
+
+    def patch(self, url, **kw):
+        return self.request("PATCH", url, **kw)
+
+    def delete(self, url, **kw):
+        return self.request("DELETE", url, **kw)
+
+
+def _client_for_user(user_id: str) -> _SigningClient:
+    app.dependency_overrides[get_user_id] = lambda: user_id
+    return _SigningClient(TestClient(app), user_id)
+
+
+def test_create_list_update_delete_report():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        client = _client_for_user(user.id)
+
+        create_resp = client.post(
+            "/api/reports",
+            json={
+                "name": "Weekly summary",
+                "frequency": "WEEKLY",
+                "send_day_of_week": 0,
+                "recipient_emails": ["me@example.com"],
+            },
+        )
+        assert create_resp.status_code == 200, create_resp.text
+        report_id = create_resp.json()["id"]
+        assert create_resp.json()["next_run_at"] is not None
+
+        list_resp = client.get("/api/reports")
+        assert list_resp.status_code == 200
+        assert any(r["id"] == report_id for r in list_resp.json())
+
+        patch_resp = client.patch(f"/api/reports/{report_id}", json={"is_active": False})
+        assert patch_resp.status_code == 200
+        assert patch_resp.json()["is_active"] is False
+
+        delete_resp = client.delete(f"/api/reports/{report_id}")
+        assert delete_resp.status_code == 204
+
+        get_resp = client.get(f"/api/reports/{report_id}")
+        assert get_resp.status_code == 404
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+        app.dependency_overrides.pop(get_user_id, None)

--- a/backend/tests/test_report_schedule_service.py
+++ b/backend/tests/test_report_schedule_service.py
@@ -1,0 +1,61 @@
+"""Tests for report scheduling math.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_report_schedule_service.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from datetime import time  # noqa: E402
+
+from app.services.report_schedule_service import compute_next_run_at  # noqa: E402
+
+
+def test_daily_next_run_today_if_time_not_passed():
+    after = datetime(2026, 7, 19, 6, 0)  # 06:00 UTC
+    result = compute_next_run_at("DAILY", time(8, 0), "UTC", None, None, after)
+    assert result == datetime(2026, 7, 19, 8, 0)
+
+
+def test_daily_next_run_tomorrow_if_time_passed():
+    after = datetime(2026, 7, 19, 9, 0)  # after 08:00
+    result = compute_next_run_at("DAILY", time(8, 0), "UTC", None, None, after)
+    assert result == datetime(2026, 7, 20, 8, 0)
+
+
+def test_weekly_picks_next_matching_weekday():
+    # 2026-07-19 is a Sunday (weekday()==6). Target Monday (0).
+    after = datetime(2026, 7, 19, 6, 0)
+    result = compute_next_run_at("WEEKLY", time(8, 0), "UTC", 0, None, after)
+    assert result == datetime(2026, 7, 20, 8, 0)  # Monday 2026-07-20
+
+
+def test_biweekly_skips_one_week_from_weekly():
+    after = datetime(2026, 7, 19, 6, 0)
+    weekly = compute_next_run_at("WEEKLY", time(8, 0), "UTC", 0, None, after)
+    biweekly = compute_next_run_at("BIWEEKLY", time(8, 0), "UTC", 0, None, after)
+    assert (biweekly - weekly).days == 7
+
+
+def test_monthly_picks_day_of_month_next_month_if_passed():
+    after = datetime(2026, 7, 19, 6, 0)
+    result = compute_next_run_at("MONTHLY", time(8, 0), "UTC", None, 1, after)
+    assert result == datetime(2026, 8, 1, 8, 0)
+
+
+def test_monthly_same_month_if_day_not_yet_passed():
+    after = datetime(2026, 7, 1, 6, 0)
+    result = compute_next_run_at("MONTHLY", time(8, 0), "UTC", None, 15, after)
+    assert result == datetime(2026, 7, 15, 8, 0)
+
+
+def test_timezone_converts_local_time_to_utc():
+    # Europe/Brussels is UTC+2 in July (CEST). 08:00 local == 06:00 UTC.
+    after = datetime(2026, 7, 19, 0, 0)  # UTC
+    result = compute_next_run_at("DAILY", time(8, 0), "Europe/Brussels", None, None, after)
+    assert result == datetime(2026, 7, 19, 6, 0)

--- a/backend/tests/test_report_tasks.py
+++ b/backend/tests/test_report_tasks.py
@@ -47,10 +47,26 @@ def _seed_due_report(db) -> Report:
     return report
 
 
+def _cleanup_user(db, user_id: str) -> None:
+    """Delete the seeded user (cascades to reports/report_runs via FK).
+
+    Without this, tests that db.commit() their seed data leave rows behind
+    in the shared dev Postgres across every test run, which makes
+    test_check_due_reports_enqueues_and_reschedules flaky (it counts
+    .delay() calls across ALL due reports, including stale ones from
+    earlier runs).
+    """
+    db.rollback()
+    db.query(User).filter(User.id == user_id).delete()
+    db.commit()
+
+
 def test_check_due_reports_enqueues_and_reschedules():
     db = SessionLocal()
+    user_id = None
     try:
         report = _seed_due_report(db)
+        user_id = report.user_id
         db.commit()
 
         with patch.object(report_tasks.send_report_run, "delay") as mock_delay:
@@ -63,14 +79,18 @@ def test_check_due_reports_enqueues_and_reschedules():
         runs = db.query(ReportRun).filter(ReportRun.report_id == report.id).all()
         assert len(runs) >= 1
     finally:
+        if user_id:
+            _cleanup_user(db, user_id)
         db.rollback()
         db.close()
 
 
 def test_send_report_run_success_marks_succeeded():
     db = SessionLocal()
+    user_id = None
     try:
         report = _seed_due_report(db)
+        user_id = report.user_id
         run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
         db.add(run)
         db.commit()
@@ -87,14 +107,18 @@ def test_send_report_run_success_marks_succeeded():
         assert run.finished_at is not None
         mock_adapter.send.assert_called_once()
     finally:
+        if user_id:
+            _cleanup_user(db, user_id)
         db.rollback()
         db.close()
 
 
 def test_send_report_run_sets_real_manage_url():
     db = SessionLocal()
+    user_id = None
     try:
         report = _seed_due_report(db)
+        user_id = report.user_id
         run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
         db.add(run)
         db.commit()
@@ -112,14 +136,18 @@ def test_send_report_run_sets_real_manage_url():
         payload = json.loads(sent_input)
         assert payload["manage_url"] == f"https://app.example.com/reports/{report.id}"
     finally:
+        if user_id:
+            _cleanup_user(db, user_id)
         db.rollback()
         db.close()
 
 
 def test_send_report_run_failure_marks_failed_without_raising():
     db = SessionLocal()
+    user_id = None
     try:
         report = _seed_due_report(db)
+        user_id = report.user_id
         run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
         db.add(run)
         db.commit()
@@ -134,14 +162,18 @@ def test_send_report_run_failure_marks_failed_without_raising():
         assert run.status == "FAILED"
         assert "no provider" in run.error_message
     finally:
+        if user_id:
+            _cleanup_user(db, user_id)
         db.rollback()
         db.close()
 
 
 def test_send_report_run_db_failure_during_transition_does_not_raise():
     db = SessionLocal()
+    user_id = None
     try:
         report = _seed_due_report(db)
+        user_id = report.user_id
         run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
         db.add(run)
         db.commit()
@@ -166,5 +198,7 @@ def test_send_report_run_db_failure_during_transition_does_not_raise():
         assert run.status == "FAILED"
         assert "db unavailable" in (run.error_message or "")
     finally:
+        if user_id:
+            _cleanup_user(db, user_id)
         db.rollback()
         db.close()

--- a/backend/tests/test_report_tasks.py
+++ b/backend/tests/test_report_tasks.py
@@ -6,6 +6,7 @@ Run with:
 from __future__ import annotations
 
 import base64
+import json
 import os
 import sys
 import uuid
@@ -85,6 +86,31 @@ def test_send_report_run_success_marks_succeeded():
         assert run.status == "SUCCEEDED"
         assert run.finished_at is not None
         mock_adapter.send.assert_called_once()
+    finally:
+        db.rollback()
+        db.close()
+
+
+def test_send_report_run_sets_real_manage_url():
+    db = SessionLocal()
+    try:
+        report = _seed_due_report(db)
+        run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
+        db.add(run)
+        db.commit()
+        run_id = str(run.id)
+
+        fake_render = MagicMock(returncode=0, stdout='{"html": "<p>hi</p>", "text": "hi"}', stderr="")
+        mock_adapter = MagicMock()
+        with patch.dict(os.environ, {"FRONTEND_URL": "https://app.example.com"}), \
+             patch.object(report_tasks.subprocess, "run", return_value=fake_render) as mock_run, \
+             patch.object(report_tasks, "get_mail_adapter", return_value=mock_adapter):
+            report_tasks.send_report_run(run_id)
+
+        mock_run.assert_called_once()
+        sent_input = mock_run.call_args.kwargs["input"]
+        payload = json.loads(sent_input)
+        assert payload["manage_url"] == f"https://app.example.com/reports/{report.id}"
     finally:
         db.rollback()
         db.close()

--- a/backend/tests/test_report_tasks.py
+++ b/backend/tests/test_report_tasks.py
@@ -99,7 +99,9 @@ def test_send_report_run_failure_marks_failed_without_raising():
         db.commit()
         run_id = str(run.id)
 
-        with patch.object(report_tasks, "get_mail_adapter", side_effect=RuntimeError("no provider")):
+        fake_render = MagicMock(returncode=0, stdout='{"html": "<p>hi</p>", "text": "hi"}', stderr="")
+        with patch.object(report_tasks.subprocess, "run", return_value=fake_render), \
+             patch.object(report_tasks, "get_mail_adapter", side_effect=RuntimeError("no provider")):
             report_tasks.send_report_run(run_id)  # must not raise
 
         db.refresh(run)

--- a/backend/tests/test_report_tasks.py
+++ b/backend/tests/test_report_tasks.py
@@ -108,3 +108,35 @@ def test_send_report_run_failure_marks_failed_without_raising():
     finally:
         db.rollback()
         db.close()
+
+
+def test_send_report_run_db_failure_during_transition_does_not_raise():
+    db = SessionLocal()
+    try:
+        report = _seed_due_report(db)
+        run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
+        db.add(run)
+        db.commit()
+        run_id = str(run.id)
+
+        from sqlalchemy.orm import Session as SASession
+
+        real_commit = SASession.commit
+        call_count = {"n": 0}
+
+        def flaky_commit(self):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("db unavailable")
+            return real_commit(self)
+
+        with patch.object(SASession, "commit", flaky_commit):
+            report_tasks.send_report_run(run_id)  # must not raise
+
+        db.rollback()
+        db.refresh(run)
+        assert run.status == "FAILED"
+        assert "db unavailable" in (run.error_message or "")
+    finally:
+        db.rollback()
+        db.close()

--- a/backend/tests/test_report_tasks.py
+++ b/backend/tests/test_report_tasks.py
@@ -1,0 +1,110 @@
+"""Tests for report Celery tasks.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_report_tasks.py -v
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-report-tasks"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Report, ReportRun, User  # noqa: E402
+from tasks import report_tasks  # noqa: E402
+
+
+def _seed_due_report(db) -> Report:
+    user = User(id=f"test-user-{uuid.uuid4()}", email=f"{uuid.uuid4()}@example.com", name="Test")
+    db.add(user)
+    db.flush()
+    report = Report(
+        user_id=user.id,
+        name="Daily",
+        frequency="DAILY",
+        recipient_emails=["me@example.com"],
+        is_active=True,
+        next_run_at=datetime.utcnow() - timedelta(minutes=1),
+    )
+    db.add(report)
+    db.flush()
+    return report
+
+
+def test_check_due_reports_enqueues_and_reschedules():
+    db = SessionLocal()
+    try:
+        report = _seed_due_report(db)
+        db.commit()
+
+        with patch.object(report_tasks.send_report_run, "delay") as mock_delay:
+            report_tasks.check_due_reports()
+
+        db.refresh(report)
+        assert report.next_run_at > datetime.utcnow()
+        mock_delay.assert_called_once()
+
+        runs = db.query(ReportRun).filter(ReportRun.report_id == report.id).all()
+        assert len(runs) >= 1
+    finally:
+        db.rollback()
+        db.close()
+
+
+def test_send_report_run_success_marks_succeeded():
+    db = SessionLocal()
+    try:
+        report = _seed_due_report(db)
+        run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
+        db.add(run)
+        db.commit()
+        run_id = str(run.id)
+
+        fake_render = MagicMock(returncode=0, stdout='{"html": "<p>hi</p>", "text": "hi"}', stderr="")
+        mock_adapter = MagicMock()
+        with patch.object(report_tasks.subprocess, "run", return_value=fake_render), \
+             patch.object(report_tasks, "get_mail_adapter", return_value=mock_adapter):
+            report_tasks.send_report_run(run_id)
+
+        db.refresh(run)
+        assert run.status == "SUCCEEDED"
+        assert run.finished_at is not None
+        mock_adapter.send.assert_called_once()
+    finally:
+        db.rollback()
+        db.close()
+
+
+def test_send_report_run_failure_marks_failed_without_raising():
+    db = SessionLocal()
+    try:
+        report = _seed_due_report(db)
+        run = ReportRun(report_id=report.id, status="SCHEDULED", recipient_emails=report.recipient_emails)
+        db.add(run)
+        db.commit()
+        run_id = str(run.id)
+
+        with patch.object(report_tasks, "get_mail_adapter", side_effect=RuntimeError("no provider")):
+            report_tasks.send_report_run(run_id)  # must not raise
+
+        db.refresh(run)
+        assert run.status == "FAILED"
+        assert "no provider" in run.error_message
+    finally:
+        db.rollback()
+        db.close()

--- a/deploy/compose/docker-compose.local.yml
+++ b/deploy/compose/docker-compose.local.yml
@@ -26,6 +26,12 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # backend/Dockerfile's frontend-deps stage renders report newsletters
+      # via `npx tsx frontend/emails/render-report.ts` and needs frontend/
+      # supplied as a named BuildKit context (see backend/Dockerfile and
+      # ../../docker-compose.yml for the same pattern).
+      additional_contexts:
+        - frontend=../../frontend
 
   mcp:
     # Use the locally-built backend image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,17 +58,17 @@ services:
       # additional context instead of widening the primary context (which
       # would also require updating Railway/CI build configs).
       additional_contexts:
-        - frontend=../frontend
+        - frontend=./frontend
     container_name: finance_celery_worker
     command: celery -A celery_app worker --loglevel=info --concurrency=4
     volumes:
       - ./backend:/app
-      # Read-only mount of frontend source so local dev edits to
-      # emails/** are picked up without a rebuild; the image also bakes in
-      # frontend/emails + node_modules at build time (see backend/Dockerfile)
-      # as the source of truth for anything not covered by this mount (e.g.
-      # if the bind mount is unavailable, such as some CI sandboxes).
-      - ./frontend:/frontend:ro
+      # Read-only mount of frontend/emails only (NOT all of frontend/) so
+      # local dev edits to the render template are picked up without a
+      # rebuild, without masking the image's baked /frontend/node_modules
+      # (a full ./frontend:/frontend mount would shadow it, breaking
+      # `npx tsx` since node_modules would then be empty).
+      - ./frontend/emails:/frontend/emails:ro
     environment:
       - DATABASE_URL=postgresql+psycopg://financeuser:financepass@db:5432/finance_db
       - REDIS_URL=redis://redis:6379/0
@@ -83,12 +83,12 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       additional_contexts:
-        - frontend=../frontend
+        - frontend=./frontend
     container_name: finance_celery_beat
     command: celery -A celery_app beat --loglevel=info
     volumes:
       - ./backend:/app
-      - ./frontend:/frontend:ro
+      - ./frontend/emails:/frontend/emails:ro
     environment:
       - DATABASE_URL=postgresql+psycopg://financeuser:financepass@db:5432/finance_db
       - REDIS_URL=redis://redis:6379/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,13 +50,29 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      # backend/Dockerfile's frontend-deps stage needs frontend/** (to
+      # render report newsletters via `npx tsx
+      # frontend/emails/render-report.ts`, invoked from
+      # backend/tasks/report_tasks.py::send_report_run) but frontend/ isn't
+      # inside the ./backend build context -- supply it as a named
+      # additional context instead of widening the primary context (which
+      # would also require updating Railway/CI build configs).
+      additional_contexts:
+        - frontend=../frontend
     container_name: finance_celery_worker
     command: celery -A celery_app worker --loglevel=info --concurrency=4
     volumes:
       - ./backend:/app
+      # Read-only mount of frontend source so local dev edits to
+      # emails/** are picked up without a rebuild; the image also bakes in
+      # frontend/emails + node_modules at build time (see backend/Dockerfile)
+      # as the source of truth for anything not covered by this mount (e.g.
+      # if the bind mount is unavailable, such as some CI sandboxes).
+      - ./frontend:/frontend:ro
     environment:
       - DATABASE_URL=postgresql+psycopg://financeuser:financepass@db:5432/finance_db
       - REDIS_URL=redis://redis:6379/0
+      - FRONTEND_EMAILS_DIR=/frontend/emails
     depends_on:
       - db
       - redis
@@ -66,13 +82,17 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      additional_contexts:
+        - frontend=../frontend
     container_name: finance_celery_beat
     command: celery -A celery_app beat --loglevel=info
     volumes:
       - ./backend:/app
+      - ./frontend:/frontend:ro
     environment:
       - DATABASE_URL=postgresql+psycopg://financeuser:financepass@db:5432/finance_db
       - REDIS_URL=redis://redis:6379/0
+      - FRONTEND_EMAILS_DIR=/frontend/emails
     depends_on:
       - db
       - redis

--- a/frontend/app/(dashboard)/reports/[id]/page.tsx
+++ b/frontend/app/(dashboard)/reports/[id]/page.tsx
@@ -1,27 +1,46 @@
 "use client";
 
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { getReport } from "@/lib/reports/api";
+import { getReport, listAccounts } from "@/lib/reports/api";
 import { ReportForm } from "@/components/reports/ReportForm";
-
-async function fetchAccounts(): Promise<{ id: string; name: string }[]> {
-  const res = await fetch("/api/accounts");
-  if (!res.ok) throw new Error("Failed to load accounts");
-  return res.json();
-}
 
 export default function EditReportPage() {
   const params = useParams<{ id: string }>();
-  const { data: report } = useQuery({ queryKey: ["reports", params.id], queryFn: () => getReport(params.id) });
-  const { data: accounts } = useQuery({ queryKey: ["accounts"], queryFn: fetchAccounts });
+  const {
+    data: report,
+    isLoading: reportLoading,
+    isError: reportError,
+  } = useQuery({ queryKey: ["reports", params.id], queryFn: () => getReport(params.id) });
+  const {
+    data: accounts,
+    isLoading: accountsLoading,
+    isError: accountsError,
+  } = useQuery({ queryKey: ["accounts"], queryFn: listAccounts });
 
-  if (!report) return <div className="p-6 text-sm text-gray-500">Loading…</div>;
+  if (reportLoading) return <div className="p-6 text-sm text-gray-500">Loading…</div>;
+
+  if (reportError || !report) {
+    return (
+      <div className="p-6 text-sm text-gray-500">
+        Report not found or failed to load.{" "}
+        <Link href="/reports" className="text-blue-600">
+          Back to reports
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold mb-4">Edit report</h1>
-      <ReportForm report={report} availableAccounts={accounts ?? []} />
+      <ReportForm
+        report={report}
+        availableAccounts={accounts ?? []}
+        accountsLoading={accountsLoading}
+        accountsError={accountsError}
+      />
     </div>
   );
 }

--- a/frontend/app/(dashboard)/reports/[id]/page.tsx
+++ b/frontend/app/(dashboard)/reports/[id]/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { getReport } from "@/lib/reports/api";
+import { ReportForm } from "@/components/reports/ReportForm";
+
+async function fetchAccounts(): Promise<{ id: string; name: string }[]> {
+  const res = await fetch("/api/accounts");
+  if (!res.ok) throw new Error("Failed to load accounts");
+  return res.json();
+}
+
+export default function EditReportPage() {
+  const params = useParams<{ id: string }>();
+  const { data: report } = useQuery({ queryKey: ["reports", params.id], queryFn: () => getReport(params.id) });
+  const { data: accounts } = useQuery({ queryKey: ["accounts"], queryFn: fetchAccounts });
+
+  if (!report) return <div className="p-6 text-sm text-gray-500">Loading…</div>;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-4">Edit report</h1>
+      <ReportForm report={report} availableAccounts={accounts ?? []} />
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
+++ b/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
@@ -8,7 +8,11 @@ import { RunStatusBadge } from "@/components/reports/RunStatusBadge";
 export default function ReportRunsPage() {
   const params = useParams<{ id: string }>();
   const { data: report } = useQuery({ queryKey: ["reports", params.id], queryFn: () => getReport(params.id) });
-  const { data: runs, isLoading } = useQuery({
+  const {
+    data: runs,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ["reports", params.id, "runs"],
     queryFn: () => listReportRuns(params.id),
     refetchInterval: 10_000,
@@ -21,6 +25,8 @@ export default function ReportRunsPage() {
 
       {isLoading ? (
         <p className="text-sm text-gray-500">Loading…</p>
+      ) : isError ? (
+        <p className="text-sm text-red-600">Failed to load runs. Please try again.</p>
       ) : runs && runs.length > 0 ? (
         <table className="w-full text-sm border rounded-lg overflow-hidden">
           <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">

--- a/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
+++ b/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
@@ -25,7 +25,11 @@ export default function ReportRunsPage() {
 
       {isLoading ? (
         <p className="text-sm text-gray-500">Loading…</p>
-      ) : isError ? (
+      ) : isError && !(runs && runs.length > 0) ? (
+        // Only show the error state when there's no cached data to fall
+        // back on — with refetchInterval polling, a single transient
+        // background refetch failure would otherwise hide a previously
+        // loaded, still-valid run history behind an error message.
         <p className="text-sm text-red-600">Failed to load runs. Please try again.</p>
       ) : runs && runs.length > 0 ? (
         <table className="w-full text-sm border rounded-lg overflow-hidden">

--- a/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
+++ b/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { getReport, listReportRuns } from "@/lib/reports/api";
+import { RunStatusBadge } from "@/components/reports/RunStatusBadge";
+
+export default function ReportRunsPage() {
+  const params = useParams<{ id: string }>();
+  const { data: report } = useQuery({ queryKey: ["reports", params.id], queryFn: () => getReport(params.id) });
+  const { data: runs, isLoading } = useQuery({
+    queryKey: ["reports", params.id, "runs"],
+    queryFn: () => listReportRuns(params.id),
+    refetchInterval: 10_000,
+  });
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-1">{report ? `${report.name} — Runs` : "Runs"}</h1>
+      <p className="text-sm text-gray-500 mb-4">Scheduled and executed sends for this report.</p>
+
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : runs && runs.length > 0 ? (
+        <table className="w-full text-sm border rounded-lg overflow-hidden">
+          <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
+            <tr>
+              <th className="px-4 py-2">Scheduled for</th>
+              <th className="px-4 py-2">Status</th>
+              <th className="px-4 py-2">Finished</th>
+              <th className="px-4 py-2">Error</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {runs.map((run) => (
+              <tr key={run.id}>
+                <td className="px-4 py-2">
+                  {run.is_test
+                    ? "Test send"
+                    : run.scheduled_for
+                    ? new Date(run.scheduled_for).toLocaleString()
+                    : "—"}
+                </td>
+                <td className="px-4 py-2">
+                  <RunStatusBadge status={run.status} />
+                </td>
+                <td className="px-4 py-2">{run.finished_at ? new Date(run.finished_at).toLocaleString() : "—"}</td>
+                <td className="px-4 py-2 text-red-600">{run.error_message ?? ""}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm text-gray-500">No runs yet.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/reports/new/page.tsx
+++ b/frontend/app/(dashboard)/reports/new/page.tsx
@@ -1,21 +1,24 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { listAccounts } from "@/lib/reports/api";
 import { ReportForm } from "@/components/reports/ReportForm";
 
-async function fetchAccounts(): Promise<{ id: string; name: string }[]> {
-  const res = await fetch("/api/accounts");
-  if (!res.ok) throw new Error("Failed to load accounts");
-  return res.json();
-}
-
 export default function NewReportPage() {
-  const { data: accounts } = useQuery({ queryKey: ["accounts"], queryFn: fetchAccounts });
+  const {
+    data: accounts,
+    isLoading: accountsLoading,
+    isError: accountsError,
+  } = useQuery({ queryKey: ["accounts"], queryFn: listAccounts });
 
   return (
     <div className="p-6">
       <h1 className="text-xl font-semibold mb-4">New report</h1>
-      <ReportForm availableAccounts={accounts ?? []} />
+      <ReportForm
+        availableAccounts={accounts ?? []}
+        accountsLoading={accountsLoading}
+        accountsError={accountsError}
+      />
     </div>
   );
 }

--- a/frontend/app/(dashboard)/reports/new/page.tsx
+++ b/frontend/app/(dashboard)/reports/new/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { ReportForm } from "@/components/reports/ReportForm";
+
+async function fetchAccounts(): Promise<{ id: string; name: string }[]> {
+  const res = await fetch("/api/accounts");
+  if (!res.ok) throw new Error("Failed to load accounts");
+  return res.json();
+}
+
+export default function NewReportPage() {
+  const { data: accounts } = useQuery({ queryKey: ["accounts"], queryFn: fetchAccounts });
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold mb-4">New report</h1>
+      <ReportForm availableAccounts={accounts ?? []} />
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/reports/page.tsx
+++ b/frontend/app/(dashboard)/reports/page.tsx
@@ -1,16 +1,29 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { deleteReport, listReports } from "@/lib/reports/api";
 
 export default function ReportsPage() {
   const queryClient = useQueryClient();
-  const { data: reports, isLoading } = useQuery({ queryKey: ["reports"], queryFn: listReports });
+  const {
+    data: reports,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({ queryKey: ["reports"], queryFn: listReports });
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   async function handleDelete(id: string) {
-    await deleteReport(id);
-    queryClient.invalidateQueries({ queryKey: ["reports"] });
+    if (!window.confirm("Delete this report? This cannot be undone.")) return;
+    setDeleteError(null);
+    try {
+      await deleteReport(id);
+      queryClient.invalidateQueries({ queryKey: ["reports"] });
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Failed to delete report. Please try again.");
+    }
   }
 
   return (
@@ -22,8 +35,17 @@ export default function ReportsPage() {
         </Link>
       </div>
 
+      {deleteError && <p className="text-sm text-red-600 mb-4">{deleteError}</p>}
+
       {isLoading ? (
         <p className="text-sm text-gray-500">Loading…</p>
+      ) : isError ? (
+        <div className="text-sm text-gray-500">
+          Failed to load reports.{" "}
+          <button onClick={() => refetch()} className="text-blue-600 font-medium">
+            Retry
+          </button>
+        </div>
       ) : reports && reports.length > 0 ? (
         <ul className="divide-y divide-gray-200 border rounded-lg">
           {reports.map((report) => (

--- a/frontend/app/(dashboard)/reports/page.tsx
+++ b/frontend/app/(dashboard)/reports/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { deleteReport, listReports } from "@/lib/reports/api";
+
+export default function ReportsPage() {
+  const queryClient = useQueryClient();
+  const { data: reports, isLoading } = useQuery({ queryKey: ["reports"], queryFn: listReports });
+
+  async function handleDelete(id: string) {
+    await deleteReport(id);
+    queryClient.invalidateQueries({ queryKey: ["reports"] });
+  }
+
+  return (
+    <div className="p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-xl font-semibold">Reports</h1>
+        <Link href="/reports/new" className="text-sm font-medium text-blue-600">
+          New report
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : reports && reports.length > 0 ? (
+        <ul className="divide-y divide-gray-200 border rounded-lg">
+          {reports.map((report) => (
+            <li key={report.id} className="flex items-center justify-between px-4 py-3">
+              <div>
+                <Link href={`/reports/${report.id}`} className="font-medium text-gray-900">
+                  {report.name}
+                </Link>
+                <p className="text-xs text-gray-500">
+                  {report.frequency.toLowerCase()} · next run{" "}
+                  {report.next_run_at ? new Date(report.next_run_at).toLocaleString() : "—"} ·{" "}
+                  {report.is_active ? "active" : "paused"}
+                </p>
+              </div>
+              <div className="flex gap-3">
+                <Link href={`/reports/${report.id}/runs`} className="text-sm text-gray-600">
+                  Runs
+                </Link>
+                <button onClick={() => handleDelete(report.id)} className="text-sm text-red-600">
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-gray-500">No reports yet. Create one to get started.</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/layout/app-sidebar.tsx
+++ b/frontend/components/layout/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   RiArrowUpDownLine,
   RiLoopRightLine,
   RiLineChartLine,
+  RiFileTextLine,
   RiArrowRightSLine,
   RiArrowLeftSLine,
 } from "@remixicon/react";
@@ -77,6 +78,11 @@ const navItems = [
     title: "Assets",
     href: "/assets",
     icon: RiWallet3Line,
+  },
+  {
+    title: "Reports",
+    href: "/reports",
+    icon: RiFileTextLine,
   },
   {
     title: "Settings",

--- a/frontend/components/reports/ReportForm.tsx
+++ b/frontend/components/reports/ReportForm.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { createReport, sendTestReport, updateReport } from "@/lib/reports/api";
+import type { Report, ReportInput } from "@/lib/reports/types";
+
+const schema = z.object({
+  name: z.string().min(1, "Required"),
+  account_ids: z.array(z.string()),
+  transaction_mode: z.enum(["RECENT", "TOP_N"]),
+  transaction_count: z.coerce.number().int().min(1).max(100),
+  transaction_direction: z.enum(["ALL", "EXPENSE", "INCOME", "INFLOW", "OUTFLOW"]),
+  frequency: z.enum(["DAILY", "WEEKLY", "BIWEEKLY", "MONTHLY"]),
+  send_time: z.string().min(1),
+  send_day_of_week: z.coerce.number().int().min(0).max(6).nullable().optional(),
+  send_day_of_month: z.coerce.number().int().min(1).max(28).nullable().optional(),
+  timezone: z.string().min(1),
+  recipient_emails: z.array(z.string().email()).min(1, "Add at least one recipient"),
+  is_active: z.boolean(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+const DEFAULTS: FormValues = {
+  name: "",
+  account_ids: [],
+  transaction_mode: "RECENT",
+  transaction_count: 10,
+  transaction_direction: "ALL",
+  frequency: "WEEKLY",
+  send_time: "08:00:00",
+  send_day_of_week: 0,
+  send_day_of_month: null,
+  timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  recipient_emails: [],
+  is_active: true,
+};
+
+export function ReportForm({
+  report,
+  availableAccounts,
+}: {
+  report?: Report;
+  availableAccounts: { id: string; name: string }[];
+}) {
+  const router = useRouter();
+  const [recipientDraft, setRecipientDraft] = useState("");
+  const [sendingTest, setSendingTest] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: report ? { ...DEFAULTS, ...report } : DEFAULTS,
+  });
+
+  const frequency = watch("frequency");
+  const recipients = watch("recipient_emails");
+  const accountIds = watch("account_ids");
+
+  async function onSubmit(values: FormValues) {
+    const input: Partial<ReportInput> = values;
+    if (report) {
+      await updateReport(report.id, input);
+    } else {
+      await createReport(input);
+    }
+    router.push("/reports");
+  }
+
+  async function handleSendTest() {
+    if (!report) return;
+    setSendingTest(true);
+    try {
+      await sendTestReport(report.id);
+    } finally {
+      setSendingTest(false);
+    }
+  }
+
+  function addRecipient() {
+    const value = recipientDraft.trim();
+    if (!value) return;
+    setValue("recipient_emails", [...recipients, value]);
+    setRecipientDraft("");
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="max-w-lg space-y-5">
+      <div>
+        <label className="block text-sm font-medium mb-1">Name</label>
+        <input {...register("name")} className="w-full border rounded px-3 py-2 text-sm" />
+        {errors.name && <p className="text-xs text-red-600 mt-1">{errors.name.message}</p>}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Accounts</label>
+        <div className="space-y-1 border rounded p-2 max-h-40 overflow-y-auto">
+          {availableAccounts.map((a) => (
+            <label key={a.id} className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={accountIds.includes(a.id)}
+                onChange={(e) =>
+                  setValue(
+                    "account_ids",
+                    e.target.checked ? [...accountIds, a.id] : accountIds.filter((id) => id !== a.id)
+                  )
+                }
+              />
+              {a.name}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <label className="block text-sm font-medium mb-1">Mode</label>
+          <select {...register("transaction_mode")} className="w-full border rounded px-2 py-2 text-sm">
+            <option value="RECENT">Most recent</option>
+            <option value="TOP_N">Top N by amount</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Count</label>
+          <input type="number" {...register("transaction_count")} className="w-full border rounded px-2 py-2 text-sm" />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Direction</label>
+          <select {...register("transaction_direction")} className="w-full border rounded px-2 py-2 text-sm">
+            <option value="ALL">All</option>
+            <option value="EXPENSE">Expenses</option>
+            <option value="INCOME">Income</option>
+            <option value="INFLOW">Inflows</option>
+            <option value="OUTFLOW">Outflows</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className="block text-sm font-medium mb-1">Frequency</label>
+          <select {...register("frequency")} className="w-full border rounded px-2 py-2 text-sm">
+            <option value="DAILY">Daily</option>
+            <option value="WEEKLY">Weekly</option>
+            <option value="BIWEEKLY">Biweekly</option>
+            <option value="MONTHLY">Monthly</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Time</label>
+          <input type="time" step={60} {...register("send_time")} className="w-full border rounded px-2 py-2 text-sm" />
+        </div>
+      </div>
+
+      {(frequency === "WEEKLY" || frequency === "BIWEEKLY") && (
+        <div>
+          <label className="block text-sm font-medium mb-1">Day of week</label>
+          <select {...register("send_day_of_week")} className="w-full border rounded px-2 py-2 text-sm">
+            {["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"].map((d, i) => (
+              <option key={d} value={i}>
+                {d}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {frequency === "MONTHLY" && (
+        <div>
+          <label className="block text-sm font-medium mb-1">Day of month</label>
+          <input
+            type="number"
+            min={1}
+            max={28}
+            {...register("send_day_of_month")}
+            className="w-full border rounded px-2 py-2 text-sm"
+          />
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium mb-1">Recipients</label>
+        <div className="flex gap-2 mb-2">
+          <input
+            value={recipientDraft}
+            onChange={(e) => setRecipientDraft(e.target.value)}
+            placeholder="name@example.com"
+            className="flex-1 border rounded px-3 py-2 text-sm"
+          />
+          <button type="button" onClick={addRecipient} className="border rounded px-3 py-2 text-sm">
+            Add
+          </button>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {recipients.map((email) => (
+            <span key={email} className="bg-gray-100 rounded-full px-3 py-1 text-xs flex items-center gap-1">
+              {email}
+              <button
+                type="button"
+                onClick={() => setValue("recipient_emails", recipients.filter((r) => r !== email))}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+        {errors.recipient_emails && <p className="text-xs text-red-600 mt-1">{errors.recipient_emails.message}</p>}
+      </div>
+
+      <div className="flex items-center gap-3 pt-2">
+        <button type="submit" disabled={isSubmitting} className="bg-blue-600 text-white rounded px-4 py-2 text-sm">
+          {report ? "Save changes" : "Create report"}
+        </button>
+        {report && (
+          <button
+            type="button"
+            onClick={handleSendTest}
+            disabled={sendingTest}
+            className="border rounded px-4 py-2 text-sm"
+          >
+            {sendingTest ? "Sending…" : "Send test now"}
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/frontend/components/reports/ReportForm.tsx
+++ b/frontend/components/reports/ReportForm.tsx
@@ -43,13 +43,18 @@ const DEFAULTS: FormValues = {
 export function ReportForm({
   report,
   availableAccounts,
+  accountsLoading,
+  accountsError,
 }: {
   report?: Report;
   availableAccounts: { id: string; name: string }[];
+  accountsLoading?: boolean;
+  accountsError?: boolean;
 }) {
   const router = useRouter();
   const [recipientDraft, setRecipientDraft] = useState("");
   const [sendingTest, setSendingTest] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const {
     register,
@@ -67,13 +72,18 @@ export function ReportForm({
   const accountIds = watch("account_ids");
 
   async function onSubmit(values: FormValues) {
-    const input: Partial<ReportInput> = values;
-    if (report) {
-      await updateReport(report.id, input);
-    } else {
-      await createReport(input);
+    setSubmitError(null);
+    try {
+      const input: Partial<ReportInput> = values;
+      if (report) {
+        await updateReport(report.id, input);
+      } else {
+        await createReport(input);
+      }
+      router.push("/reports");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Failed to save report. Please try again.");
     }
-    router.push("/reports");
   }
 
   async function handleSendTest() {
@@ -103,6 +113,11 @@ export function ReportForm({
 
       <div>
         <label className="block text-sm font-medium mb-1">Accounts</label>
+        {accountsLoading ? (
+          <p className="text-sm text-gray-500">Loading accounts…</p>
+        ) : accountsError ? (
+          <p className="text-sm text-red-600">Failed to load accounts. Please refresh and try again.</p>
+        ) : (
         <div className="space-y-1 border rounded p-2 max-h-40 overflow-y-auto">
           {availableAccounts.map((a) => (
             <label key={a.id} className="flex items-center gap-2 text-sm">
@@ -120,6 +135,7 @@ export function ReportForm({
             </label>
           ))}
         </div>
+        )}
       </div>
 
       <div className="grid grid-cols-3 gap-3">
@@ -133,6 +149,9 @@ export function ReportForm({
         <div>
           <label className="block text-sm font-medium mb-1">Count</label>
           <input type="number" {...register("transaction_count")} className="w-full border rounded px-2 py-2 text-sm" />
+          {errors.transaction_count && (
+            <p className="text-xs text-red-600 mt-1">{errors.transaction_count.message}</p>
+          )}
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Direction</label>
@@ -172,6 +191,9 @@ export function ReportForm({
               </option>
             ))}
           </select>
+          {errors.send_day_of_week && (
+            <p className="text-xs text-red-600 mt-1">{errors.send_day_of_week.message}</p>
+          )}
         </div>
       )}
 
@@ -185,6 +207,9 @@ export function ReportForm({
             {...register("send_day_of_month")}
             className="w-full border rounded px-2 py-2 text-sm"
           />
+          {errors.send_day_of_month && (
+            <p className="text-xs text-red-600 mt-1">{errors.send_day_of_month.message}</p>
+          )}
         </div>
       )}
 
@@ -217,8 +242,19 @@ export function ReportForm({
         {errors.recipient_emails && <p className="text-xs text-red-600 mt-1">{errors.recipient_emails.message}</p>}
       </div>
 
+      <div>
+        <label className="flex items-center gap-2 text-sm font-medium">
+          <input type="checkbox" {...register("is_active")} />
+          Active
+        </label>
+      </div>
+
       <div className="flex items-center gap-3 pt-2">
-        <button type="submit" disabled={isSubmitting} className="bg-blue-600 text-white rounded px-4 py-2 text-sm">
+        <button
+          type="submit"
+          disabled={isSubmitting || accountsLoading || accountsError}
+          className="bg-blue-600 text-white rounded px-4 py-2 text-sm disabled:opacity-50"
+        >
           {report ? "Save changes" : "Create report"}
         </button>
         {report && (
@@ -232,6 +268,7 @@ export function ReportForm({
           </button>
         )}
       </div>
+      {submitError && <p className="text-xs text-red-600">{submitError}</p>}
     </form>
   );
 }

--- a/frontend/components/reports/RunStatusBadge.tsx
+++ b/frontend/components/reports/RunStatusBadge.tsx
@@ -1,0 +1,16 @@
+import type { ReportRunStatus } from "@/lib/reports/types";
+
+const STYLES: Record<ReportRunStatus, string> = {
+  SCHEDULED: "bg-gray-100 text-gray-700",
+  RUNNING: "bg-blue-100 text-blue-700",
+  SUCCEEDED: "bg-green-100 text-green-700",
+  FAILED: "bg-red-100 text-red-700",
+};
+
+export function RunStatusBadge({ status }: { status: ReportRunStatus }) {
+  return (
+    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STYLES[status]}`}>
+      {status}
+    </span>
+  );
+}

--- a/frontend/emails/__tests__/render-report.test.ts
+++ b/frontend/emails/__tests__/render-report.test.ts
@@ -1,0 +1,64 @@
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const scriptPath = path.resolve(__dirname, "../render-report.ts");
+const cwd = path.resolve(__dirname, "../..");
+
+function runRenderReport(input: string) {
+  return spawnSync("npx", ["tsx", scriptPath], {
+    input,
+    cwd,
+    encoding: "utf-8",
+  });
+}
+
+describe("render-report.ts subprocess failure path", () => {
+  it("exits non-zero with stderr output on malformed JSON stdin", () => {
+    const result = runRenderReport("{ this is not valid json");
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toBeTruthy();
+    expect(result.stderr.length).toBeGreaterThan(0);
+    expect(result.stdout).toBe("");
+  }, 30000);
+
+  it("exits non-zero with stderr output when required 'transactions' field is missing", () => {
+    const input = JSON.stringify({
+      report_name: "Weekly summary",
+      generated_at: "2026-07-19T08:00:00Z",
+      accounts: [],
+      manage_url: "https://app.example.com/reports/1",
+      // transactions field intentionally omitted
+    });
+
+    const result = runRenderReport(input);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toBeTruthy();
+    expect(result.stderr.length).toBeGreaterThan(0);
+    expect(result.stdout).toBe("");
+  }, 30000);
+
+  it("succeeds with exit code 0 and valid JSON output on well-formed input", () => {
+    const input = JSON.stringify({
+      report_name: "Weekly summary",
+      generated_at: "2026-07-19T08:00:00Z",
+      accounts: [{ name: "Checking", institution: "Bank X", balance: "1234.56", currency: "EUR" }],
+      transactions: {
+        mode_label: "Last 2 transactions",
+        items: [
+          { description: "Groceries", category: null, date: "2026-07-18", amount: "50.00", currency: "EUR", direction: "out" },
+        ],
+      },
+      manage_url: "https://app.example.com/reports/1",
+    });
+
+    const result = runRenderReport(input);
+
+    expect(result.status).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.html).toContain("Weekly summary");
+    expect(parsed.text).toBeTruthy();
+  }, 30000);
+});

--- a/frontend/emails/__tests__/report-newsletter.test.ts
+++ b/frontend/emails/__tests__/report-newsletter.test.ts
@@ -1,0 +1,37 @@
+import { render } from "@react-email/render";
+import { describe, expect, it } from "vitest";
+import ReportNewsletter from "../report-newsletter";
+
+describe("ReportNewsletter", () => {
+  it("renders balances and transactions", async () => {
+    const html = await render(
+      ReportNewsletter({
+        reportName: "Weekly summary",
+        generatedAt: "2026-07-19T08:00:00Z",
+        accounts: [{ name: "Checking", institution: "Bank X", balance: "1234.56", currency: "EUR" }],
+        transactionsModeLabel: "Last 2 transactions",
+        transactions: [
+          { description: "Groceries", category: null, date: "2026-07-18", amount: "50.00", currency: "EUR", direction: "out" },
+        ],
+        manageUrl: "https://app.example.com/reports/1",
+      })
+    );
+    expect(html).toContain("Weekly summary");
+    expect(html).toContain("Checking");
+    expect(html).toContain("Groceries");
+  });
+
+  it("shows an empty state with no transactions", async () => {
+    const html = await render(
+      ReportNewsletter({
+        reportName: "Weekly summary",
+        generatedAt: "2026-07-19T08:00:00Z",
+        accounts: [],
+        transactionsModeLabel: "Last 5 transactions",
+        transactions: [],
+        manageUrl: "#",
+      })
+    );
+    expect(html).toContain("No transactions to show.");
+  });
+});

--- a/frontend/emails/components/report/BalancesSection.tsx
+++ b/frontend/emails/components/report/BalancesSection.tsx
@@ -1,0 +1,39 @@
+import { Section, Text } from "@react-email/components";
+
+export type BalanceItem = {
+  name: string;
+  institution: string | null;
+  balance: string;
+  currency: string;
+};
+
+export function BalancesSection({ accounts }: { accounts: BalanceItem[] }) {
+  if (accounts.length === 0) return null;
+  return (
+    <Section style={{ padding: "8px 20px" }}>
+      <Text style={{ fontSize: "12px", fontWeight: 600, color: "#6B7280", textTransform: "uppercase", margin: "0 0 8px" }}>
+        Account Balances
+      </Text>
+      {accounts.map((a) => (
+        <Section
+          key={a.name}
+          style={{
+            background: "#F9FAFB",
+            borderRadius: "8px",
+            padding: "14px 16px",
+            marginBottom: "8px",
+            width: "100%",
+          }}
+        >
+          <Text style={{ fontSize: "14px", fontWeight: 600, color: "#111827", margin: 0 }}>{a.name}</Text>
+          {a.institution ? (
+            <Text style={{ fontSize: "12px", color: "#6B7280", margin: "2px 0 6px" }}>{a.institution}</Text>
+          ) : null}
+          <Text style={{ fontSize: "18px", fontWeight: 700, color: "#111827", margin: 0 }}>
+            {a.balance} {a.currency}
+          </Text>
+        </Section>
+      ))}
+    </Section>
+  );
+}

--- a/frontend/emails/components/report/BalancesSection.tsx
+++ b/frontend/emails/components/report/BalancesSection.tsx
@@ -14,9 +14,9 @@ export function BalancesSection({ accounts }: { accounts: BalanceItem[] }) {
       <Text style={{ fontSize: "12px", fontWeight: 600, color: "#6B7280", textTransform: "uppercase", margin: "0 0 8px" }}>
         Account Balances
       </Text>
-      {accounts.map((a) => (
+      {accounts.map((a, index) => (
         <Section
-          key={a.name}
+          key={`${a.name}-${index}`}
           style={{
             background: "#F9FAFB",
             borderRadius: "8px",

--- a/frontend/emails/components/report/ReportFooter.tsx
+++ b/frontend/emails/components/report/ReportFooter.tsx
@@ -1,0 +1,13 @@
+import { Hr, Link, Section, Text } from "@react-email/components";
+
+export function ReportFooter({ manageUrl, sentAt }: { manageUrl: string; sentAt: string }) {
+  const formatted = new Date(sentAt).toLocaleString("en-US");
+  return (
+    <Section style={{ padding: "16px 20px 24px" }}>
+      <Hr style={{ borderColor: "#E5E7EB" }} />
+      <Text style={{ fontSize: "11px", color: "#9CA3AF", margin: "12px 0 0" }}>
+        Sent {formatted} · <Link href={manageUrl} style={{ color: "#6B7280" }}>Manage this report</Link>
+      </Text>
+    </Section>
+  );
+}

--- a/frontend/emails/components/report/ReportHeader.tsx
+++ b/frontend/emails/components/report/ReportHeader.tsx
@@ -1,0 +1,17 @@
+import { Heading, Section, Text } from "@react-email/components";
+
+export function ReportHeader({ reportName, generatedAt }: { reportName: string; generatedAt: string }) {
+  const formatted = new Date(generatedAt).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  return (
+    <Section style={{ padding: "24px 20px 8px" }}>
+      <Heading as="h1" style={{ fontSize: "20px", margin: 0, color: "#111827" }}>
+        {reportName}
+      </Heading>
+      <Text style={{ fontSize: "13px", color: "#6B7280", margin: "4px 0 0" }}>{formatted}</Text>
+    </Section>
+  );
+}

--- a/frontend/emails/components/report/TransactionsSection.tsx
+++ b/frontend/emails/components/report/TransactionsSection.tsx
@@ -1,0 +1,51 @@
+import { Section, Text } from "@react-email/components";
+
+export type TransactionItem = {
+  description: string;
+  category: string | null;
+  date: string;
+  amount: string;
+  currency: string;
+  direction: "in" | "out";
+};
+
+export function TransactionsSection({ modeLabel, items }: { modeLabel: string; items: TransactionItem[] }) {
+  return (
+    <Section style={{ padding: "8px 20px 24px" }}>
+      <Text style={{ fontSize: "12px", fontWeight: 600, color: "#6B7280", textTransform: "uppercase", margin: "0 0 8px" }}>
+        {modeLabel}
+      </Text>
+      {items.length === 0 ? (
+        <Text style={{ fontSize: "13px", color: "#6B7280" }}>No transactions to show.</Text>
+      ) : (
+        items.map((t, i) => (
+          <Section
+            key={`${t.description}-${t.date}-${i}`}
+            style={{
+              borderBottom: "1px solid #E5E7EB",
+              padding: "10px 0",
+              width: "100%",
+            }}
+          >
+            <Text style={{ fontSize: "14px", color: "#111827", margin: 0, fontWeight: 500 }}>{t.description}</Text>
+            <Text style={{ fontSize: "12px", color: "#6B7280", margin: "2px 0 0" }}>
+              {t.date}
+              {t.category ? ` · ${t.category}` : ""}
+            </Text>
+            <Text
+              style={{
+                fontSize: "14px",
+                fontWeight: 600,
+                margin: "4px 0 0",
+                color: t.direction === "out" ? "#EF4444" : "#10B981",
+              }}
+            >
+              {t.direction === "out" ? "-" : "+"}
+              {t.amount} {t.currency}
+            </Text>
+          </Section>
+        ))
+      )}
+    </Section>
+  );
+}

--- a/frontend/emails/render-report.ts
+++ b/frontend/emails/render-report.ts
@@ -1,0 +1,28 @@
+import { render } from "@react-email/render";
+import ReportNewsletter, { type ReportNewsletterProps } from "./report-newsletter";
+
+async function main() {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+  const input = JSON.parse(Buffer.concat(chunks).toString("utf-8"));
+
+  const props: ReportNewsletterProps = {
+    reportName: input.report_name,
+    generatedAt: input.generated_at,
+    accounts: input.accounts,
+    transactionsModeLabel: input.transactions.mode_label,
+    transactions: input.transactions.items,
+    manageUrl: input.manage_url ?? "#",
+  };
+
+  const element = ReportNewsletter(props);
+  const html = await render(element, { pretty: false });
+  const text = await render(element, { plainText: true });
+
+  process.stdout.write(JSON.stringify({ html, text }));
+}
+
+main().catch((err) => {
+  process.stderr.write(String(err?.stack ?? err));
+  process.exit(1);
+});

--- a/frontend/emails/report-newsletter.tsx
+++ b/frontend/emails/report-newsletter.tsx
@@ -1,0 +1,38 @@
+import { Body, Container, Head, Html, Preview } from "@react-email/components";
+import { BalancesSection, type BalanceItem } from "./components/report/BalancesSection";
+import { ReportFooter } from "./components/report/ReportFooter";
+import { ReportHeader } from "./components/report/ReportHeader";
+import { TransactionsSection, type TransactionItem } from "./components/report/TransactionsSection";
+
+export type ReportNewsletterProps = {
+  reportName: string;
+  generatedAt: string;
+  accounts: BalanceItem[];
+  transactionsModeLabel: string;
+  transactions: TransactionItem[];
+  manageUrl: string;
+};
+
+export default function ReportNewsletter({
+  reportName,
+  generatedAt,
+  accounts,
+  transactionsModeLabel,
+  transactions,
+  manageUrl,
+}: ReportNewsletterProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>{reportName} — your latest financial summary</Preview>
+      <Body style={{ backgroundColor: "#F3F4F6", margin: 0, fontFamily: "-apple-system, Segoe UI, sans-serif" }}>
+        <Container style={{ maxWidth: "600px", width: "100%", margin: "0 auto", backgroundColor: "#FFFFFF" }}>
+          <ReportHeader reportName={reportName} generatedAt={generatedAt} />
+          <BalancesSection accounts={accounts} />
+          <TransactionsSection modeLabel={transactionsModeLabel} items={transactions} />
+          <ReportFooter manageUrl={manageUrl} sentAt={generatedAt} />
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/frontend/lib/db/migrations/0025_reports_and_report_runs.sql
+++ b/frontend/lib/db/migrations/0025_reports_and_report_runs.sql
@@ -1,0 +1,44 @@
+CREATE TABLE "reports" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" text NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"account_ids" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"transaction_mode" varchar(20) DEFAULT 'RECENT' NOT NULL,
+	"transaction_count" integer DEFAULT 10 NOT NULL,
+	"transaction_direction" varchar(20) DEFAULT 'ALL' NOT NULL,
+	"frequency" varchar(20) NOT NULL,
+	"send_time" time DEFAULT '08:00:00' NOT NULL,
+	"send_day_of_week" integer,
+	"send_day_of_month" integer,
+	"timezone" varchar(64) DEFAULT 'UTC' NOT NULL,
+	"recipient_emails" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"next_run_at" timestamp,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "report_runs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"report_id" uuid NOT NULL,
+	"scheduled_for" timestamp,
+	"is_test" boolean DEFAULT false NOT NULL,
+	"started_at" timestamp,
+	"finished_at" timestamp,
+	"status" varchar(20) DEFAULT 'SCHEDULED' NOT NULL,
+	"error_message" text,
+	"recipient_emails" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "reports" ADD CONSTRAINT "reports_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "report_runs" ADD CONSTRAINT "report_runs_report_id_reports_id_fk" FOREIGN KEY ("report_id") REFERENCES "public"."reports"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "idx_reports_user" ON "reports" USING btree ("user_id");
+--> statement-breakpoint
+CREATE INDEX "idx_reports_next_run_at" ON "reports" USING btree ("next_run_at");
+--> statement-breakpoint
+CREATE INDEX "idx_report_runs_report" ON "report_runs" USING btree ("report_id");
+--> statement-breakpoint
+CREATE INDEX "idx_report_runs_status" ON "report_runs" USING btree ("status");

--- a/frontend/lib/db/migrations/meta/_journal.json
+++ b/frontend/lib/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
 			"when": 1777879474826,
 			"tag": "0022_investment_plans",
 			"breakpoints": true
+		},
+		{
+			"idx": 23,
+			"version": "7",
+			"when": 1784634000000,
+			"tag": "0025_reports_and_report_runs",
+			"breakpoints": true
 		}
 	]
 }

--- a/frontend/lib/db/schema.ts
+++ b/frontend/lib/db/schema.ts
@@ -13,6 +13,7 @@ import {
   unique,
   numeric,
   date,
+  time,
   uniqueIndex,
   primaryKey,
 } from "drizzle-orm/pg-core";
@@ -1054,6 +1055,65 @@ export const vehicleOwnersRelations = relations(vehicleOwners, ({ one }) => ({
 }));
 
 // ============================================================================
+// Newsletter Reports
+// ============================================================================
+
+export const reports = pgTable(
+  "reports",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    name: varchar("name", { length: 255 }).notNull(),
+    accountIds: jsonb("account_ids").$type<string[]>().default([]).notNull(),
+    transactionMode: varchar("transaction_mode", { length: 20 })
+      .notNull()
+      .default("RECENT"), // RECENT, TOP_N
+    transactionCount: integer("transaction_count").notNull().default(10),
+    transactionDirection: varchar("transaction_direction", { length: 20 })
+      .notNull()
+      .default("ALL"), // ALL, EXPENSE, INCOME, INFLOW, OUTFLOW
+    frequency: varchar("frequency", { length: 20 }).notNull(), // DAILY, WEEKLY, BIWEEKLY, MONTHLY
+    sendTime: time("send_time").notNull().default("08:00:00"),
+    sendDayOfWeek: integer("send_day_of_week"), // 0=Monday..6=Sunday, WEEKLY/BIWEEKLY
+    sendDayOfMonth: integer("send_day_of_month"), // 1..28, MONTHLY
+    timezone: varchar("timezone", { length: 64 }).notNull().default("UTC"),
+    recipientEmails: jsonb("recipient_emails").$type<string[]>().default([]).notNull(),
+    isActive: boolean("is_active").default(true).notNull(),
+    nextRunAt: timestamp("next_run_at"),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => [
+    index("idx_reports_user").on(table.userId),
+    index("idx_reports_next_run_at").on(table.nextRunAt),
+  ]
+);
+
+export const reportRuns = pgTable(
+  "report_runs",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    reportId: uuid("report_id")
+      .references(() => reports.id, { onDelete: "cascade" })
+      .notNull(),
+    scheduledFor: timestamp("scheduled_for"),
+    isTest: boolean("is_test").default(false).notNull(),
+    startedAt: timestamp("started_at"),
+    finishedAt: timestamp("finished_at"),
+    status: varchar("status", { length: 20 }).notNull().default("SCHEDULED"), // SCHEDULED, RUNNING, SUCCEEDED, FAILED
+    errorMessage: text("error_message"),
+    recipientEmails: jsonb("recipient_emails").$type<string[]>().default([]).notNull(),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (table) => [
+    index("idx_report_runs_report").on(table.reportId),
+    index("idx_report_runs_status").on(table.status),
+  ]
+);
+
+// ============================================================================
 // Type Exports
 // ============================================================================
 
@@ -1111,3 +1171,9 @@ export type NewBankConnection = typeof bankConnections.$inferInsert;
 
 export type InternalTransfer = typeof internalTransfers.$inferSelect;
 export type NewInternalTransfer = typeof internalTransfers.$inferInsert;
+
+export type Report = typeof reports.$inferSelect;
+export type NewReport = typeof reports.$inferInsert;
+
+export type ReportRun = typeof reportRuns.$inferSelect;
+export type NewReportRun = typeof reportRuns.$inferInsert;

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -42,8 +42,5 @@ export function listReportRuns(id: string): Promise<ReportRun[]> {
 }
 
 export function listAccounts(): Promise<{ id: string; name: string }[]> {
-  // Backend route is registered at GET /api/accounts/ (trailing slash).
-  // Without it, FastAPI issues a 307 redirect that the internal-auth-signed
-  // proxy request doesn't survive correctly.
-  return request<{ id: string; name: string }[]>("/accounts/");
+  return request<{ id: string; name: string }[]>("/accounts");
 }

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -40,3 +40,7 @@ export function sendTestReport(id: string): Promise<ReportRun> {
 export function listReportRuns(id: string): Promise<ReportRun[]> {
   return request<ReportRun[]>(`/reports/${id}/runs`);
 }
+
+export function listAccounts(): Promise<{ id: string; name: string }[]> {
+  return request<{ id: string; name: string }[]>("/accounts");
+}

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -1,0 +1,42 @@
+import type { Report, ReportInput, ReportRun } from "./types";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/api${path}`, {
+    ...init,
+    headers: { "Content-Type": "application/json", ...(init?.headers ?? {}) },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Request to ${path} failed (${res.status}): ${body}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
+
+export function listReports(): Promise<Report[]> {
+  return request<Report[]>("/reports");
+}
+
+export function getReport(id: string): Promise<Report> {
+  return request<Report>(`/reports/${id}`);
+}
+
+export function createReport(input: Partial<ReportInput>): Promise<Report> {
+  return request<Report>("/reports", { method: "POST", body: JSON.stringify(input) });
+}
+
+export function updateReport(id: string, input: Partial<ReportInput>): Promise<Report> {
+  return request<Report>(`/reports/${id}`, { method: "PATCH", body: JSON.stringify(input) });
+}
+
+export function deleteReport(id: string): Promise<void> {
+  return request<void>(`/reports/${id}`, { method: "DELETE" });
+}
+
+export function sendTestReport(id: string): Promise<ReportRun> {
+  return request<ReportRun>(`/reports/${id}/send-test`, { method: "POST" });
+}
+
+export function listReportRuns(id: string): Promise<ReportRun[]> {
+  return request<ReportRun[]>(`/reports/${id}/runs`);
+}

--- a/frontend/lib/reports/api.ts
+++ b/frontend/lib/reports/api.ts
@@ -42,5 +42,8 @@ export function listReportRuns(id: string): Promise<ReportRun[]> {
 }
 
 export function listAccounts(): Promise<{ id: string; name: string }[]> {
-  return request<{ id: string; name: string }[]>("/accounts");
+  // Backend route is registered at GET /api/accounts/ (trailing slash).
+  // Without it, FastAPI issues a 307 redirect that the internal-auth-signed
+  // proxy request doesn't survive correctly.
+  return request<{ id: string; name: string }[]>("/accounts/");
 }

--- a/frontend/lib/reports/types.ts
+++ b/frontend/lib/reports/types.ts
@@ -1,0 +1,37 @@
+export type TransactionMode = "RECENT" | "TOP_N";
+export type TransactionDirection = "ALL" | "EXPENSE" | "INCOME" | "INFLOW" | "OUTFLOW";
+export type ReportFrequency = "DAILY" | "WEEKLY" | "BIWEEKLY" | "MONTHLY";
+export type ReportRunStatus = "SCHEDULED" | "RUNNING" | "SUCCEEDED" | "FAILED";
+
+export type Report = {
+  id: string;
+  name: string;
+  account_ids: string[];
+  transaction_mode: TransactionMode;
+  transaction_count: number;
+  transaction_direction: TransactionDirection;
+  frequency: ReportFrequency;
+  send_time: string;
+  send_day_of_week: number | null;
+  send_day_of_month: number | null;
+  timezone: string;
+  recipient_emails: string[];
+  is_active: boolean;
+  next_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ReportRun = {
+  id: string;
+  scheduled_for: string | null;
+  is_test: boolean;
+  started_at: string | null;
+  finished_at: string | null;
+  status: ReportRunStatus;
+  error_message: string | null;
+  recipient_emails: string[];
+  created_at: string;
+};
+
+export type ReportInput = Omit<Report, "id" | "next_run_at" | "created_at" | "updated_at">;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "shadcn": "^3.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "tsx": "^4.19.0",
     "tw-animate-css": "^1.4.0",
     "xlsx": "file:xlsx-0.20.3.tgz",
     "zod": "3.25.76",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 1.1.0(@types/react@19.2.10)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@better-auth/oauth-provider':
         specifier: ^1.6.5
-        version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))))(better-call@1.3.5(zod@3.25.76))
+        version: 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1)))(better-call@1.3.5(zod@3.25.76))
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.3))
@@ -44,7 +44,7 @@ importers:
         version: 2.4.3
       better-auth:
         specifier: ^1.6.5
-        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3)))
+        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1))
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.4
@@ -108,6 +108,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.1
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -165,7 +168,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1)
 
 packages:
 
@@ -502,11 +505,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.is'
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -783,89 +786,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -989,24 +1008,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.7':
     resolution: {integrity: sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.7':
     resolution: {integrity: sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.7':
     resolution: {integrity: sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.7':
     resolution: {integrity: sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==}
@@ -1269,30 +1292,35 @@ packages:
   '@react-email/body@0.3.0':
     resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/button@0.2.1':
     resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-block@0.2.1':
     resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/code-inline@0.0.6':
     resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/column@0.0.14':
     resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -1306,60 +1334,70 @@ packages:
   '@react-email/container@0.0.16':
     resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/font@0.0.10':
     resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/head@0.0.13':
     resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/heading@0.0.16':
     resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/hr@0.0.12':
     resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/html@0.0.12':
     resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/img@0.0.12':
     resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/link@0.0.13':
     resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/markdown@0.0.18':
     resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/preview@0.0.14':
     resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -1380,12 +1418,14 @@ packages:
   '@react-email/row@0.0.13':
     resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
   '@react-email/section@0.0.17':
     resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -1431,6 +1471,7 @@ packages:
   '@react-email/text@0.1.6':
     resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
     engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
@@ -1473,66 +1514,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1627,24 +1681,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1885,41 +1943,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3519,24 +3585,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -4086,6 +4156,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -4487,6 +4558,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -5115,12 +5191,12 @@ snapshots:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/oauth-provider@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))))(better-call@1.3.5(zod@3.25.76))':
+  '@better-auth/oauth-provider@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1)))(better-call@1.3.5(zod@3.25.76))':
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3)))
+      better-auth: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1))
       better-call: 1.3.5(zod@3.25.76)
       jose: 6.1.3
       zod: 4.3.6
@@ -6367,14 +6443,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@vitest/mocker@4.0.18(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.7(@types/node@20.19.30)(typescript@5.9.3)
-      vite: 7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.1)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -6544,7 +6620,7 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
-  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))):
+  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.8)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))(next@16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1)):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@3.25.76))(jose@6.1.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(kysely@0.28.16)(postgres@3.4.8))
@@ -6569,7 +6645,7 @@ snapshots:
       next: 16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -9052,6 +9128,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.1:
+    dependencies:
+      esbuild: 0.25.12
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tw-animate-css@1.4.0: {}
 
   type-check@0.4.0:
@@ -9211,7 +9293,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2):
+  vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9224,11 +9306,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      tsx: 4.23.1
 
-  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3)):
+  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.30)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1))(lightningcss@1.30.2)(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(tsx@4.23.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@vitest/mocker': 4.0.18(msw@2.12.7(@types/node@20.19.30)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -9245,7 +9328,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)
+      vite: 7.3.1(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.23.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "jsdom",
-    include: ["lib/**/*.test.{ts,tsx}", "components/**/*.test.{ts,tsx}"],
+    include: ["lib/**/*.test.{ts,tsx}", "components/**/*.test.{ts,tsx}", "emails/**/*.test.{ts,tsx}"],
     setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- Adds a "Reports" section where users configure recurring email newsletters (daily/weekly/biweekly/monthly) covering selected account balances and a configurable transaction list (recent, or top-N by expense/income/inflow/outflow), sent to freeform recipient addresses.
- Backend: `reports`/`report_runs` schema (Drizzle + SQLAlchemy), scheduling math, report data aggregation reusing existing account/transaction services, a provider-agnostic mail adapter (SMTP/Resend/usesend, selected by env var), FastAPI CRUD routes with enum/bounds validation, and Celery Beat tasks that poll due reports and send them (never raising past the task boundary).
- Frontend: a mobile-first React Email template rendered via a Node subprocess invoked from Celery, plus Reports dashboard pages (list/create/edit/run-history) wired into the sidebar nav.
- Infra: the Celery worker image now bakes in Node + the render-only frontend assets so the render subprocess actually runs in the deployed container (verified with a real `--network none` build+run).

## Design docs
- Spec: `docs/superpowers/specs/2026-07-19-newsletter-reports-design.md`
- Plan: `docs/superpowers/plans/2026-07-19-newsletter-reports.md`
(Not committed — `docs/` is gitignored in this repo; available locally.)

## Test plan
- [x] Backend unit/integration tests (models, scheduling math, data service, mail adapter, routes, Celery tasks) — run per-task via Docker against a real Postgres throughout development, all passing.
- [x] Frontend: `tsc --noEmit` clean, vitest suite (`emails/__tests__/`) passing including a genuine subprocess-level failure-path test for the render script.
- [x] Verified the Celery worker's render pipeline end-to-end by building `backend/Dockerfile` for real and running `render-report.ts` inside the built image with `--network none`, confirming valid HTML/text output with no runtime network dependency.
- [ ] Manual smoke test with a real mail provider against a running Docker Compose stack (Task 14 — pending, requires live SMTP/Resend/usesend credentials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scheduled email reports that summarize selected account balances and recent or top-N transactions, delivered daily/weekly/biweekly/monthly to specified recipients. Includes backend scheduling and sending via `Celery`, a provider-agnostic mail adapter, a `React Email` template rendered in the worker image, and a new Reports UI.

- **New Features**
  - Database: `reports` and `report_runs` tables (Drizzle + SQLAlchemy) with `next_run_at` in UTC.
  - API: `FastAPI` CRUD, enum/bounds validation, account ownership checks, send-test endpoint; requires `recipient_emails`, rejects explicit nulls on PATCH for non-nullable fields; accounts list route no longer redirects (registered without a trailing-slash).
  - Scheduling: `compute_next_run_at` and `check_due_reports` (every 5 min); commits runs before enqueue, atomically claims a run before sending to avoid duplicates, idempotent `send_report_run`, marks FAILED on errors; DST behavior documented.
  - Data: balances/transactions aggregation; correct functional vs native currency pairing; TOP_N+ALL ordered by absolute amount.
  - Email: `React Email` newsletter rendered via `npx tsx frontend/emails/render-report.ts`, sending HTML and text; footer includes a real manage link; `generated_at` includes a UTC suffix.
  - Mail: adapter supports SMTP > `resend` > `usesend`; hardened SMTP (timeouts, port 465 SSL, refused-recipient checks); requires explicit `*_FROM` env vars.
  - Frontend: Reports list/create/edit/run-history pages, sidebar entry; form with validation, is_active toggle, test send, better load/error states; keeps cached run history on transient poll errors; avoids duplicate React keys in email components.
  - Infra: backend image bakes Node and render assets; CI/Compose pass a named BuildKit context `frontend=...`; root compose additional_contexts path fixed; dev volume narrowed to `frontend/emails` to avoid masking baked `node_modules`.
  - Tests: coverage for models, scheduling, data aggregation, routes, Celery tasks, mail adapter, render subprocess failure paths; JSONB round-trips; scoped validators; mocked subprocess in failure tests; cleans up seeded data for stability.

- **Migration**
  - Apply migration `0025_reports_and_report_runs`.
  - Configure a mail provider via env. SMTP: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`. Resend: `RESEND_API_KEY`, `RESEND_FROM`. usesend: `USESEND_API_KEY`, `USESEND_FROM`.
  - Run `Celery` worker and beat; `check-due-reports` is scheduled every 5 minutes.
  - If building the backend image outside Compose/GitHub Actions, pass BuildKit context `frontend=./frontend` so the renderer works.

<sup>Written for commit 8bb75d59c94d38c6c2f8bf1387706def3bfdab23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

