### PR TITLE
fix(frontend): Reports UI design-system compliance + two real bugs

### DIFF
--- a/frontend/app/(dashboard)/reports/[id]/page.tsx
+++ b/frontend/app/(dashboard)/reports/[id]/page.tsx
@@ -19,13 +19,13 @@ export default function EditReportPage() {
     isError: accountsError,
   } = useQuery({ queryKey: ["accounts"], queryFn: listAccounts });
 
-  if (reportLoading) return <div className="p-6 text-sm text-gray-500">Loading…</div>;
+  if (reportLoading) return <div className="p-6 text-sm text-muted-foreground">Loading…</div>;
 
   if (reportError || !report) {
     return (
-      <div className="p-6 text-sm text-gray-500">
+      <div className="p-6 text-sm text-muted-foreground">
         Report not found or failed to load.{" "}
-        <Link href="/reports" className="text-blue-600">
+        <Link href="/reports" className="text-foreground underline underline-offset-4">
           Back to reports
         </Link>
       </div>
@@ -33,7 +33,7 @@ export default function EditReportPage() {
   }
 
   return (
-    <div className="p-6">
+    <div className="p-6 text-foreground">
       <h1 className="text-xl font-semibold mb-4">Edit report</h1>
       <ReportForm
         report={report}

--- a/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
+++ b/frontend/app/(dashboard)/reports/[id]/runs/page.tsx
@@ -19,21 +19,21 @@ export default function ReportRunsPage() {
   });
 
   return (
-    <div className="p-6">
+    <div className="p-6 text-foreground">
       <h1 className="text-xl font-semibold mb-1">{report ? `${report.name} — Runs` : "Runs"}</h1>
-      <p className="text-sm text-gray-500 mb-4">Scheduled and executed sends for this report.</p>
+      <p className="text-sm text-muted-foreground mb-4">Scheduled and executed sends for this report.</p>
 
       {isLoading ? (
-        <p className="text-sm text-gray-500">Loading…</p>
+        <p className="text-sm text-muted-foreground">Loading…</p>
       ) : isError && !(runs && runs.length > 0) ? (
         // Only show the error state when there's no cached data to fall
         // back on — with refetchInterval polling, a single transient
         // background refetch failure would otherwise hide a previously
         // loaded, still-valid run history behind an error message.
-        <p className="text-sm text-red-600">Failed to load runs. Please try again.</p>
+        <p className="text-sm text-destructive">Failed to load runs. Please try again.</p>
       ) : runs && runs.length > 0 ? (
-        <table className="w-full text-sm border rounded-lg overflow-hidden">
-          <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
+        <table className="w-full text-sm border border-border rounded-lg overflow-hidden">
+          <thead className="bg-muted text-left text-xs uppercase text-muted-foreground">
             <tr>
               <th className="px-4 py-2">Scheduled for</th>
               <th className="px-4 py-2">Status</th>
@@ -41,7 +41,7 @@ export default function ReportRunsPage() {
               <th className="px-4 py-2">Error</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100">
+          <tbody className="divide-y divide-border">
             {runs.map((run) => (
               <tr key={run.id}>
                 <td className="px-4 py-2">
@@ -55,13 +55,13 @@ export default function ReportRunsPage() {
                   <RunStatusBadge status={run.status} />
                 </td>
                 <td className="px-4 py-2">{run.finished_at ? new Date(run.finished_at).toLocaleString() : "—"}</td>
-                <td className="px-4 py-2 text-red-600">{run.error_message ?? ""}</td>
+                <td className="px-4 py-2 text-destructive">{run.error_message ?? ""}</td>
               </tr>
             ))}
           </tbody>
         </table>
       ) : (
-        <p className="text-sm text-gray-500">No runs yet.</p>
+        <p className="text-sm text-muted-foreground">No runs yet.</p>
       )}
     </div>
   );

--- a/frontend/app/(dashboard)/reports/new/page.tsx
+++ b/frontend/app/(dashboard)/reports/new/page.tsx
@@ -12,7 +12,7 @@ export default function NewReportPage() {
   } = useQuery({ queryKey: ["accounts"], queryFn: listAccounts });
 
   return (
-    <div className="p-6">
+    <div className="p-6 text-foreground">
       <h1 className="text-xl font-semibold mb-4">New report</h1>
       <ReportForm
         availableAccounts={accounts ?? []}

--- a/frontend/app/(dashboard)/reports/page.tsx
+++ b/frontend/app/(dashboard)/reports/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { deleteReport, listReports } from "@/lib/reports/api";
+import { buttonVariants } from "@/components/ui/button";
 
 export default function ReportsPage() {
   const queryClient = useQueryClient();
@@ -27,44 +28,44 @@ export default function ReportsPage() {
   }
 
   return (
-    <div className="p-6">
+    <div className="p-6 text-foreground">
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-semibold">Reports</h1>
-        <Link href="/reports/new" className="text-sm font-medium text-blue-600">
+        <Link href="/reports/new" className={buttonVariants({ size: "sm" })}>
           New report
         </Link>
       </div>
 
-      {deleteError && <p className="text-sm text-red-600 mb-4">{deleteError}</p>}
+      {deleteError && <p className="text-sm text-destructive mb-4">{deleteError}</p>}
 
       {isLoading ? (
-        <p className="text-sm text-gray-500">Loading…</p>
+        <p className="text-sm text-muted-foreground">Loading…</p>
       ) : isError ? (
-        <div className="text-sm text-gray-500">
+        <div className="text-sm text-muted-foreground">
           Failed to load reports.{" "}
-          <button onClick={() => refetch()} className="text-blue-600 font-medium">
+          <button onClick={() => refetch()} className="text-foreground font-medium underline underline-offset-4">
             Retry
           </button>
         </div>
       ) : reports && reports.length > 0 ? (
-        <ul className="divide-y divide-gray-200 border rounded-lg">
+        <ul className="divide-y divide-border border border-border rounded-lg">
           {reports.map((report) => (
             <li key={report.id} className="flex items-center justify-between px-4 py-3">
               <div>
-                <Link href={`/reports/${report.id}`} className="font-medium text-gray-900">
+                <Link href={`/reports/${report.id}`} className="font-medium text-foreground hover:underline">
                   {report.name}
                 </Link>
-                <p className="text-xs text-gray-500">
+                <p className="text-xs text-muted-foreground">
                   {report.frequency.toLowerCase()} · next run{" "}
                   {report.next_run_at ? new Date(report.next_run_at).toLocaleString() : "—"} ·{" "}
                   {report.is_active ? "active" : "paused"}
                 </p>
               </div>
-              <div className="flex gap-3">
-                <Link href={`/reports/${report.id}/runs`} className="text-sm text-gray-600">
+              <div className="flex items-center gap-3">
+                <Link href={`/reports/${report.id}/runs`} className="text-sm text-muted-foreground hover:text-foreground">
                   Runs
                 </Link>
-                <button onClick={() => handleDelete(report.id)} className="text-sm text-red-600">
+                <button onClick={() => handleDelete(report.id)} className="text-sm text-destructive hover:underline">
                   Delete
                 </button>
               </div>
@@ -72,7 +73,7 @@ export default function ReportsPage() {
           ))}
         </ul>
       ) : (
-        <p className="text-sm text-gray-500">No reports yet. Create one to get started.</p>
+        <p className="text-sm text-muted-foreground">No reports yet. Create one to get started.</p>
       )}
     </div>
   );

--- a/frontend/components/reports/ReportForm.tsx
+++ b/frontend/components/reports/ReportForm.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createReport, sendTestReport, updateReport } from "@/lib/reports/api";
 import type { Report, ReportInput } from "@/lib/reports/types";
+import { Button } from "@/components/ui/button";
 
 const schema = z.object({
   name: z.string().min(1, "Required"),
@@ -54,6 +55,8 @@ export function ReportForm({
   const router = useRouter();
   const [recipientDraft, setRecipientDraft] = useState("");
   const [sendingTest, setSendingTest] = useState(false);
+  const [sendTestError, setSendTestError] = useState<string | null>(null);
+  const [sendTestSuccess, setSendTestSuccess] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const {
@@ -89,8 +92,13 @@ export function ReportForm({
   async function handleSendTest() {
     if (!report) return;
     setSendingTest(true);
+    setSendTestError(null);
+    setSendTestSuccess(false);
     try {
       await sendTestReport(report.id);
+      setSendTestSuccess(true);
+    } catch (err) {
+      setSendTestError(err instanceof Error ? err.message : "Failed to send test. Please try again.");
     } finally {
       setSendingTest(false);
     }
@@ -99,35 +107,39 @@ export function ReportForm({
   function addRecipient() {
     const value = recipientDraft.trim();
     if (!value) return;
-    setValue("recipient_emails", [...recipients, value]);
+    setValue("recipient_emails", [...recipients, value], { shouldValidate: true });
     setRecipientDraft("");
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="max-w-lg space-y-5">
+    <form onSubmit={handleSubmit(onSubmit)} className="max-w-lg space-y-5 text-foreground">
       <div>
         <label className="block text-sm font-medium mb-1">Name</label>
-        <input {...register("name")} className="w-full border rounded px-3 py-2 text-sm" />
-        {errors.name && <p className="text-xs text-red-600 mt-1">{errors.name.message}</p>}
+        <input
+          {...register("name")}
+          className="w-full border border-border bg-background text-foreground rounded px-3 py-2 text-sm placeholder:text-muted-foreground"
+        />
+        {errors.name && <p className="text-xs text-destructive mt-1">{errors.name.message}</p>}
       </div>
 
       <div>
         <label className="block text-sm font-medium mb-1">Accounts</label>
         {accountsLoading ? (
-          <p className="text-sm text-gray-500">Loading accounts…</p>
+          <p className="text-sm text-muted-foreground">Loading accounts…</p>
         ) : accountsError ? (
-          <p className="text-sm text-red-600">Failed to load accounts. Please refresh and try again.</p>
+          <p className="text-sm text-destructive">Failed to load accounts. Please refresh and try again.</p>
         ) : (
-        <div className="space-y-1 border rounded p-2 max-h-40 overflow-y-auto">
+        <div className="space-y-1 border border-border rounded p-2 max-h-40 overflow-y-auto">
           {availableAccounts.map((a) => (
-            <label key={a.id} className="flex items-center gap-2 text-sm">
+            <label key={a.id} className="flex items-center gap-2 text-sm text-foreground">
               <input
                 type="checkbox"
                 checked={accountIds.includes(a.id)}
                 onChange={(e) =>
                   setValue(
                     "account_ids",
-                    e.target.checked ? [...accountIds, a.id] : accountIds.filter((id) => id !== a.id)
+                    e.target.checked ? [...accountIds, a.id] : accountIds.filter((id) => id !== a.id),
+                    { shouldValidate: true }
                   )
                 }
               />
@@ -141,21 +153,31 @@ export function ReportForm({
       <div className="grid grid-cols-3 gap-3">
         <div>
           <label className="block text-sm font-medium mb-1">Mode</label>
-          <select {...register("transaction_mode")} className="w-full border rounded px-2 py-2 text-sm">
+          <select
+            {...register("transaction_mode")}
+            className="w-full border border-border bg-background text-foreground rounded px-2 py-2 text-sm"
+          >
             <option value="RECENT">Most recent</option>
             <option value="TOP_N">Top N by amount</option>
           </select>
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Count</label>
-          <input type="number" {...register("transaction_count")} className="w-full border rounded px-2 py-2 text-sm" />
+          <input
+            type="number"
+            {...register("transaction_count")}
+            className="w-full border border-border bg-background text-foreground rounded px-2 py-2 text-sm"
+          />
           {errors.transaction_count && (
-            <p className="text-xs text-red-600 mt-1">{errors.transaction_count.message}</p>
+            <p className="text-xs text-destructive mt-1">{errors.transaction_count.message}</p>
           )}
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Direction</label>
-          <select {...register("transaction_direction")} className="w-full border rounded px-2 py-2 text-sm">
+          <select
+            {...register("transaction_direction")}
+            className="w-full border border-border bg-background text-foreground rounded px-2 py-2 text-sm"
+          >
             <option value="ALL">All</option>
             <option value="EXPENSE">Expenses</option>
             <option value="INCOME">Income</option>
@@ -168,7 +190,10 @@ export function ReportForm({
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label className="block text-sm font-medium mb-1">Frequency</label>
-          <select {...register("frequency")} className="w-full border rounded px-2 py-2 text-sm">
+          <select
+            {...register("frequency")}
+            className="w-full border border-border bg-background text-foreground rounded px-2 py-2 text-sm"
+          >
             <option value="DAILY">Daily</option>
             <option value="WEEKLY">Weekly</option>
             <option value="BIWEEKLY">Biweekly</option>
@@ -177,14 +202,22 @@ export function ReportForm({
         </div>
         <div>
           <label className="block text-sm font-medium mb-1">Time</label>
-          <input type="time" step={60} {...register("send_time")} className="w-full border rounded px-2 py-2 text-sm" />
+          <input
+            type="time"
+            step={60}
+            {...register("send_time")}
+            className="w-full border border-border bg-background text-foreground rounded px-2 py-2 text-sm"
+          />
         </div>
       </div>
 
       {(frequency === "WEEKLY" || frequency === "BIWEEKLY") && (
         <div>
           <label className="block text-sm font-medium mb-1">Day of week</label>
-          <select {...register("send_day_of_week")} className="w-full border rounded px-2 py-2 text-sm">
+          <select
+            {...register("send_day_of_week")}
+            className="w-full border border-border bg-background text-foreground rounded px-2 py-2 text-sm"
+          >
             {["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"].map((d, i) => (
               <option key={d} value={i}>
                 {d}
@@ -192,7 +225,7 @@ export function ReportForm({
             ))}
           </select>
           {errors.send_day_of_week && (
-            <p className="text-xs text-red-600 mt-1">{errors.send_day_of_week.message}</p>
+            <p className="text-xs text-destructive mt-1">{errors.send_day_of_week.message}</p>
           )}
         </div>
       )}
@@ -205,10 +238,10 @@ export function ReportForm({
             min={1}
             max={28}
             {...register("send_day_of_month")}
-            className="w-full border rounded px-2 py-2 text-sm"
+            className="w-full border border-border bg-background text-foreground rounded px-2 py-2 text-sm"
           />
           {errors.send_day_of_month && (
-            <p className="text-xs text-red-600 mt-1">{errors.send_day_of_month.message}</p>
+            <p className="text-xs text-destructive mt-1">{errors.send_day_of_month.message}</p>
           )}
         </div>
       )}
@@ -220,26 +253,38 @@ export function ReportForm({
             value={recipientDraft}
             onChange={(e) => setRecipientDraft(e.target.value)}
             placeholder="name@example.com"
-            className="flex-1 border rounded px-3 py-2 text-sm"
+            className="flex-1 border border-border bg-background text-foreground rounded px-3 py-2 text-sm placeholder:text-muted-foreground"
           />
-          <button type="button" onClick={addRecipient} className="border rounded px-3 py-2 text-sm">
+          <Button type="button" variant="outline" onClick={addRecipient}>
             Add
-          </button>
+          </Button>
         </div>
         <div className="flex flex-wrap gap-2">
           {recipients.map((email) => (
-            <span key={email} className="bg-gray-100 rounded-full px-3 py-1 text-xs flex items-center gap-1">
+            <span
+              key={email}
+              className="bg-muted text-foreground rounded-full px-3 py-1 text-xs flex items-center gap-1"
+            >
               {email}
               <button
                 type="button"
-                onClick={() => setValue("recipient_emails", recipients.filter((r) => r !== email))}
+                className="text-muted-foreground hover:text-foreground"
+                onClick={() =>
+                  setValue(
+                    "recipient_emails",
+                    recipients.filter((r) => r !== email),
+                    { shouldValidate: true }
+                  )
+                }
               >
                 ×
               </button>
             </span>
           ))}
         </div>
-        {errors.recipient_emails && <p className="text-xs text-red-600 mt-1">{errors.recipient_emails.message}</p>}
+        {errors.recipient_emails && (
+          <p className="text-xs text-destructive mt-1">{errors.recipient_emails.message}</p>
+        )}
       </div>
 
       <div>
@@ -250,25 +295,22 @@ export function ReportForm({
       </div>
 
       <div className="flex items-center gap-3 pt-2">
-        <button
-          type="submit"
-          disabled={isSubmitting || accountsLoading || accountsError}
-          className="bg-blue-600 text-white rounded px-4 py-2 text-sm disabled:opacity-50"
-        >
+        <Button type="submit" disabled={isSubmitting || accountsLoading || accountsError}>
           {report ? "Save changes" : "Create report"}
-        </button>
+        </Button>
         {report && (
-          <button
-            type="button"
-            onClick={handleSendTest}
-            disabled={sendingTest}
-            className="border rounded px-4 py-2 text-sm"
-          >
+          <Button type="button" variant="outline" onClick={handleSendTest} disabled={sendingTest}>
             {sendingTest ? "Sending…" : "Send test now"}
-          </button>
+          </Button>
         )}
       </div>
-      {submitError && <p className="text-xs text-red-600">{submitError}</p>}
+      {submitError && <p className="text-xs text-destructive">{submitError}</p>}
+      {sendTestError && <p className="text-xs text-destructive">{sendTestError}</p>}
+      {sendTestSuccess && (
+        <p className="text-xs text-muted-foreground">
+          Test queued — check the Runs tab for delivery status.
+        </p>
+      )}
     </form>
   );
 }

--- a/frontend/components/reports/RunStatusBadge.tsx
+++ b/frontend/components/reports/RunStatusBadge.tsx
@@ -1,16 +1,16 @@
 import type { ReportRunStatus } from "@/lib/reports/types";
+import { Badge, type badgeVariants } from "@/components/ui/badge";
+import type { VariantProps } from "class-variance-authority";
 
-const STYLES: Record<ReportRunStatus, string> = {
-  SCHEDULED: "bg-gray-100 text-gray-700",
-  RUNNING: "bg-blue-100 text-blue-700",
-  SUCCEEDED: "bg-green-100 text-green-700",
-  FAILED: "bg-red-100 text-red-700",
+type BadgeVariant = NonNullable<VariantProps<typeof badgeVariants>["variant"]>;
+
+const VARIANTS: Record<ReportRunStatus, BadgeVariant> = {
+  SCHEDULED: "secondary",
+  RUNNING: "outline",
+  SUCCEEDED: "default",
+  FAILED: "destructive",
 };
 
 export function RunStatusBadge({ status }: { status: ReportRunStatus }) {
-  return (
-    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STYLES[status]}`}>
-      {status}
-    </span>
-  );
+  return <Badge variant={VARIANTS[status]}>{status}</Badge>;
 }


### PR DESCRIPTION
## Summary

Follow-up to #136. Fixes two real bugs in the Reports UI plus design-system compliance issues found while testing the feature end-to-end against production.

## Bugs fixed

**1. "Send test now" failed silently.** `handleSendTest` awaited `sendTestReport()` with no error handling and no success feedback — if the request failed (e.g. the worker couldn't dispatch), the button just stopped spinning and nothing happened. Now surfaces both an error and a success message.

**2. Stale validation errors.** `addRecipient` and the account-checkbox / recipient-chip `setValue` calls didn't pass `{ shouldValidate: true }`, so a previously-shown validation error stayed on screen after the user had corrected the input.

## Design-system compliance

Replaced raw Tailwind colors with semantic tokens throughout the Reports UI:

- `text-blue-600` / `bg-blue-600` → removed entirely (blue is not in our palette)
- `border` → `border-border`, `bg-gray-100` → `bg-muted`, `text-gray-900` → `text-foreground`, `text-red-600` → `text-destructive`
- Raw `<button>` elements → the `Button` component (`variant="outline"` for secondary actions)
- `RunStatusBadge` rewritten to use `Badge` variants instead of hand-rolled color classes

Note: `Button` in this codebase is built on `@base-ui/react`, which uses a `render` prop rather than Radix's `asChild`. For the "New report" link, `buttonVariants({ size: "sm" })` is applied directly to the `Link` instead.

## Testing

- `npx tsc --noEmit` passes clean
- Verified against the live deployment: the Send-test button now reports failures instead of silently swallowing them

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two Reports UI bugs and aligns the pages with our design system for better readability and dark-theme support. Adds success/error feedback for “Send test now” and ensures validation updates correctly.

- **Bug Fixes**
  - “Send test now” shows success and error messages instead of failing silently.
  - Recipient and account changes revalidate the form (`{ shouldValidate: true }`) to clear stale errors.

- **Refactors**
  - Replaced raw Tailwind colors with semantic tokens and adopted `Button` and `Badge` components (RunStatusBadge now uses Badge variants).
  - Standardized styles: `text-foreground`, `text-muted-foreground`, `text-destructive`, `border-border`, `bg-muted`, and `bg-background`; used `buttonVariants({ size: "sm" })` for the “New report” link.

<sup>Written for commit 90b9ae330dcad8122f987e9303b4b91c60a054a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

