### PR TITLE
Add MCP tools for scheduled report management

### DIFF
--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -8,7 +8,7 @@ from pydantic import AnyHttpUrl
 
 from app.db_helpers import get_mcp_user_id
 from app.mcp.auth import CompositeAuthProvider, AS_ISSUER, MCP_PUBLIC_URL
-from app.mcp.tools import accounts, categories, transactions, analytics, recurring, investments, people as people_tools
+from app.mcp.tools import accounts, categories, transactions, analytics, recurring, investments, people as people_tools, reports as report_tools
 
 _auth = RemoteAuthProvider(
     token_verifier=CompositeAuthProvider(),
@@ -42,6 +42,9 @@ The `user_id` parameter is optional on all tools but must match the authenticate
 - **Recurring**: List and view subscriptions/bills
 - **Investments**: List holdings, portfolio summary/history, symbol search,
   import broker trades (CSV/PDF/XLSX statements), realized & unrealized P&L (FIFO)
+- **Reports**: Create, list, view, update, delete, and send-test scheduled
+  email newsletters (account balances + transaction digest, on a
+  daily/weekly/biweekly/monthly cadence)
 
 ## Bulk recategorization workflow (recommended)
 
@@ -983,3 +986,199 @@ def get_household_summary(
         investments, properties, vehicles, total (all share-attributed).
     """
     return people_tools.get_household_summary(get_mcp_user_id(user_id), person_ids)
+
+
+# ============================================================================
+# Report Tools
+# ============================================================================
+
+@mcp.tool
+def list_reports(user_id: str | None = None) -> list[dict]:
+    """
+    List all scheduled report newsletters for the user.
+
+    Args:
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        List of report dicts (id, name, frequency, schedule fields,
+        recipient_emails, next_run_at, is_active, etc.)
+    """
+    return report_tools.list_reports(get_mcp_user_id(user_id))
+
+
+@mcp.tool
+def get_report(report_id: str, user_id: str | None = None) -> dict | None:
+    """
+    Get a single scheduled report by ID.
+
+    Args:
+        report_id: The report's ID
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        Report dict, or None if not found / not owned by this user.
+    """
+    return report_tools.get_report(get_mcp_user_id(user_id), report_id)
+
+
+@mcp.tool
+def create_report(
+    name: str,
+    frequency: str,
+    recipient_emails: list[str],
+    account_ids: list[str] | None = None,
+    transaction_mode: str = "RECENT",
+    transaction_count: int = 10,
+    transaction_direction: str = "ALL",
+    send_time: str = "08:00:00",
+    send_day_of_week: int | None = None,
+    send_day_of_month: int | None = None,
+    timezone: str = "UTC",
+    is_active: bool = True,
+    user_id: str | None = None,
+) -> dict:
+    """
+    Create a new scheduled report newsletter.
+
+    Args:
+        name: Display name for this report
+        frequency: One of "DAILY", "WEEKLY", "BIWEEKLY", "MONTHLY"
+        recipient_emails: List of email addresses to send to (at least one required)
+        account_ids: Account IDs whose balances to include (optional, defaults to none)
+        transaction_mode: "RECENT" (most recent N transactions) or "TOP_N"
+            (largest by amount) — defaults to "RECENT"
+        transaction_count: How many transactions to include, 1-100 (default 10)
+        transaction_direction: "ALL", "EXPENSE", "INCOME", "INFLOW", or
+            "OUTFLOW" — filters which transactions are eligible (default "ALL")
+        send_time: Local send time as "HH:MM" or "HH:MM:SS" (default "08:00:00")
+        send_day_of_week: Required if frequency is WEEKLY or BIWEEKLY.
+            0=Monday .. 6=Sunday
+        send_day_of_month: Required if frequency is MONTHLY. 1-28
+        timezone: IANA timezone name, e.g. "Europe/Brussels" (default "UTC")
+        is_active: Whether the report is active/scheduled (default True)
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        {"success": True, "report": {...}} on success, or
+        {"success": False, "error": "<message>"} on validation failure
+        (e.g. bad frequency, missing required day field, invalid email,
+        unowned account_id).
+    """
+    return report_tools.create_report(
+        user_id=get_mcp_user_id(user_id),
+        name=name,
+        frequency=frequency,
+        recipient_emails=recipient_emails,
+        account_ids=account_ids,
+        transaction_mode=transaction_mode,
+        transaction_count=transaction_count,
+        transaction_direction=transaction_direction,
+        send_time=send_time,
+        send_day_of_week=send_day_of_week,
+        send_day_of_month=send_day_of_month,
+        timezone=timezone,
+        is_active=is_active,
+    )
+
+
+@mcp.tool
+def update_report(
+    report_id: str,
+    name: str | None = None,
+    account_ids: list[str] | None = None,
+    transaction_mode: str | None = None,
+    transaction_count: int | None = None,
+    transaction_direction: str | None = None,
+    frequency: str | None = None,
+    send_time: str | None = None,
+    send_day_of_week: int | None = None,
+    send_day_of_month: int | None = None,
+    timezone: str | None = None,
+    recipient_emails: list[str] | None = None,
+    is_active: bool | None = None,
+    user_id: str | None = None,
+) -> dict:
+    """
+    Update a scheduled report. Only provided (non-None) fields are changed;
+    all others keep their current value.
+
+    Changing frequency to WEEKLY/BIWEEKLY without send_day_of_week, or to
+    MONTHLY without send_day_of_month, will fail — either provide the day
+    field in the same call, or ensure the report already has one set.
+
+    Args:
+        report_id: The report's ID
+        (see create_report for the meaning of each other field)
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        {"success": True, "report": {...}} on success, or
+        {"success": False, "error": "<message>"} if not found or invalid.
+    """
+    return report_tools.update_report(
+        user_id=get_mcp_user_id(user_id),
+        report_id=report_id,
+        name=name,
+        account_ids=account_ids,
+        transaction_mode=transaction_mode,
+        transaction_count=transaction_count,
+        transaction_direction=transaction_direction,
+        frequency=frequency,
+        send_time=send_time,
+        send_day_of_week=send_day_of_week,
+        send_day_of_month=send_day_of_month,
+        timezone=timezone,
+        recipient_emails=recipient_emails,
+        is_active=is_active,
+    )
+
+
+@mcp.tool
+def delete_report(report_id: str, user_id: str | None = None) -> dict:
+    """
+    Permanently delete a scheduled report (and its run history).
+
+    Args:
+        report_id: The report's ID
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        {"success": True, "error": None} on success, or
+        {"success": False, "error": "<message>"} if not found.
+    """
+    return report_tools.delete_report(get_mcp_user_id(user_id), report_id)
+
+
+@mcp.tool
+def send_test_report(report_id: str, user_id: str | None = None) -> dict:
+    """
+    Trigger an immediate test send of a report, bypassing its schedule.
+
+    Args:
+        report_id: The report's ID
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        {"success": True, "run": {...}} with the created (SCHEDULED,
+        then asynchronously RUNNING/SUCCEEDED/FAILED) run record, or
+        {"success": False, "error": "<message>"} if the report isn't found.
+    """
+    return report_tools.send_test_report(get_mcp_user_id(user_id), report_id)
+
+
+@mcp.tool
+def list_report_runs(report_id: str, user_id: str | None = None) -> list[dict]:
+    """
+    List scheduled and executed send history for a report.
+
+    Args:
+        report_id: The report's ID
+        user_id: The user's ID (optional, defaults to configured user)
+
+    Returns:
+        List of run dicts (status, scheduled_for, started_at, finished_at,
+        error_message, is_test), most recent first. Empty list if the
+        report isn't found.
+    """
+    return report_tools.list_report_runs(get_mcp_user_id(user_id), report_id)

--- a/backend/app/mcp/tools/reports.py
+++ b/backend/app/mcp/tools/reports.py
@@ -177,6 +177,9 @@ def send_test_report(user_id: str, report_id: str) -> dict:
         except ReportNotFoundError as e:
             db.rollback()
             return {"success": False, "error": str(e)}
+        except ReportValidationError as e:
+            db.rollback()
+            return {"success": False, "error": str(e)}
         except Exception as e:  # noqa: BLE001
             db.rollback()
             return {"success": False, "error": f"Database error: {str(e)}"}

--- a/backend/app/mcp/tools/reports.py
+++ b/backend/app/mcp/tools/reports.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from app.mcp.dependencies import get_db
 from app.services import report_service
-from app.services.report_service import ReportNotFoundError, ReportValidationError
+from app.services.report_service import ReportDispatchError, ReportNotFoundError, ReportValidationError
 
 
 def _serialize_report(report) -> dict:
@@ -177,7 +177,7 @@ def send_test_report(user_id: str, report_id: str) -> dict:
         except ReportNotFoundError as e:
             db.rollback()
             return {"success": False, "error": str(e)}
-        except ReportValidationError as e:
+        except ReportDispatchError as e:
             db.rollback()
             return {"success": False, "error": str(e)}
         except Exception as e:  # noqa: BLE001

--- a/backend/app/mcp/tools/reports.py
+++ b/backend/app/mcp/tools/reports.py
@@ -1,0 +1,190 @@
+"""Report (scheduled newsletter) tools for the MCP server.
+
+All mutation tools return {"success": bool, ...} dicts rather than
+raising, following the established pattern in categories.py/investments.py
+— get_db() does not auto-rollback on exception, so every mutation path
+here explicitly rolls back on failure before returning an error dict.
+"""
+from __future__ import annotations
+
+from app.mcp.dependencies import get_db
+from app.services import report_service
+from app.services.report_service import ReportNotFoundError, ReportValidationError
+
+
+def _serialize_report(report) -> dict:
+    return {
+        "id": str(report.id),
+        "name": report.name,
+        "account_ids": list(report.account_ids or []),
+        "transaction_mode": report.transaction_mode,
+        "transaction_count": report.transaction_count,
+        "transaction_direction": report.transaction_direction,
+        "frequency": report.frequency,
+        "send_time": report.send_time.isoformat() if report.send_time else None,
+        "send_day_of_week": report.send_day_of_week,
+        "send_day_of_month": report.send_day_of_month,
+        "timezone": report.timezone,
+        "recipient_emails": list(report.recipient_emails or []),
+        "is_active": report.is_active,
+        "next_run_at": report.next_run_at.isoformat() if report.next_run_at else None,
+        "created_at": report.created_at.isoformat() if report.created_at else None,
+        "updated_at": report.updated_at.isoformat() if report.updated_at else None,
+    }
+
+
+def _serialize_run(run) -> dict:
+    return {
+        "id": str(run.id),
+        "report_id": str(run.report_id),
+        "scheduled_for": run.scheduled_for.isoformat() if run.scheduled_for else None,
+        "is_test": run.is_test,
+        "started_at": run.started_at.isoformat() if run.started_at else None,
+        "finished_at": run.finished_at.isoformat() if run.finished_at else None,
+        "status": run.status,
+        "error_message": run.error_message,
+        "recipient_emails": list(run.recipient_emails or []),
+        "created_at": run.created_at.isoformat() if run.created_at else None,
+    }
+
+
+def list_reports(user_id: str) -> list[dict]:
+    with get_db() as db:
+        return [_serialize_report(r) for r in report_service.list_reports(db, user_id)]
+
+
+def get_report(user_id: str, report_id: str) -> dict | None:
+    with get_db() as db:
+        try:
+            return _serialize_report(report_service.get_report(db, user_id, report_id))
+        except ReportNotFoundError:
+            return None
+
+
+def create_report(
+    user_id: str,
+    name: str,
+    frequency: str,
+    recipient_emails: list[str],
+    account_ids: list[str] | None = None,
+    transaction_mode: str = "RECENT",
+    transaction_count: int = 10,
+    transaction_direction: str = "ALL",
+    send_time: str = "08:00:00",
+    send_day_of_week: int | None = None,
+    send_day_of_month: int | None = None,
+    timezone: str = "UTC",
+    is_active: bool = True,
+) -> dict:
+    payload = {
+        "name": name,
+        "frequency": frequency,
+        "recipient_emails": recipient_emails,
+        "account_ids": account_ids or [],
+        "transaction_mode": transaction_mode,
+        "transaction_count": transaction_count,
+        "transaction_direction": transaction_direction,
+        "send_time": send_time,
+        "send_day_of_week": send_day_of_week,
+        "send_day_of_month": send_day_of_month,
+        "timezone": timezone,
+        "is_active": is_active,
+    }
+    with get_db() as db:
+        try:
+            report = report_service.create_report(db, user_id, payload)
+            return {"success": True, "report": _serialize_report(report)}
+        except ReportValidationError as e:
+            db.rollback()
+            return {"success": False, "error": str(e)}
+        except Exception as e:  # noqa: BLE001
+            db.rollback()
+            return {"success": False, "error": f"Database error: {str(e)}"}
+
+
+def update_report(
+    user_id: str,
+    report_id: str,
+    name: str | None = None,
+    account_ids: list[str] | None = None,
+    transaction_mode: str | None = None,
+    transaction_count: int | None = None,
+    transaction_direction: str | None = None,
+    frequency: str | None = None,
+    send_time: str | None = None,
+    send_day_of_week: int | None = None,
+    send_day_of_month: int | None = None,
+    timezone: str | None = None,
+    recipient_emails: list[str] | None = None,
+    is_active: bool | None = None,
+) -> dict:
+    # Only include explicitly-provided (non-None) fields, so omission
+    # preserves the existing value (PATCH semantics) rather than nulling
+    # it out. Fields that are legitimately settable to a falsy-but-valid
+    # value (is_active=False) are still passed through explicitly by the
+    # caller providing that exact value, not omitted.
+    payload = {
+        k: v
+        for k, v in {
+            "name": name,
+            "account_ids": account_ids,
+            "transaction_mode": transaction_mode,
+            "transaction_count": transaction_count,
+            "transaction_direction": transaction_direction,
+            "frequency": frequency,
+            "send_time": send_time,
+            "send_day_of_week": send_day_of_week,
+            "send_day_of_month": send_day_of_month,
+            "timezone": timezone,
+            "recipient_emails": recipient_emails,
+            "is_active": is_active,
+        }.items()
+        if v is not None
+    }
+    with get_db() as db:
+        try:
+            report = report_service.update_report(db, user_id, report_id, payload)
+            return {"success": True, "report": _serialize_report(report)}
+        except ReportNotFoundError as e:
+            db.rollback()
+            return {"success": False, "error": str(e)}
+        except ReportValidationError as e:
+            db.rollback()
+            return {"success": False, "error": str(e)}
+        except Exception as e:  # noqa: BLE001
+            db.rollback()
+            return {"success": False, "error": f"Database error: {str(e)}"}
+
+
+def delete_report(user_id: str, report_id: str) -> dict:
+    with get_db() as db:
+        try:
+            report_service.delete_report(db, user_id, report_id)
+            return {"success": True, "error": None}
+        except ReportNotFoundError as e:
+            db.rollback()
+            return {"success": False, "error": str(e)}
+        except Exception as e:  # noqa: BLE001
+            db.rollback()
+            return {"success": False, "error": f"Database error: {str(e)}"}
+
+
+def send_test_report(user_id: str, report_id: str) -> dict:
+    with get_db() as db:
+        try:
+            run = report_service.send_test_report(db, user_id, report_id)
+            return {"success": True, "run": _serialize_run(run)}
+        except ReportNotFoundError as e:
+            db.rollback()
+            return {"success": False, "error": str(e)}
+        except Exception as e:  # noqa: BLE001
+            db.rollback()
+            return {"success": False, "error": f"Database error: {str(e)}"}
+
+
+def list_report_runs(user_id: str, report_id: str) -> list[dict]:
+    with get_db() as db:
+        try:
+            return [_serialize_run(r) for r in report_service.list_report_runs(db, user_id, report_id)]
+        except ReportNotFoundError:
+            return []

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -5,7 +5,7 @@ from app.database import get_db
 from app.db_helpers import get_user_id
 from app.schemas import ReportCreate, ReportResponse, ReportRunResponse, ReportUpdate
 from app.services import report_service
-from app.services.report_service import ReportNotFoundError, ReportValidationError
+from app.services.report_service import ReportDispatchError, ReportNotFoundError, ReportValidationError
 
 router = APIRouter()
 
@@ -55,8 +55,8 @@ def send_test_report(report_id: str, user_id: str = Depends(get_user_id), db: Se
         return report_service.send_test_report(db, user_id, report_id)
     except ReportNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-    except ReportValidationError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+    except ReportDispatchError as e:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(e))
 
 
 @router.get("/{report_id}/runs", response_model=list[ReportRunResponse])

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -55,6 +55,8 @@ def send_test_report(report_id: str, user_id: str = Depends(get_user_id), db: Se
         return report_service.send_test_report(db, user_id, report_id)
     except ReportNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ReportValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
 
 
 @router.get("/{report_id}/runs", response_model=list[ReportRunResponse])

--- a/backend/app/routes/reports.py
+++ b/backend/app/routes/reports.py
@@ -1,174 +1,65 @@
-from datetime import datetime, time as time_cls
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.db_helpers import get_user_id
-from app.models import Account, Report, ReportRun
 from app.schemas import ReportCreate, ReportResponse, ReportRunResponse, ReportUpdate
-from app.services.report_schedule_service import compute_next_run_at
-from tasks.report_tasks import send_report_run
+from app.services import report_service
+from app.services.report_service import ReportNotFoundError, ReportValidationError
 
 router = APIRouter()
 
 
-def _parse_time(value: str) -> time_cls:
-    hh, mm, *rest = value.split(":")
-    ss = int(rest[0]) if rest else 0
-    return time_cls(int(hh), int(mm), ss)
-
-
-def _validate_account_ids(account_ids: list[str], user_id: str, db: Session) -> None:
-    if not account_ids:
-        return
-    parsed_ids = []
-    for raw_id in account_ids:
-        try:
-            parsed_ids.append(UUID(raw_id))
-        except ValueError:
-            raise HTTPException(
-                status_code=422,
-                detail="One or more account_ids are invalid or not owned by this user",
-            )
-    owned_count = (
-        db.query(Account)
-        .filter(Account.user_id == user_id, Account.id.in_(parsed_ids))
-        .count()
-    )
-    if owned_count != len(set(parsed_ids)):
-        raise HTTPException(
-            status_code=422,
-            detail="One or more account_ids are invalid or not owned by this user",
-        )
-
-
-def _recompute_next_run(report: Report) -> None:
-    report.next_run_at = compute_next_run_at(
-        frequency=report.frequency,
-        send_time=report.send_time,
-        timezone=report.timezone,
-        send_day_of_week=report.send_day_of_week,
-        send_day_of_month=report.send_day_of_month,
-        after=datetime.utcnow(),
-    )
-
-
 @router.post("", response_model=ReportResponse)
 def create_report(payload: ReportCreate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
-    _validate_account_ids(payload.account_ids, user_id, db)
-    report = Report(
-        user_id=user_id,
-        name=payload.name,
-        account_ids=payload.account_ids,
-        transaction_mode=payload.transaction_mode,
-        transaction_count=payload.transaction_count,
-        transaction_direction=payload.transaction_direction,
-        frequency=payload.frequency,
-        send_time=_parse_time(payload.send_time),
-        send_day_of_week=payload.send_day_of_week,
-        send_day_of_month=payload.send_day_of_month,
-        timezone=payload.timezone,
-        recipient_emails=payload.recipient_emails,
-        is_active=payload.is_active,
-    )
-    _recompute_next_run(report)
-    db.add(report)
-    db.commit()
-    db.refresh(report)
-    return report
+    try:
+        return report_service.create_report(db, user_id, payload.model_dump())
+    except ReportValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
 
 
 @router.get("", response_model=list[ReportResponse])
 def list_reports(user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
-    return db.query(Report).filter(Report.user_id == user_id).order_by(Report.created_at.desc()).all()
-
-
-def _get_owned_report(report_id: UUID, user_id: str, db: Session) -> Report:
-    report = db.query(Report).filter(Report.id == report_id, Report.user_id == user_id).first()
-    if not report:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Report not found")
-    return report
+    return report_service.list_reports(db, user_id)
 
 
 @router.get("/{report_id}", response_model=ReportResponse)
-def get_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
-    return _get_owned_report(report_id, user_id, db)
+def get_report(report_id: str, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    try:
+        return report_service.get_report(db, user_id, report_id)
+    except ReportNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
 
 @router.patch("/{report_id}", response_model=ReportResponse)
-def update_report(report_id: UUID, payload: ReportUpdate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
-    report = _get_owned_report(report_id, user_id, db)
-    data = payload.model_dump(exclude_unset=True)
-
-    # These columns are NOT NULL in the DB. exclude_unset=True keeps an
-    # explicit `"field": null` in the payload (distinct from omitting the
-    # key entirely), which would otherwise reach setattr() below and only
-    # fail later as an uncaught IntegrityError/500 on commit.
-    _NON_NULLABLE_FIELDS = ("name", "account_ids", "recipient_emails", "frequency", "is_active", "timezone")
-    null_fields = [f for f in _NON_NULLABLE_FIELDS if f in data and data[f] is None]
-    if null_fields:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Field(s) cannot be null: {', '.join(null_fields)}",
-        )
-
-    if "account_ids" in data and data["account_ids"] is not None:
-        _validate_account_ids(data["account_ids"], user_id, db)
-    if "send_time" in data and data["send_time"] is not None:
-        data["send_time"] = _parse_time(data["send_time"])
-    for field, value in data.items():
-        setattr(report, field, value)
-
-    if (report.frequency in ("WEEKLY", "BIWEEKLY") and report.send_day_of_week is None) or (
-        report.frequency == "MONTHLY" and report.send_day_of_month is None
-    ):
-        # setattr() above already mutated the in-session ORM object; roll
-        # back so no partial state is ever committed.
-        db.rollback()
-        raise HTTPException(
-            status_code=422,
-            detail="send_day_of_week/send_day_of_month is required for the selected frequency",
-        )
-
-    _recompute_next_run(report)
-    db.commit()
-    db.refresh(report)
-    return report
+def update_report(report_id: str, payload: ReportUpdate, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    try:
+        return report_service.update_report(db, user_id, report_id, payload.model_dump(exclude_unset=True))
+    except ReportNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ReportValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
 
 
 @router.delete("/{report_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
-    report = _get_owned_report(report_id, user_id, db)
-    db.delete(report)
-    db.commit()
+def delete_report(report_id: str, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    try:
+        report_service.delete_report(db, user_id, report_id)
+    except ReportNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
 
 @router.post("/{report_id}/send-test", response_model=ReportRunResponse)
-def send_test_report(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
-    report = _get_owned_report(report_id, user_id, db)
-    run = ReportRun(
-        report_id=report.id,
-        scheduled_for=None,
-        is_test=True,
-        status="SCHEDULED",
-        recipient_emails=report.recipient_emails,
-    )
-    db.add(run)
-    db.commit()
-    db.refresh(run)
-    send_report_run.delay(str(run.id))
-    return run
+def send_test_report(report_id: str, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    try:
+        return report_service.send_test_report(db, user_id, report_id)
+    except ReportNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 
 
 @router.get("/{report_id}/runs", response_model=list[ReportRunResponse])
-def list_report_runs(report_id: UUID, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
-    _get_owned_report(report_id, user_id, db)
-    return (
-        db.query(ReportRun)
-        .filter(ReportRun.report_id == report_id)
-        .order_by(ReportRun.created_at.desc())
-        .limit(100)
-        .all()
-    )
+def list_report_runs(report_id: str, user_id: str = Depends(get_user_id), db: Session = Depends(get_db)):
+    try:
+        return report_service.list_report_runs(db, user_id, report_id)
+    except ReportNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -1,0 +1,178 @@
+"""Shared business logic for report CRUD, reused by both the REST routes
+(backend/app/routes/reports.py) and the MCP tools
+(backend/app/mcp/tools/reports.py) so validation/behavior is identical
+regardless of caller.
+"""
+from __future__ import annotations
+
+from datetime import datetime, time as time_cls
+from uuid import UUID
+
+import pydantic
+from sqlalchemy.orm import Session
+
+from app.models import Account, Report, ReportRun
+from app.schemas import ReportCreate, ReportUpdate
+from app.services.report_schedule_service import compute_next_run_at
+from tasks.report_tasks import send_report_run
+
+
+class ReportValidationError(Exception):
+    """Raised for any field-level or cross-field validation failure."""
+
+
+class ReportNotFoundError(Exception):
+    """Raised when a report_id doesn't exist or isn't owned by user_id."""
+
+
+_NON_NULLABLE_UPDATE_FIELDS = ("name", "account_ids", "recipient_emails", "frequency", "is_active", "timezone")
+
+
+def _parse_time(value: str) -> time_cls:
+    hh, mm, *rest = value.split(":")
+    ss = int(rest[0]) if rest else 0
+    return time_cls(int(hh), int(mm), ss)
+
+
+def _validate_account_ids(account_ids: list[str], user_id: str, db: Session) -> None:
+    if not account_ids:
+        return
+    parsed_ids = []
+    for raw_id in account_ids:
+        try:
+            parsed_ids.append(UUID(raw_id))
+        except ValueError:
+            raise ReportValidationError("One or more account_ids are invalid or not owned by this user")
+    owned_count = (
+        db.query(Account)
+        .filter(Account.user_id == user_id, Account.id.in_(parsed_ids))
+        .count()
+    )
+    if owned_count != len(set(parsed_ids)):
+        raise ReportValidationError("One or more account_ids are invalid or not owned by this user")
+
+
+def _recompute_next_run(report: Report) -> None:
+    report.next_run_at = compute_next_run_at(
+        frequency=report.frequency,
+        send_time=report.send_time,
+        timezone=report.timezone,
+        send_day_of_week=report.send_day_of_week,
+        send_day_of_month=report.send_day_of_month,
+        after=datetime.utcnow(),
+    )
+
+
+def list_reports(db: Session, user_id: str) -> list[Report]:
+    return db.query(Report).filter(Report.user_id == user_id).order_by(Report.created_at.desc()).all()
+
+
+def _get_owned_report(db: Session, user_id: str, report_id: str) -> Report:
+    try:
+        report_uuid = UUID(report_id)
+    except ValueError:
+        raise ReportNotFoundError("Report not found")
+    report = db.query(Report).filter(Report.id == report_uuid, Report.user_id == user_id).first()
+    if not report:
+        raise ReportNotFoundError("Report not found")
+    return report
+
+
+def get_report(db: Session, user_id: str, report_id: str) -> Report:
+    return _get_owned_report(db, user_id, report_id)
+
+
+def create_report(db: Session, user_id: str, payload: dict) -> Report:
+    try:
+        parsed = ReportCreate(**payload)
+    except pydantic.ValidationError as e:
+        raise ReportValidationError(str(e))
+
+    _validate_account_ids(parsed.account_ids, user_id, db)
+
+    report = Report(
+        user_id=user_id,
+        name=parsed.name,
+        account_ids=parsed.account_ids,
+        transaction_mode=parsed.transaction_mode,
+        transaction_count=parsed.transaction_count,
+        transaction_direction=parsed.transaction_direction,
+        frequency=parsed.frequency,
+        send_time=_parse_time(parsed.send_time),
+        send_day_of_week=parsed.send_day_of_week,
+        send_day_of_month=parsed.send_day_of_month,
+        timezone=parsed.timezone,
+        recipient_emails=parsed.recipient_emails,
+        is_active=parsed.is_active,
+    )
+    _recompute_next_run(report)
+    db.add(report)
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+def update_report(db: Session, user_id: str, report_id: str, payload: dict) -> Report:
+    report = _get_owned_report(db, user_id, report_id)
+
+    try:
+        parsed = ReportUpdate(**payload)
+    except pydantic.ValidationError as e:
+        raise ReportValidationError(str(e))
+
+    data = parsed.model_dump(exclude_unset=True)
+
+    null_fields = [f for f in _NON_NULLABLE_UPDATE_FIELDS if f in data and data[f] is None]
+    if null_fields:
+        raise ReportValidationError(f"Field(s) cannot be null: {', '.join(null_fields)}")
+
+    if "account_ids" in data and data["account_ids"] is not None:
+        _validate_account_ids(data["account_ids"], user_id, db)
+    if "send_time" in data and data["send_time"] is not None:
+        data["send_time"] = _parse_time(data["send_time"])
+    for field, value in data.items():
+        setattr(report, field, value)
+
+    if (report.frequency in ("WEEKLY", "BIWEEKLY") and report.send_day_of_week is None) or (
+        report.frequency == "MONTHLY" and report.send_day_of_month is None
+    ):
+        db.rollback()
+        raise ReportValidationError("send_day_of_week/send_day_of_month is required for the selected frequency")
+
+    _recompute_next_run(report)
+    db.commit()
+    db.refresh(report)
+    return report
+
+
+def delete_report(db: Session, user_id: str, report_id: str) -> None:
+    report = _get_owned_report(db, user_id, report_id)
+    db.delete(report)
+    db.commit()
+
+
+def send_test_report(db: Session, user_id: str, report_id: str) -> ReportRun:
+    report = _get_owned_report(db, user_id, report_id)
+    run = ReportRun(
+        report_id=report.id,
+        scheduled_for=None,
+        is_test=True,
+        status="SCHEDULED",
+        recipient_emails=report.recipient_emails,
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+    send_report_run.delay(str(run.id))
+    return run
+
+
+def list_report_runs(db: Session, user_id: str, report_id: str) -> list[ReportRun]:
+    _get_owned_report(db, user_id, report_id)
+    return (
+        db.query(ReportRun)
+        .filter(ReportRun.report_id == UUID(report_id))
+        .order_by(ReportRun.created_at.desc())
+        .limit(100)
+        .all()
+    )

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -163,7 +163,16 @@ def send_test_report(db: Session, user_id: str, report_id: str) -> ReportRun:
     db.add(run)
     db.commit()
     db.refresh(run)
-    send_report_run.delay(str(run.id))
+    try:
+        send_report_run.delay(str(run.id))
+    except Exception as e:
+        # Dispatch failed (e.g. Redis/broker unreachable) after the run
+        # was already committed — delete it rather than leaving a
+        # SCHEDULED row that will never be picked up and never
+        # transitions out of SCHEDULED.
+        db.delete(run)
+        db.commit()
+        raise ReportValidationError(f"Failed to enqueue send: {e}") from e
     return run
 
 

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -25,6 +25,13 @@ class ReportNotFoundError(Exception):
     """Raised when a report_id doesn't exist or isn't owned by user_id."""
 
 
+class ReportDispatchError(Exception):
+    """Raised when enqueueing a send fails for infra reasons (e.g. broker
+    unreachable) — distinct from ReportValidationError since this isn't a
+    bad-request condition; callers should map it to a 5xx/service-unavailable
+    style response, not 422."""
+
+
 _NON_NULLABLE_UPDATE_FIELDS = ("name", "account_ids", "recipient_emails", "frequency", "is_active", "timezone")
 
 
@@ -172,7 +179,7 @@ def send_test_report(db: Session, user_id: str, report_id: str) -> ReportRun:
         # transitions out of SCHEDULED.
         db.delete(run)
         db.commit()
-        raise ReportValidationError(f"Failed to enqueue send: {e}") from e
+        raise ReportDispatchError(f"Failed to enqueue send: {e}") from e
     return run
 
 

--- a/backend/tests/test_mcp_reports_tools.py
+++ b/backend/tests/test_mcp_reports_tools.py
@@ -1,0 +1,173 @@
+"""Tests for the report MCP tools module.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_mcp_reports_tools.py -v
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+import uuid
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-mcp-reports"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import User  # noqa: E402
+from app.mcp.tools import reports as report_tools  # noqa: E402
+
+
+def _seed_user(db) -> User:
+    user = User(id=f"test-user-{uuid.uuid4()}", email=f"{uuid.uuid4()}@example.com", name="Test User")
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _cleanup(db, user_id: str) -> None:
+    db.rollback()
+    db.query(User).filter(User.id == user_id).delete()
+    db.commit()
+
+
+def test_create_report_success_shape():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        result = report_tools.create_report(
+            user_id=user.id, name="Weekly summary", frequency="WEEKLY",
+            send_day_of_week=0, recipient_emails=["me@example.com"],
+        )
+        assert result["success"] is True
+        assert result["report"]["name"] == "Weekly summary"
+        assert result["report"]["frequency"] == "WEEKLY"
+    finally:
+        _cleanup(db, user.id)
+        db.close()
+
+
+def test_create_report_validation_error_shape():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        result = report_tools.create_report(
+            user_id=user.id, name="Bad", frequency="YEARLY", recipient_emails=["me@example.com"],
+        )
+        assert result["success"] is False
+        assert "error" in result
+    finally:
+        _cleanup(db, user.id)
+        db.close()
+
+
+def test_list_reports_returns_dicts():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        report_tools.create_report(
+            user_id=user.id, name="R1", frequency="DAILY", recipient_emails=["me@example.com"],
+        )
+        out = report_tools.list_reports(user_id=user.id)
+        assert isinstance(out, list)
+        assert len(out) == 1
+        assert out[0]["name"] == "R1"
+    finally:
+        _cleanup(db, user.id)
+        db.close()
+
+
+def test_get_report_not_found_returns_none():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        out = report_tools.get_report(user_id=user.id, report_id=str(uuid.uuid4()))
+        assert out is None
+    finally:
+        _cleanup(db, user.id)
+        db.close()
+
+
+def test_update_report_success_and_error_shapes():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        created = report_tools.create_report(
+            user_id=user.id, name="R1", frequency="DAILY", recipient_emails=["me@example.com"],
+        )
+        report_id = created["report"]["id"]
+
+        ok = report_tools.update_report(user_id=user.id, report_id=report_id, is_active=False)
+        assert ok["success"] is True
+        assert ok["report"]["is_active"] is False
+
+        bad = report_tools.update_report(user_id=user.id, report_id=str(uuid.uuid4()), is_active=False)
+        assert bad["success"] is False
+    finally:
+        _cleanup(db, user.id)
+        db.close()
+
+
+def test_delete_report_success_and_not_found():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        created = report_tools.create_report(
+            user_id=user.id, name="R1", frequency="DAILY", recipient_emails=["me@example.com"],
+        )
+        report_id = created["report"]["id"]
+
+        ok = report_tools.delete_report(user_id=user.id, report_id=report_id)
+        assert ok["success"] is True
+
+        again = report_tools.delete_report(user_id=user.id, report_id=report_id)
+        assert again["success"] is False
+    finally:
+        _cleanup(db, user.id)
+        db.close()
+
+
+def test_send_test_report_enqueues():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        created = report_tools.create_report(
+            user_id=user.id, name="R1", frequency="DAILY", recipient_emails=["me@example.com"],
+        )
+        report_id = created["report"]["id"]
+        with patch("app.services.report_service.send_report_run") as mock_task:
+            result = report_tools.send_test_report(user_id=user.id, report_id=report_id)
+        assert result["success"] is True
+        assert result["run"]["is_test"] is True
+        mock_task.delay.assert_called_once()
+    finally:
+        _cleanup(db, user.id)
+        db.close()
+
+
+def test_list_report_runs():
+    db = SessionLocal()
+    user = _seed_user(db)
+    try:
+        created = report_tools.create_report(
+            user_id=user.id, name="R1", frequency="DAILY", recipient_emails=["me@example.com"],
+        )
+        report_id = created["report"]["id"]
+        with patch("app.services.report_service.send_report_run"):
+            report_tools.send_test_report(user_id=user.id, report_id=report_id)
+        runs = report_tools.list_report_runs(user_id=user.id, report_id=report_id)
+        assert len(runs) == 1
+        assert runs[0]["is_test"] is True
+    finally:
+        _cleanup(db, user.id)
+        db.close()

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -254,8 +254,8 @@ def test_send_test_report_deletes_run_if_dispatch_fails():
             mock_task.delay.side_effect = RuntimeError("broker unreachable")
             try:
                 report_service.send_test_report(db, user.id, str(report.id))
-                assert False, "expected ReportValidationError"
-            except report_service.ReportValidationError:
+                assert False, "expected ReportDispatchError"
+            except report_service.ReportDispatchError:
                 pass
         runs = report_service.list_report_runs(db, user.id, str(report.id))
         assert len(runs) == 0

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -242,6 +242,30 @@ def test_send_test_report_creates_run_and_enqueues():
         db.close()
 
 
+def test_send_test_report_deletes_run_if_dispatch_fails():
+    # If send_report_run.delay() raises (e.g. broker unreachable) after the
+    # ReportRun row was already committed, it must not be left behind as a
+    # zombie SCHEDULED row that never gets picked up.
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload())
+        with patch("app.services.report_service.send_report_run") as mock_task:
+            mock_task.delay.side_effect = RuntimeError("broker unreachable")
+            try:
+                report_service.send_test_report(db, user.id, str(report.id))
+                assert False, "expected ReportValidationError"
+            except report_service.ReportValidationError:
+                pass
+        runs = report_service.list_report_runs(db, user.id, str(report.id))
+        assert len(runs) == 0
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
 def test_list_report_runs_scoped_to_report():
     db = SessionLocal()
     try:

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -1,0 +1,258 @@
+"""Tests for the shared report service layer.
+
+Run with:
+    cd backend && .venv/bin/pytest tests/test_report_service.py -v
+"""
+from __future__ import annotations
+
+import base64
+import os
+import sys
+import uuid
+from datetime import datetime, time, timedelta
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _set_test_env() -> None:
+    key = base64.urlsafe_b64encode(b"p" * 32).decode("utf-8").rstrip("=")
+    os.environ["DATA_ENCRYPTION_KEY_CURRENT"] = key
+    os.environ["DATA_ENCRYPTION_KEY_ID"] = "k-test-report-service"
+    os.environ.pop("DATA_ENCRYPTION_KEY_PREVIOUS", None)
+
+
+_set_test_env()
+
+from app.database import SessionLocal  # noqa: E402
+from app.models import Account, Report, ReportRun, User  # noqa: E402
+from app.services import report_service  # noqa: E402
+
+
+def _seed_user(db) -> User:
+    user = User(id=f"test-user-{uuid.uuid4()}", email=f"{uuid.uuid4()}@example.com", name="Test User")
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _base_payload(**overrides):
+    payload = {
+        "name": "Weekly summary",
+        "frequency": "WEEKLY",
+        "send_day_of_week": 0,
+        "recipient_emails": ["me@example.com"],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_create_report_success():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload())
+        assert report.id is not None
+        assert report.next_run_at is not None
+        assert report.frequency == "WEEKLY"
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_create_report_rejects_invalid_frequency():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        try:
+            report_service.create_report(db, user.id, _base_payload(frequency="YEARLY"))
+            assert False, "expected ReportValidationError"
+        except report_service.ReportValidationError:
+            pass
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_create_report_rejects_weekly_without_send_day_of_week():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        payload = _base_payload()
+        del payload["send_day_of_week"]
+        try:
+            report_service.create_report(db, user.id, payload)
+            assert False, "expected ReportValidationError"
+        except report_service.ReportValidationError:
+            pass
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_create_report_rejects_foreign_account_id():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        other = _seed_user(db)
+        acc = Account(user_id=other.id, name="Other's account", account_type="checking", currency="EUR")
+        db.add(acc)
+        db.flush()
+        try:
+            report_service.create_report(db, user.id, _base_payload(account_ids=[str(acc.id)]))
+            assert False, "expected ReportValidationError"
+        except report_service.ReportValidationError:
+            pass
+    finally:
+        db.query(User).filter(User.id.in_([user.id, other.id])).delete(synchronize_session=False)
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_get_report_raises_not_found_for_foreign_report():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        other = _seed_user(db)
+        report = report_service.create_report(db, other.id, _base_payload())
+        try:
+            report_service.get_report(db, user.id, str(report.id))
+            assert False, "expected ReportNotFoundError"
+        except report_service.ReportNotFoundError:
+            pass
+    finally:
+        db.query(User).filter(User.id.in_([user.id, other.id])).delete(synchronize_session=False)
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_update_report_partial_update_preserves_other_fields():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload())
+        updated = report_service.update_report(db, user.id, str(report.id), {"is_active": False})
+        assert updated.is_active is False
+        assert updated.name == "Weekly summary"
+        assert updated.frequency == "WEEKLY"
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_update_report_rejects_frequency_change_without_day_field():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload(frequency="DAILY", send_day_of_week=None))
+        try:
+            report_service.update_report(db, user.id, str(report.id), {"frequency": "MONTHLY"})
+            assert False, "expected ReportValidationError"
+        except report_service.ReportValidationError:
+            pass
+        # Confirm no partial mutation was committed.
+        db.rollback()
+        fetched = report_service.get_report(db, user.id, str(report.id))
+        assert fetched.frequency == "DAILY"
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_update_report_rejects_explicit_null_account_ids():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload())
+        try:
+            report_service.update_report(db, user.id, str(report.id), {"account_ids": None})
+            assert False, "expected ReportValidationError"
+        except report_service.ReportValidationError:
+            pass
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_delete_report_removes_it():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload())
+        report_id = str(report.id)
+        report_service.delete_report(db, user.id, report_id)
+        try:
+            report_service.get_report(db, user.id, report_id)
+            assert False, "expected ReportNotFoundError"
+        except report_service.ReportNotFoundError:
+            pass
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_delete_report_raises_not_found_for_foreign_report():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        other = _seed_user(db)
+        report = report_service.create_report(db, other.id, _base_payload())
+        try:
+            report_service.delete_report(db, user.id, str(report.id))
+            assert False, "expected ReportNotFoundError"
+        except report_service.ReportNotFoundError:
+            pass
+    finally:
+        db.query(User).filter(User.id.in_([user.id, other.id])).delete(synchronize_session=False)
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_send_test_report_creates_run_and_enqueues():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload())
+        with patch("app.services.report_service.send_report_run") as mock_task:
+            run = report_service.send_test_report(db, user.id, str(report.id))
+        assert run.is_test is True
+        assert run.status == "SCHEDULED"
+        mock_task.delay.assert_called_once_with(str(run.id))
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()
+
+
+def test_list_report_runs_scoped_to_report():
+    db = SessionLocal()
+    try:
+        user = _seed_user(db)
+        report = report_service.create_report(db, user.id, _base_payload())
+        db.add(ReportRun(report_id=report.id, status="SUCCEEDED", recipient_emails=["me@example.com"]))
+        db.commit()
+        runs = report_service.list_report_runs(db, user.id, str(report.id))
+        assert len(runs) == 1
+    finally:
+        db.query(User).filter(User.id == user.id).delete()
+        db.commit()
+        db.rollback()
+        db.close()


