### PR TITLE
fix(bank): allow re-linking accounts after a consent expires

### DIFF
--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -29,6 +29,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# Connection states that no longer sync. An account attached to one of these
+# may be re-linked to a fresh connection; consents expire roughly every 90
+# days, so this is the normal path back to a working link.
+# Mirrored in frontend/lib/actions/bank-connections.ts (DEAD_CONNECTION_STATUSES).
+_RELINKABLE_CONNECTION_STATUSES = {"expired", "disconnected", "error"}
+
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 ASPSP_CACHE_TTL = 86400  # 24 hours
 
@@ -344,11 +350,23 @@ def map_accounts(
                     status_code=404,
                     detail=f"Account '{mapping.existing_account_id}' not found",
                 )
-            if existing.bank_connection_id is not None:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Account '{mapping.existing_account_id}' is already linked to a bank connection",
-                )
+            # Re-linking is only a conflict when the account is still attached
+            # to a LIVE connection. After a consent expires the user must
+            # re-authorize, and reattaching the account to the new connection
+            # is the whole point of this wizard — rejecting it forced "create
+            # new account" and produced duplicates.
+            if existing.bank_connection_id is not None and existing.bank_connection_id != connection.id:
+                current = db.query(BankConnection).filter(
+                    BankConnection.id == existing.bank_connection_id,
+                ).first()
+                if current is not None and current.status not in _RELINKABLE_CONNECTION_STATUSES:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            f"Account '{mapping.existing_account_id}' is already linked to an "
+                            f"active bank connection ({current.aspsp_name})."
+                        ),
+                    )
             existing.bank_connection_id = connection.id
             existing.provider = "enable_banking"
             existing.external_id = mapping.bank_uid
@@ -544,31 +562,47 @@ def _build_suggested_mappings(
     user_id: str,
     raw_accounts: list,
 ) -> list:
-    """For each bank account UID, check if the user has an existing account with that external_id_hash."""
+    """Suggest, per bank account, whether to link to an existing account.
+
+    Matches on external_id_hash first, then falls back to the IBAN. The
+    fallback matters on re-authorization: the bank issues a new account uid
+    each time a consent is granted, so external_id alone stops matching and
+    the wizard would suggest creating a duplicate of an account the user
+    already has. The IBAN survives re-consent and is globally unique.
+    """
     results = []
     for raw_acc in raw_accounts:
         uid = raw_acc.get("uid") or raw_acc.get("id") or ""
         bank_name = raw_acc.get("account_name") or raw_acc.get("name") or "Bank Account"
+        raw_iban = raw_acc.get("iban") or (raw_acc.get("account_id") or {}).get("iban") or ""
 
-        if not uid:
-            results.append({
-                "bank_uid": uid,
-                "bank_name": bank_name,
-                "suggested_action": "create",
-                "suggested_account_id": None,
-                "suggested_account_name": None,
-            })
-            continue
+        existing = None
 
-        uid_hash = blind_index(uid)
-        existing = (
-            db.query(Account)
-            .filter(
-                Account.user_id == user_id,
-                Account.external_id_hash == uid_hash,
-            )
-            .first()
-        )
+        if uid:
+            uid_hash = blind_index(uid)
+            # A null hash (encryption unconfigured) would compile to
+            # `external_id_hash IS NULL` and match an unrelated account.
+            if uid_hash:
+                existing = (
+                    db.query(Account)
+                    .filter(
+                        Account.user_id == user_id,
+                        Account.external_id_hash == uid_hash,
+                    )
+                    .first()
+                )
+
+        if existing is None and raw_iban:
+            iban_hash = blind_index(raw_iban.replace(" ", "").upper())
+            if iban_hash:
+                existing = (
+                    db.query(Account)
+                    .filter(
+                        Account.user_id == user_id,
+                        Account.iban_hash == iban_hash,
+                    )
+                    .first()
+                )
 
         if existing:
             results.append({

--- a/backend/tests/test_bank_connectivity_fixes.py
+++ b/backend/tests/test_bank_connectivity_fixes.py
@@ -189,6 +189,136 @@ class TestSuggestedMappings(unittest.TestCase):
         self.assertEqual(no_match["suggested_action"], "create")
         self.assertIsNone(no_match["suggested_account_id"])
 
+    def test_falls_back_to_iban_when_external_id_is_unknown(self):
+        """Re-authorization mints a new uid; the IBAN still identifies the account.
+
+        Without the fallback the wizard suggests "create", producing a
+        duplicate of an account the user already has.
+        """
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        existing_account = MagicMock()
+        existing_account.id = "acc-uuid-1"
+        existing_account.name = "ABN AMRO Giannis"
+
+        mock_db = MagicMock()
+
+        # The uid lookup misses (new uid after re-consent); the IBAN lookup hits.
+        results_by_hash = {"iban-hash": existing_account, "new-uid-hash": None}
+        captured = []
+
+        def filter_side_effect(*args, **kwargs):
+            captured.append(args)
+            holder = MagicMock()
+            # The second positional filter is the hash comparison; decide from
+            # whichever hash the production code looked up most recently.
+            holder.first.return_value = results_by_hash.get(lookup["hash"])
+            return holder
+
+        lookup = {"hash": None}
+
+        def blind_index_side_effect(value):
+            mapping = {
+                "eb-new-uid": "new-uid-hash",
+                "NL64ABNA0123453784": "iban-hash",
+            }
+            lookup["hash"] = mapping.get(value)
+            return lookup["hash"]
+
+        mock_db.query.return_value.filter.side_effect = filter_side_effect
+
+        with patch("app.routes.enable_banking.blind_index", side_effect=blind_index_side_effect):
+            result = _build_suggested_mappings(
+                db=mock_db,
+                user_id="user-1",
+                raw_accounts=[
+                    {
+                        "uid": "eb-new-uid",
+                        "account_name": "I KOTSAKIACHIDIS",
+                        "iban": "NL64 ABNA 0123 4537 84",
+                    }
+                ],
+            )
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["suggested_action"], "link")
+        self.assertEqual(result[0]["suggested_account_id"], "acc-uuid-1")
+        self.assertEqual(result[0]["suggested_account_name"], "ABN AMRO Giannis")
+
+    def test_unhashable_values_do_not_match_an_arbitrary_account(self):
+        """A null blind index must not compile to `hash IS NULL` and match anything."""
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        stray_account = MagicMock()
+        stray_account.id = "acc-uuid-stray"
+        stray_account.name = "Unrelated Account"
+
+        mock_db = MagicMock()
+        # Any query that reaches the DB returns a row — so if the production
+        # code queries at all with a null hash, the test fails.
+        mock_db.query.return_value.filter.return_value.first.return_value = stray_account
+
+        with patch("app.routes.enable_banking.blind_index", return_value=None):
+            result = _build_suggested_mappings(
+                db=mock_db,
+                user_id="user-1",
+                raw_accounts=[{"uid": "some-uid", "account_name": "X", "iban": "NL64ABNA0123453784"}],
+            )
+
+        self.assertEqual(result[0]["suggested_action"], "create")
+        self.assertIsNone(result[0]["suggested_account_id"])
+
+
+class TestRelinkableConnectionStatuses(unittest.TestCase):
+    """Accounts on a dead connection must be re-linkable after re-authorization."""
+
+    def test_dead_statuses_cover_every_non_syncing_state(self):
+        from app.routes.enable_banking import _RELINKABLE_CONNECTION_STATUSES
+
+        # These are the states a connection lands in when it stops syncing.
+        # If one were missing, its accounts would be permanently unlinkable
+        # and the user would be forced to create a duplicate.
+        for status in ("expired", "disconnected", "error"):
+            self.assertIn(status, _RELINKABLE_CONNECTION_STATUSES)
+
+        # An active connection is a genuine conflict and must NOT be included.
+        self.assertNotIn("active", _RELINKABLE_CONNECTION_STATUSES)
+        self.assertNotIn("pending_setup", _RELINKABLE_CONNECTION_STATUSES)
+
+    def test_frontend_and_backend_status_lists_agree(self):
+        """The wizard offers the account; the API must accept it.
+
+        If these two lists drift, the account is shown as linkable and then
+        rejected on submit — a dead end for the user.
+        """
+        import pathlib
+        import re
+
+        from app.routes.enable_banking import _RELINKABLE_CONNECTION_STATUSES
+
+        ts_path = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "frontend"
+            / "lib"
+            / "actions"
+            / "bank-connections.ts"
+        )
+        if not ts_path.exists():  # backend-only checkout
+            self.skipTest("frontend source not present")
+
+        source = ts_path.read_text(encoding="utf-8")
+        match = re.search(
+            r"DEAD_CONNECTION_STATUSES\s*=\s*\[([^\]]*)\]", source, re.S
+        )
+        self.assertIsNotNone(match, "DEAD_CONNECTION_STATUSES not found in frontend")
+        frontend_statuses = set(re.findall(r'"([^"]+)"', match.group(1)))
+
+        self.assertEqual(
+            frontend_statuses,
+            set(_RELINKABLE_CONNECTION_STATUSES),
+            "Frontend linkable-account filter and backend link guard disagree.",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, and, desc, isNull } from "drizzle-orm";
+import { eq, and, desc, isNull, or, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { bankConnections, accounts } from "@/lib/db/schema";
 import { requireAuth, getAuthenticatedSession } from "@/lib/auth-helpers";
@@ -203,9 +203,29 @@ export async function getConnectionForMapping(connectionId: string) {
   return connection;
 }
 
+/** Connection states that no longer sync, so their accounts are re-linkable. */
+const DEAD_CONNECTION_STATUSES = ["expired", "disconnected", "error"];
+
 export async function getLinkableAccounts() {
   const userId = await requireAuth();
   if (!userId) return [];
+
+  // Accounts attached to a dead connection must stay linkable. A consent
+  // expires roughly every 90 days; when the user re-authorizes, the bank
+  // issues a new account uid, so the only way to reattach history to the
+  // existing account is to pick it here. Offering just the unattached
+  // accounts made that impossible and forced "create new" — which is how
+  // duplicate accounts were produced.
+  const deadConnections = await db
+    .select({ id: bankConnections.id })
+    .from(bankConnections)
+    .where(
+      and(
+        eq(bankConnections.userId, userId),
+        inArray(bankConnections.status, DEAD_CONNECTION_STATUSES)
+      )
+    );
+  const deadConnectionIds = deadConnections.map((c) => c.id);
 
   return db
     .select({
@@ -220,7 +240,12 @@ export async function getLinkableAccounts() {
     .where(
       and(
         eq(accounts.userId, userId),
-        isNull(accounts.bankConnectionId)
+        deadConnectionIds.length > 0
+          ? or(
+              isNull(accounts.bankConnectionId),
+              inArray(accounts.bankConnectionId, deadConnectionIds)
+            )
+          : isNull(accounts.bankConnectionId)
       )
     )
     .orderBy(accounts.name);


### PR DESCRIPTION
## Problem

Found live: re-authorizing an expired ABN AMRO consent was a **dead end**. The map-accounts wizard's "Link to existing account" dropdown listed manual and investment accounts but *not* the bank account being reconnected — leaving "Create new account" as the only option, which duplicates the account and splits its history.

Consents expire roughly every 90 days, so this is the normal path, not an edge case. All 7 of this user's bank accounts were affected (2 ABN AMRO, 5 Revolut).

Three independent gaps, each of which alone breaks the flow:

**1. `getLinkableAccounts` hid the account** — filtered `isNull(accounts.bankConnectionId)`, so any account attached to a connection was excluded. Since accounts stay attached to the *old* connection after it expires, they became permanently unlinkable.

**2. `_build_suggested_mappings` suggested the duplicate** — matched on `external_id_hash` only. Enable Banking mints a new account uid per consent, so the uid never matches after re-authorization and the wizard suggested `create`. Same blind spot fixed in the sync path in #138.

**3. `submit_account_mappings` rejected the link** — returned 400 for any account with a non-null `bank_connection_id`. So even after fixing (1) and (2), picking the correct account would fail on submit. **A frontend-only fix would have looked correct and then errored.**

## Change

1. `getLinkableAccounts` also returns accounts whose connection is `expired`, `disconnected` or `error`.
2. `_build_suggested_mappings` falls back to `iban_hash` when the uid lookup misses — the IBAN survives re-consent and is globally unique.
3. The link guard only rejects when the account's current connection is still **live**; re-linking off a dead connection is permitted, as is a no-op re-link to the same connection.

**Null-hash guard:** `blind_index()` returns `None` when encryption is unconfigured, and `hash == None` compiles to `IS NULL`, which would match an arbitrary account. Both lookups now skip the query rather than run it — the same defect class cubic caught in #138.

## Cross-language duplication

The dead-status list necessarily exists in both TS and Python. Drift would be silent and user-visible (account shown as linkable, then rejected on submit), so a test parses `DEAD_CONNECTION_STATUSES` out of the frontend source and asserts it equals the backend set. Verified it fails when the lists are made to disagree.

## Tests

4 new tests in `test_bank_connectivity_fixes.py`; each verified to fail with its corresponding fix reverted:

- IBAN fallback produces `link` instead of `create` when the uid is new
- a null blind index never matches an arbitrary account
- the dead-status set covers every non-syncing state and excludes `active`/`pending_setup`
- frontend and backend status lists agree

`149 passed` across the sync/account/bank/report suites, against an unchanged pre-existing baseline of 7 failed / 6 errors (SQLite/JSONB environment issues, verified identical on `origin/main`). `tsc --noEmit` clean.

Verified against production data: the new query returns all 7 bank accounts; previously it returned none of them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes re-linking after bank consent expiry so users can attach new connections to existing accounts without creating duplicates.

- **Bug Fixes**
  - `getLinkableAccounts` now shows accounts attached to `expired`, `disconnected`, or `error` connections.
  - Suggested mappings fall back to IBAN when the UID changes; null blind-index values no longer query.
  - API accepts re-linking unless the account is still on a live connection; active connections still reject.
  - Frontend and backend share the same dead-connection list; tests enforce they stay in sync.

<sup>Written for commit 62b94d6fea939da30395fcf43f0ce95700cbabac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