### PR DESCRIPTION
## Summary
- Adds full CRUD + send-test MCP tools for scheduled email reports (`list_reports`, `get_report`, `create_report`, `update_report`, `delete_report`, `send_test_report`, `list_report_runs`), so an AI agent (Claude Desktop/Code/web) can set up, configure, and delete newsletters the same way the dashboard UI does.
- Extracts the business logic that used to live inline in `backend/app/routes/reports.py` into a shared `backend/app/services/report_service.py` (typed `ReportValidationError`/`ReportNotFoundError` exceptions), so the REST API and the new MCP tools share identical validation/behavior instead of duplicating it.
- `backend/app/mcp/tools/reports.py` adapts the service's exceptions into the MCP convention (`{"success": False, "error": ...}` dicts, never raising), matching the established pattern in `categories.py`/`investments.py`, with explicit `db.rollback()` on every failure path (required since the MCP `get_db()` context manager doesn't auto-rollback on exception).
- Registers the 7 tools on the existing FastMCP server with docstrings covering every field (frequency values, direction/mode enums, day-field requirements, timezone format).

## Test plan
- [x] `backend/tests/test_report_service.py` (new, 12 tests) — validation errors, ownership errors, happy paths for all 7 service functions.
- [x] `backend/tests/test_report_routes.py` (existing, unmodified) — regression check that the routes.py refactor didn't change REST behavior.
- [x] `backend/tests/test_mcp_reports_tools.py` (new, 8 tests) — dict-shape contract for each MCP tool, including error paths.
- [x] Full report test suite (68 tests across all report-related files) run against real Postgres — all passing, independently re-verified in the final whole-branch review.
- [x] Confirmed every mutation tool correctly scopes by `user_id` via `report_service._get_owned_report` — no cross-user access path.
- [x] Confirmed `from app.mcp.server import mcp` imports cleanly with all 7 new tools registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP tools to create, manage, and test-send scheduled email reports, backed by a shared `report_service` so REST and MCP use the same validation, error handling, and behavior. This lets agents set up newsletters end-to-end while keeping logic consistent and easier to maintain.

- **New Features**
  - Added `list_reports`, `get_report`, `create_report`, `update_report`, `delete_report`, `send_test_report`, `list_report_runs` on the FastMCP server.
  - Tools return `{"success": bool, ...}` with explicit DB rollbacks on errors; no exceptions leak through.
  - Validates frequency/day fields, direction/mode enums, timezone, recipients, and ownership of `account_ids`.
  - All reads/mutations are scoped by `user_id`; REST routes now delegate to the shared `report_service`.

- **Bug Fixes**
  - Prevent orphaned `ReportRun` rows when `send_test_report` enqueue fails: delete the run and raise `ReportDispatchError`. REST maps this to 503 Service Unavailable; MCP returns `{"success": False, "error": ...}`.

<sup>Written for commit e0c5d2323aed8a38a37e4cb27e782832e345dee6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

