### PR TITLE
fix(enable-banking): renew an expired consent in place instead of as a new connection

### DIFF
--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -21,9 +21,9 @@ from app.database import get_db
 from app.db_helpers import get_user_id
 from app.models import BankConnection, Account
 from app.integrations.enable_banking_auth import EnableBankingClient
-from app.integrations.enable_banking_adapter import EnableBankingAdapter, _ACCOUNT_TYPE_MAP
+from app.integrations.enable_banking_adapter import EnableBankingAdapter, _ACCOUNT_TYPE_MAP, _extract_iban
 from app.services.sync_service import SyncService
-from app.security.data_encryption import encrypt_value, blind_index
+from app.security.data_encryption import encrypt_value, blind_index, blind_index_candidates
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ router = APIRouter()
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 ASPSP_CACHE_TTL = 86400  # 24 hours
+AUTH_STATE_TTL = 1800  # 30 min — must outlast a slow bank login, see initiate_auth
 
 
 # --- Request/Response models ---
@@ -38,6 +39,9 @@ ASPSP_CACHE_TTL = 86400  # 24 hours
 class AuthRequest(BaseModel):
     aspsp_name: str
     aspsp_country: str
+    # Set to re-authorize an existing connection in place (consent renewal)
+    # instead of creating a second one. See initiate_auth.
+    connection_id: Optional[str] = None
 
 class AuthResponse(BaseModel):
     url: str
@@ -49,6 +53,9 @@ class SessionRequest(BaseModel):
 class SessionResponse(BaseModel):
     connection_id: str
     accounts_count: int
+    # True when an existing connection was renewed: accounts stayed mapped, so
+    # the caller must skip the account-mapping wizard.
+    reconnected: bool = False
 
 class SyncProgress(BaseModel):
     stage: str  # "syncing" | "done"
@@ -105,6 +112,103 @@ def _get_redis() -> redis.Redis:
     return redis.from_url(REDIS_URL, decode_responses=True)
 
 
+def _read_auth_state(state: Optional[str], user_id: str) -> dict:
+    """Consume the OAuth state nonce and return its payload.
+
+    Raises 403 if the nonce was issued to a different user. A missing or
+    unreadable nonce yields an empty payload, which the caller treats as a
+    plain first-time connect.
+    """
+    if not state:
+        return {}
+
+    try:
+        r = _get_redis()
+        raw = r.get(f"eb:state:{state}")
+        r.delete(f"eb:state:{state}")  # single use, even on mismatch
+    except Exception:
+        logger.warning("Failed to validate OAuth state from Redis")
+        return {}
+
+    if not raw:
+        return {}
+
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        payload = {"user_id": raw}  # nonce written before the payload was JSON
+
+    if payload.get("user_id") and payload["user_id"] != user_id:
+        raise HTTPException(status_code=403, detail="OAuth state mismatch")
+
+    return payload
+
+
+def _repoint_account_uids(db: Session, connection: BankConnection, raw_accounts: list) -> int:
+    """Re-point the connection's accounts at the account uids of a fresh consent.
+
+    Enable Banking mints a new account uid on every re-authorization, and the
+    connection sync reads each account's stored uid directly — it cannot call
+    adapter.fetch_accounts(), because EB only returns rich account objects at
+    OAuth time (see the note in tasks.enable_banking_tasks). So a renewed
+    consent must rewrite the uids here, while those objects are in hand, or
+    every subsequent sync requests accounts that no longer exist.
+
+    Accounts are matched on their old uid first, then on IBAN, which survives
+    re-consent. A raw account matching nothing is left alone: it is new at the
+    bank and was never mapped to one of the user's accounts.
+
+    The IBAN leg needs encryption configured, since IBAN is only ever stored as
+    a ciphertext + blind index. The uid leg works either way.
+    """
+    linked = db.query(Account).filter(
+        Account.bank_connection_id == connection.id,
+    ).all()
+    if not linked:
+        return 0
+
+    by_uid = {
+        uid: a
+        for a in linked
+        if (uid := SyncService._resolve_account_external_id(a))
+    }
+    by_iban_hash = {a.iban_hash: a for a in linked if a.iban_hash}
+    claimed: set = set()
+
+    repointed = 0
+    for raw in raw_accounts:
+        uid = raw.get("uid") or raw.get("id")
+        if not uid:
+            continue
+
+        account = by_uid.get(uid)
+        if account is None:
+            # Two bank accounts can share an IBAN (multi-currency), so an
+            # account already claimed by a uid or earlier IBAN hit is not
+            # re-pointed — that would leave the first one holding a dead uid.
+            iban = _extract_iban(raw) or _extract_iban(raw.get("account_id"))
+            account = next(
+                (
+                    by_iban_hash[h]
+                    for h in blind_index_candidates(iban)
+                    if h in by_iban_hash and by_iban_hash[h].id not in claimed
+                ),
+                None,
+            )
+        if account is None:
+            logger.info(
+                "Reconnect: bank account %s on connection %s matched no mapped account, skipping",
+                uid, connection.id,
+            )
+            continue
+
+        SyncService._set_account_external_id_fields(account, uid)
+        claimed.add(account.id)
+        repointed += 1
+
+    return repointed
+
+
 # --- Routes ---
 
 @router.get("/aspsps")
@@ -150,15 +254,44 @@ def initiate_auth(
     user_id: str = Depends(get_user_id),
     db: Session = Depends(get_db),
 ):
-    """Generate bank authorization URL for PSU redirect."""
+    """Generate bank authorization URL for PSU redirect.
+
+    With body.connection_id set, the resulting consent renews that connection
+    instead of creating a new one — its accounts stay mapped and no wizard runs.
+    """
     client = _get_eb_client()
 
-    # Generate a random state nonce (don't leak user_id in the redirect URL)
+    if body.connection_id:
+        owned = db.query(BankConnection).filter(
+            BankConnection.id == body.connection_id,
+            BankConnection.user_id == user_id,
+        ).first()
+        if not owned:
+            raise HTTPException(status_code=404, detail="Connection not found")
+
+    # Generate a random state nonce (don't leak user_id in the redirect URL).
+    # The connection being renewed rides along here, server-side, so a tampered
+    # callback cannot re-point a connection the user did not choose.
     state_nonce = str(uuid_mod.uuid4())
+    state_payload = json.dumps({"user_id": user_id, "connection_id": body.connection_id})
     try:
         r = _get_redis()
-        r.setex(f"eb:state:{state_nonce}", 600, user_id)  # 10 min TTL
+        # 30 min, not the previous 10: a PSU opening the bank app for 2FA can
+        # easily take longer, and an expired nonce drops a renewal onto the
+        # first-time-connect path, where the accounts are still held by the old
+        # connection and the wizard can only offer "create new" — duplicates.
+        r.setex(f"eb:state:{state_nonce}", AUTH_STATE_TTL, state_payload)
     except Exception:
+        # Losing the state degrades a renewal into a second connection, and from
+        # there into duplicate accounts, so a renewal fails before the redirect
+        # rather than continuing.
+        # ponytail: Redis dying mid-redirect still lands on the wizard; move the
+        # intent to Postgres if that window ever bites.
+        if body.connection_id:
+            raise HTTPException(
+                status_code=503,
+                detail="Cannot start the reconnect right now. Please try again.",
+            )
         logger.warning("Failed to store OAuth state in Redis")
 
     auth_payload = {
@@ -192,20 +325,12 @@ def create_session(
     """
     Exchange authorization code for an Enable Banking session.
     Creates a bank_connections row and upserts accounts.
+
+    When the state nonce carries a connection_id, the consent renews that
+    connection in place instead: its accounts keep their mapping, their uids are
+    re-pointed at the new consent, and a sync is dispatched immediately.
     """
-    # Validate OAuth state nonce if provided
-    if body.state:
-        try:
-            r = _get_redis()
-            stored_user_id = r.get(f"eb:state:{body.state}")
-            if stored_user_id and stored_user_id != user_id:
-                raise HTTPException(status_code=403, detail="OAuth state mismatch")
-            # Clean up used nonce
-            r.delete(f"eb:state:{body.state}")
-        except HTTPException:
-            raise
-        except Exception:
-            logger.warning("Failed to validate OAuth state from Redis")
+    state_payload = _read_auth_state(body.state, user_id)
 
     client = _get_eb_client()
 
@@ -235,6 +360,54 @@ def create_session(
     else:
         consent_expires_at = datetime.now(timezone.utc) + timedelta(days=90)
 
+    accounts_count = len(session_data.get("accounts", []))
+
+    reconnect_id = state_payload.get("connection_id")
+    if reconnect_id:
+        connection = db.query(BankConnection).filter(
+            BankConnection.id == reconnect_id,
+            BankConnection.user_id == user_id,
+        ).first()
+        if not connection:
+            raise HTTPException(status_code=404, detail="Connection to reconnect not found")
+
+        # Authorizing a different bank must never take over this connection: its
+        # accounts would then be re-pointed at another institution's uids.
+        if (connection.aspsp_name or "").strip().lower() != aspsp_name.strip().lower():
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"This authorization is for {aspsp_name}, but the connection "
+                    f"being reconnected is with {connection.aspsp_name}."
+                ),
+            )
+
+        connection.session_id = session_id
+        connection.consent_expires_at = consent_expires_at
+        connection.status = "active"
+        connection.last_sync_error = None
+        repointed = _repoint_account_uids(db, connection, session_data.get("accounts", []))
+        db.commit()
+
+        logger.info(
+            "Reconnected connection %s (%s): re-pointed %d of %d accounts",
+            connection.id, connection.aspsp_name, repointed, accounts_count,
+        )
+
+        # Each account resumes from its own last_synced_at, so the gap since the
+        # consent lapsed is backfilled without asking for a lookback window.
+        try:
+            from tasks.enable_banking_tasks import sync_bank_connection
+            sync_bank_connection.delay(str(connection.id))
+        except Exception:
+            logger.warning("Failed to dispatch sync task after reconnect", exc_info=True)
+
+        return SessionResponse(
+            connection_id=str(connection.id),
+            accounts_count=accounts_count,
+            reconnected=True,
+        )
+
     # Create bank_connections row (status=pending_setup; accounts mapped in a separate step)
     connection = BankConnection(
         user_id=user_id,
@@ -249,8 +422,6 @@ def create_session(
     db.add(connection)
     db.commit()
     db.refresh(connection)
-
-    accounts_count = len(session_data.get("accounts", []))
 
     return SessionResponse(
         connection_id=str(connection.id),

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 import redis
 import json
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
@@ -201,9 +202,12 @@ def _repoint_account_uids(db: Session, connection: BankConnection, raw_accounts:
                 for a in by_iban_hash.get(h, ())
                 if a.id not in claimed
             ]
+            # With several candidates and no currency agreeing, guessing would file
+            # one currency's transactions under another's account. Leave it
+            # unmapped: its sync fails loudly, which beats silent misfiling.
             account = next(
                 (a for a in candidates if (a.currency or "").upper() == currency),
-                candidates[0] if candidates else None,
+                candidates[0] if len(candidates) == 1 else None,
             )
         if account is None:
             logger.info(
@@ -379,9 +383,12 @@ def create_session(
     # thing this flow exists to prevent. Refuse, and let them retry from Settings.
     # An unambiguous first-time connect still proceeds, as it always has.
     if body.state and not state_payload:
+        # Normalized like the takeover check below: an exact comparison would miss
+        # a stored name differing only by case or padding, fall through, and open
+        # the second connection this guard exists to prevent.
         already_connected = db.query(BankConnection).filter(
             BankConnection.user_id == user_id,
-            BankConnection.aspsp_name == aspsp_name,
+            func.lower(func.trim(BankConnection.aspsp_name)) == aspsp_name.strip().lower(),
             BankConnection.status != "disconnected",
         ).first()
         if already_connected:

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -172,7 +172,14 @@ def _repoint_account_uids(db: Session, connection: BankConnection, raw_accounts:
         for a in linked
         if (uid := SyncService._resolve_account_external_id(a))
     }
-    by_iban_hash = {a.iban_hash: a for a in linked if a.iban_hash}
+    # IBAN maps to a list, not a single account: multi-currency accounts share
+    # one IBAN, and collapsing them would leave all but one holding a dead uid —
+    # which fails the whole connection sync, since a per-account failure re-raises
+    # (tasks.enable_banking_tasks).
+    by_iban_hash: dict = {}
+    for a in linked:
+        if a.iban_hash:
+            by_iban_hash.setdefault(a.iban_hash, []).append(a)
     claimed: set = set()
 
     repointed = 0
@@ -183,17 +190,20 @@ def _repoint_account_uids(db: Session, connection: BankConnection, raw_accounts:
 
         account = by_uid.get(uid)
         if account is None:
-            # Two bank accounts can share an IBAN (multi-currency), so an
-            # account already claimed by a uid or earlier IBAN hit is not
-            # re-pointed — that would leave the first one holding a dead uid.
+            # Currency breaks the tie between accounts sharing an IBAN. Choosing
+            # arbitrarily would file one currency's transactions under the other
+            # currency's account.
             iban = _extract_iban(raw) or _extract_iban(raw.get("account_id"))
+            currency = (raw.get("currency") or "").upper()
+            candidates = [
+                a
+                for h in blind_index_candidates(iban)
+                for a in by_iban_hash.get(h, ())
+                if a.id not in claimed
+            ]
             account = next(
-                (
-                    by_iban_hash[h]
-                    for h in blind_index_candidates(iban)
-                    if h in by_iban_hash and by_iban_hash[h].id not in claimed
-                ),
-                None,
+                (a for a in candidates if (a.currency or "").upper() == currency),
+                candidates[0] if candidates else None,
             )
         if account is None:
             logger.info(
@@ -361,6 +371,28 @@ def create_session(
         consent_expires_at = datetime.now(timezone.utc) + timedelta(days=90)
 
     accounts_count = len(session_data.get("accounts", []))
+
+    # A state that was supplied but could not be read — Redis unreachable, or a
+    # nonce that outlived its TTL — leaves the renewal intent unknown. Falling
+    # through would open a second connection to a bank the user already has, and
+    # the wizard could then only offer "create new": duplicate accounts, the very
+    # thing this flow exists to prevent. Refuse, and let them retry from Settings.
+    # An unambiguous first-time connect still proceeds, as it always has.
+    if body.state and not state_payload:
+        already_connected = db.query(BankConnection).filter(
+            BankConnection.user_id == user_id,
+            BankConnection.aspsp_name == aspsp_name,
+            BankConnection.status != "disconnected",
+        ).first()
+        if already_connected:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"You are already connected to {aspsp_name}, and this "
+                    "authorization could not be confirmed. Reconnect that bank from "
+                    "Settings › Bank Connections instead of connecting it again."
+                ),
+            )
 
     reconnect_id = state_payload.get("connection_id")
     if reconnect_id:

--- a/backend/tests/test_enable_banking_reconnect.py
+++ b/backend/tests/test_enable_banking_reconnect.py
@@ -132,6 +132,44 @@ class TestRepointAccountUids(unittest.TestCase):
         self.assertEqual(SyncService._resolve_account_external_id(usd), "new-usd")
         self.assertEqual(SyncService._resolve_account_external_id(eur), "new-eur")
 
+    def test_ambiguous_shared_iban_is_left_unmapped(self):
+        """No currency agrees and several accounts share the IBAN: guessing would file
+        one currency's transactions under another's account."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        eur = _account("eur", uid="old-eur", iban="NL01ABNA0123456789", currency="EUR")
+        usd = _account("usd", uid="old-usd", iban="NL01ABNA0123456789", currency="USD")
+        db = _db_with_linked_accounts([eur, usd])
+
+        count = _repoint_account_uids(
+            db,
+            MagicMock(id="conn-1"),
+            [{"uid": "new-gbp", "iban": "NL01ABNA0123456789", "currency": "GBP"}],
+        )
+
+        self.assertEqual(count, 0)
+        self.assertEqual(SyncService._resolve_account_external_id(eur), "old-eur")
+        self.assertEqual(SyncService._resolve_account_external_id(usd), "old-usd")
+
+    def test_lone_candidate_still_matches_on_a_currency_mismatch(self):
+        """One account on the IBAN is unambiguous, so a currency disagreement (a
+        never-recorded currency, say) must not block the re-point."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        acc = _account("only", uid="old-uid", iban="NL01ABNA0123456789", currency="EUR")
+        db = _db_with_linked_accounts([acc])
+
+        count = _repoint_account_uids(
+            db,
+            MagicMock(id="conn-1"),
+            [{"uid": "new-uid", "iban": "NL01ABNA0123456789", "currency": "GBP"}],
+        )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(SyncService._resolve_account_external_id(acc), "new-uid")
+
     def test_scheme_form_iban_is_matched(self):
         """EB also returns the IBAN nested under account_id in scheme form."""
         from app.routes.enable_banking import _repoint_account_uids
@@ -346,6 +384,63 @@ class TestUnreadableState(unittest.TestCase):
 
         self.assertFalse(result.reconnected)
         db.add.assert_called_once()
+
+
+class TestUnreadableStateAgainstTheDatabase(unittest.TestCase):
+    """The bank-name match happens in SQL, so a mocked session cannot prove it."""
+
+    def test_matches_a_stored_name_differing_by_case_and_padding(self):
+        from fastapi import HTTPException
+        from app.database import Base, SessionLocal, engine
+        from app.db_helpers import get_or_create_system_user
+        from app.models import BankConnection
+        from app.routes.enable_banking import create_session, SessionRequest
+
+        Base.metadata.create_all(bind=engine)
+        db = SessionLocal()
+        user_id = None
+        try:
+            user_id = str(get_or_create_system_user(db).id)
+            db.add(BankConnection(
+                user_id=user_id,
+                provider="enable_banking",
+                session_id="old-session",
+                aspsp_name="  abn amro  ",  # as stored
+                aspsp_country="NL",
+                status="expired",
+            ))
+            db.commit()
+
+            redis_mock = MagicMock()
+            redis_mock.get.return_value = None  # nonce gone: intent unknown
+
+            with patch("app.routes.enable_banking._get_redis", return_value=redis_mock), \
+                 patch("app.routes.enable_banking._get_eb_client") as client:
+                client.return_value.post.return_value.json.return_value = {
+                    "session_id": "new-session",
+                    "aspsp": {"name": "ABN AMRO", "country": "NL"},  # as returned now
+                    "accounts": [{"uid": "uid-1"}],
+                }
+                with self.assertRaises(HTTPException) as ctx:
+                    create_session(
+                        SessionRequest(code="auth-code", state="nonce"),
+                        user_id=user_id,
+                        db=db,
+                    )
+
+            self.assertEqual(ctx.exception.status_code, 409)
+            self.assertEqual(
+                db.query(BankConnection).filter(BankConnection.user_id == user_id).count(),
+                1,
+                "the guard must not have opened a second connection",
+            )
+        finally:
+            if user_id:
+                db.query(BankConnection).filter(
+                    BankConnection.user_id == user_id,
+                ).delete()
+                db.commit()
+            db.close()
 
 
 class TestReconnectAuth(unittest.TestCase):

--- a/backend/tests/test_enable_banking_reconnect.py
+++ b/backend/tests/test_enable_banking_reconnect.py
@@ -1,0 +1,340 @@
+"""Tests for Enable Banking consent renewal (reconnect an existing connection).
+
+Enable Banking mints a new account uid on every re-authorization, and the
+connection sync reads each account's stored uid directly, so a renewal that
+fails to re-point those uids leaves every subsequent sync asking the bank for
+accounts that no longer exist.
+"""
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _account(name, uid=None, iban=None):
+    """An unsaved Account with encrypted uid/IBAN fields populated."""
+    from app.models import Account
+    from app.services.sync_service import SyncService
+
+    acc = Account(
+        id=f"acct-{name}",
+        user_id="user-1",
+        name=name,
+        account_type="checking",
+        currency="EUR",
+    )
+    if uid:
+        SyncService._set_account_external_id_fields(acc, uid)
+    if iban:
+        SyncService._set_account_iban_fields(acc, iban)
+    return acc
+
+
+def _db_with_linked_accounts(accounts):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = accounts
+    return db
+
+
+class TestRepointAccountUids(unittest.TestCase):
+    def test_rotated_uid_is_matched_by_iban(self):
+        """The uid changed at re-consent; the IBAN survives and identifies the account."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        acc = _account("Giannis", uid="old-uid", iban="NL01ABNA0123456789")
+        db = _db_with_linked_accounts([acc])
+
+        count = _repoint_account_uids(
+            db,
+            MagicMock(id="conn-1"),
+            [{"uid": "new-uid", "iban": "NL01 ABNA 0123 456789"}],
+        )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(SyncService._resolve_account_external_id(acc), "new-uid")
+
+    def test_unchanged_uid_still_matches(self):
+        """A bank that keeps uids stable must not fall through to the IBAN path."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        acc = _account("Giannis", uid="same-uid", iban="NL01ABNA0123456789")
+        db = _db_with_linked_accounts([acc])
+
+        count = _repoint_account_uids(
+            db, MagicMock(id="conn-1"), [{"uid": "same-uid", "iban": "NL01ABNA0123456789"}]
+        )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(SyncService._resolve_account_external_id(acc), "same-uid")
+
+    def test_account_new_at_the_bank_is_skipped(self):
+        """An unrecognized bank account must not steal a mapped account's uid."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        acc = _account("Giannis", uid="old-uid", iban="NL01ABNA0123456789")
+        db = _db_with_linked_accounts([acc])
+
+        count = _repoint_account_uids(
+            db, MagicMock(id="conn-1"), [{"uid": "new-uid", "iban": "NL99RABO9999999999"}]
+        )
+
+        self.assertEqual(count, 0)
+        self.assertEqual(SyncService._resolve_account_external_id(acc), "old-uid")
+
+    def test_accounts_sharing_an_iban_are_claimed_once(self):
+        """Multi-currency accounts share an IBAN; the second must not overwrite the first."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        acc = _account("Giannis", uid="old-uid", iban="NL01ABNA0123456789")
+        db = _db_with_linked_accounts([acc])
+
+        count = _repoint_account_uids(
+            db,
+            MagicMock(id="conn-1"),
+            [
+                {"uid": "new-uid-1", "iban": "NL01ABNA0123456789"},
+                {"uid": "new-uid-2", "iban": "NL01ABNA0123456789"},
+            ],
+        )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(SyncService._resolve_account_external_id(acc), "new-uid-1")
+
+    def test_scheme_form_iban_is_matched(self):
+        """EB also returns the IBAN nested under account_id in scheme form."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        acc = _account("Giannis", uid="old-uid", iban="NL01ABNA0123456789")
+        db = _db_with_linked_accounts([acc])
+
+        count = _repoint_account_uids(
+            db,
+            MagicMock(id="conn-1"),
+            [{
+                "uid": "new-uid",
+                "account_id": {"scheme_name": "IBAN", "identification": "NL01ABNA0123456789"},
+            }],
+        )
+
+        self.assertEqual(count, 1)
+        self.assertEqual(SyncService._resolve_account_external_id(acc), "new-uid")
+
+
+class TestReconnectSession(unittest.TestCase):
+    """POST /session renews the connection carried in the OAuth state."""
+
+    def _patches(self, session_data, state_payload):
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = json.dumps(state_payload)
+        client_patch = patch("app.routes.enable_banking._get_eb_client")
+        redis_patch = patch("app.routes.enable_banking._get_redis", return_value=redis_mock)
+        client = client_patch.start()
+        client.return_value.post.return_value.json.return_value = session_data
+        redis_patch.start()
+        self.addCleanup(client_patch.stop)
+        self.addCleanup(redis_patch.stop)
+
+    def _connection(self):
+        return MagicMock(
+            id="conn-1",
+            aspsp_name="ABN AMRO",
+            session_id="old-session",
+            status="expired",
+            last_sync_error="Consent expired. Please reconnect.",
+        )
+
+    def test_renews_in_place_without_creating_a_connection(self):
+        from app.routes.enable_banking import create_session, SessionRequest
+        from app.services.sync_service import SyncService
+
+        conn = self._connection()
+        acc = _account("Giannis", uid="old-uid", iban="NL01ABNA0123456789")
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = conn
+        db.query.return_value.filter.return_value.all.return_value = [acc]
+
+        self._patches(
+            {
+                "session_id": "new-session",
+                "aspsp": {"name": "ABN AMRO", "country": "NL"},
+                "accounts": [{"uid": "new-uid", "iban": "NL01ABNA0123456789"}],
+            },
+            {"user_id": "user-1", "connection_id": "conn-1"},
+        )
+
+        with patch("tasks.enable_banking_tasks.sync_bank_connection") as sync_task:
+            result = create_session(
+                SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
+            )
+
+        self.assertTrue(result.reconnected)
+        self.assertEqual(result.connection_id, "conn-1")
+        self.assertEqual(conn.session_id, "new-session")
+        self.assertEqual(conn.status, "active")
+        self.assertIsNone(conn.last_sync_error)
+        db.add.assert_not_called()  # no second connection row
+        sync_task.delay.assert_called_once_with("conn-1")
+        # The renewal is worthless without this: the sync reads stored uids, so a
+        # connection left holding the pre-consent uid asks for dead accounts.
+        self.assertEqual(SyncService._resolve_account_external_id(acc), "new-uid")
+
+    def test_authorizing_a_different_bank_is_rejected(self):
+        """Otherwise the connection's accounts get re-pointed at another bank's uids."""
+        from fastapi import HTTPException
+        from app.routes.enable_banking import create_session, SessionRequest
+
+        conn = self._connection()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = conn
+
+        self._patches(
+            {
+                "session_id": "new-session",
+                "aspsp": {"name": "Revolut", "country": "LT"},
+                "accounts": [],
+            },
+            {"user_id": "user-1", "connection_id": "conn-1"},
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            create_session(
+                SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(conn.session_id, "old-session")
+        db.commit.assert_not_called()
+
+    def test_state_from_another_user_is_rejected(self):
+        from fastapi import HTTPException
+        from app.routes.enable_banking import create_session, SessionRequest
+
+        db = MagicMock()
+        self._patches(
+            {"session_id": "new-session", "aspsp": {"name": "ABN AMRO"}, "accounts": []},
+            {"user_id": "someone-else", "connection_id": "conn-1"},
+        )
+
+        with self.assertRaises(HTTPException) as ctx:
+            create_session(
+                SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
+            )
+
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_plain_state_without_connection_creates_a_new_connection(self):
+        """A first-time connect (and any pre-upgrade nonce) still lands on the wizard."""
+        from app.routes.enable_banking import create_session, SessionRequest
+
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = "user-1"  # nonce written before payloads were JSON
+        db = MagicMock()
+
+        with patch("app.routes.enable_banking._get_redis", return_value=redis_mock), \
+             patch("app.routes.enable_banking._get_eb_client") as client:
+            client.return_value.post.return_value.json.return_value = {
+                "session_id": "new-session",
+                "aspsp": {"name": "ABN AMRO", "country": "NL"},
+                "accounts": [{"uid": "uid-1"}],
+            }
+            result = create_session(
+                SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
+            )
+
+        self.assertFalse(result.reconnected)
+        db.add.assert_called_once()
+
+
+class TestReconnectAuth(unittest.TestCase):
+    """POST /auth carries the connection to renew in the server-side state."""
+
+    def test_state_stores_the_connection_id(self):
+        from app.routes.enable_banking import initiate_auth, AuthRequest
+
+        redis_mock = MagicMock()
+        db = MagicMock()
+
+        with patch("app.routes.enable_banking._get_redis", return_value=redis_mock), \
+             patch("app.routes.enable_banking._get_eb_client") as client:
+            client.return_value.redirect_uri = "https://app.example/callback"
+            client.return_value.post.return_value.json.return_value = {"url": "https://bank/auth"}
+            initiate_auth(
+                AuthRequest(aspsp_name="ABN AMRO", aspsp_country="NL", connection_id="conn-1"),
+                user_id="user-1",
+                db=db,
+            )
+
+        stored = json.loads(redis_mock.setex.call_args[0][2])
+        self.assertEqual(stored, {"user_id": "user-1", "connection_id": "conn-1"})
+        # An expired nonce silently drops the renewal onto the first-time-connect
+        # path, so the window has to outlast a 2FA detour into the bank's app.
+        self.assertGreaterEqual(redis_mock.setex.call_args[0][1], 1800)
+
+    def test_reconnect_fails_when_state_cannot_be_stored(self):
+        """A lost state silently degrades a renewal into duplicate accounts."""
+        from fastapi import HTTPException
+        from app.routes.enable_banking import initiate_auth, AuthRequest
+
+        redis_mock = MagicMock()
+        redis_mock.setex.side_effect = Exception("redis down")
+        db = MagicMock()
+
+        with patch("app.routes.enable_banking._get_redis", return_value=redis_mock), \
+             patch("app.routes.enable_banking._get_eb_client") as client:
+            client.return_value.redirect_uri = "https://app.example/callback"
+            with self.assertRaises(HTTPException) as ctx:
+                initiate_auth(
+                    AuthRequest(aspsp_name="ABN AMRO", aspsp_country="NL", connection_id="conn-1"),
+                    user_id="user-1",
+                    db=db,
+                )
+
+        self.assertEqual(ctx.exception.status_code, 503)
+
+    def test_a_first_time_connect_survives_redis_being_down(self):
+        from app.routes.enable_banking import initiate_auth, AuthRequest
+
+        redis_mock = MagicMock()
+        redis_mock.setex.side_effect = Exception("redis down")
+        db = MagicMock()
+
+        with patch("app.routes.enable_banking._get_redis", return_value=redis_mock), \
+             patch("app.routes.enable_banking._get_eb_client") as client:
+            client.return_value.redirect_uri = "https://app.example/callback"
+            client.return_value.post.return_value.json.return_value = {"url": "https://bank/auth"}
+            result = initiate_auth(
+                AuthRequest(aspsp_name="ABN AMRO", aspsp_country="NL"),
+                user_id="user-1",
+                db=db,
+            )
+
+        self.assertEqual(result.url, "https://bank/auth")
+
+    def test_reconnecting_a_foreign_connection_is_rejected(self):
+        from fastapi import HTTPException
+        from app.routes.enable_banking import initiate_auth, AuthRequest
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        with patch("app.routes.enable_banking._get_eb_client"):
+            with self.assertRaises(HTTPException) as ctx:
+                initiate_auth(
+                    AuthRequest(aspsp_name="ABN AMRO", aspsp_country="NL", connection_id="conn-x"),
+                    user_id="user-1",
+                    db=db,
+                )
+
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_enable_banking_reconnect.py
+++ b/backend/tests/test_enable_banking_reconnect.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-def _account(name, uid=None, iban=None):
+def _account(name, uid=None, iban=None, currency="EUR"):
     """An unsaved Account with encrypted uid/IBAN fields populated."""
     from app.models import Account
     from app.services.sync_service import SyncService
@@ -24,7 +24,7 @@ def _account(name, uid=None, iban=None):
         user_id="user-1",
         name=name,
         account_type="checking",
-        currency="EUR",
+        currency=currency,
     )
     if uid:
         SyncService._set_account_external_id_fields(acc, uid)
@@ -106,6 +106,31 @@ class TestRepointAccountUids(unittest.TestCase):
 
         self.assertEqual(count, 1)
         self.assertEqual(SyncService._resolve_account_external_id(acc), "new-uid-1")
+
+    def test_two_accounts_sharing_an_iban_are_both_repointed(self):
+        """Multi-currency accounts share an IBAN. Leaving one on a dead uid fails the
+        whole connection sync, because a per-account failure re-raises."""
+        from app.routes.enable_banking import _repoint_account_uids
+        from app.services.sync_service import SyncService
+
+        eur = _account("eur", uid="old-eur", iban="NL01ABNA0123456789", currency="EUR")
+        usd = _account("usd", uid="old-usd", iban="NL01ABNA0123456789", currency="USD")
+        db = _db_with_linked_accounts([eur, usd])
+
+        count = _repoint_account_uids(
+            db,
+            MagicMock(id="conn-1"),
+            [
+                {"uid": "new-usd", "iban": "NL01ABNA0123456789", "currency": "USD"},
+                {"uid": "new-eur", "iban": "NL01ABNA0123456789", "currency": "EUR"},
+            ],
+        )
+
+        self.assertEqual(count, 2)
+        # Currency, not arrival order, decides which account gets which uid —
+        # otherwise one currency's transactions land in the other's account.
+        self.assertEqual(SyncService._resolve_account_external_id(usd), "new-usd")
+        self.assertEqual(SyncService._resolve_account_external_id(eur), "new-eur")
 
     def test_scheme_form_iban_is_matched(self):
         """EB also returns the IBAN nested under account_id in scheme form."""
@@ -245,6 +270,76 @@ class TestReconnectSession(unittest.TestCase):
                 "aspsp": {"name": "ABN AMRO", "country": "NL"},
                 "accounts": [{"uid": "uid-1"}],
             }
+            result = create_session(
+                SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
+            )
+
+        self.assertFalse(result.reconnected)
+        db.add.assert_called_once()
+
+
+class TestUnreadableState(unittest.TestCase):
+    """A state that cannot be read must not silently become a second connection."""
+
+    def _patch_client(self, aspsp_name="ABN AMRO"):
+        client_patch = patch("app.routes.enable_banking._get_eb_client")
+        client = client_patch.start()
+        client.return_value.post.return_value.json.return_value = {
+            "session_id": "new-session",
+            "aspsp": {"name": aspsp_name, "country": "NL"},
+            "accounts": [{"uid": "uid-1"}],
+        }
+        self.addCleanup(client_patch.stop)
+
+    def test_refuses_when_that_bank_is_already_connected(self):
+        """Redis down mid-renewal would otherwise reopen the duplicate-account path."""
+        from fastapi import HTTPException
+        from app.routes.enable_banking import create_session, SessionRequest
+
+        redis_mock = MagicMock()
+        redis_mock.get.side_effect = Exception("redis down")
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = MagicMock(id="conn-1")
+        self._patch_client()
+
+        with patch("app.routes.enable_banking._get_redis", return_value=redis_mock):
+            with self.assertRaises(HTTPException) as ctx:
+                create_session(
+                    SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
+                )
+
+        self.assertEqual(ctx.exception.status_code, 409)
+        db.add.assert_not_called()
+
+    def test_expired_nonce_is_treated_the_same_as_an_unreachable_redis(self):
+        from fastapi import HTTPException
+        from app.routes.enable_banking import create_session, SessionRequest
+
+        redis_mock = MagicMock()
+        redis_mock.get.return_value = None  # nonce outlived its TTL
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = MagicMock(id="conn-1")
+        self._patch_client()
+
+        with patch("app.routes.enable_banking._get_redis", return_value=redis_mock):
+            with self.assertRaises(HTTPException) as ctx:
+                create_session(
+                    SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
+                )
+
+        self.assertEqual(ctx.exception.status_code, 409)
+
+    def test_first_time_connect_to_a_new_bank_still_proceeds(self):
+        """No existing connection means no ambiguity, so this must not regress."""
+        from app.routes.enable_banking import create_session, SessionRequest
+
+        redis_mock = MagicMock()
+        redis_mock.get.side_effect = Exception("redis down")
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        self._patch_client()
+
+        with patch("app.routes.enable_banking._get_redis", return_value=redis_mock):
             result = create_session(
                 SessionRequest(code="auth-code", state="nonce"), user_id="user-1", db=db
             )

--- a/frontend/app/api/enable-banking/callback/route.ts
+++ b/frontend/app/api/enable-banking/callback/route.ts
@@ -89,6 +89,12 @@ export async function GET(req: NextRequest) {
 
     const data = await resp.json();
     const connectionId = data.connection_id;
+
+    // A renewed consent keeps its account mapping, so there is nothing to map.
+    if (data.reconnected) {
+      return NextResponse.redirect(`${baseUrl}/settings?tab=bank-connections`);
+    }
+
     return NextResponse.redirect(
       `${baseUrl}/settings/connect-bank/map-accounts?connectionId=${connectionId}`
     );

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -25,7 +25,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { triggerSync, disconnectBank, triggerRecategorize } from "@/lib/actions/bank-connections";
+import { triggerSync, disconnectBank, triggerRecategorize, initiateAuth } from "@/lib/actions/bank-connections";
 type BankConnectionItem = {
   id: string;
   aspspName: string;
@@ -55,6 +55,8 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
   const [syncingIds, setSyncingIds] = useState<Set<string>>(new Set());
   const [recategorizingIds, setRecategorizingIds] = useState<Set<string>>(new Set());
   const [disconnectingIds, setDisconnectingIds] = useState<Set<string>>(new Set());
+  const [reconnectingIds, setReconnectingIds] = useState<Set<string>>(new Set());
+  const [reconnectError, setReconnectError] = useState<Map<string, string>>(new Map());
   const [pollingIds, setPollingIds] = useState<Set<string>>(new Set());
   const [syncProgress, setSyncProgress] = useState<Map<string, SyncProgress>>(new Map());
   const [elapsedSeconds, setElapsedSeconds] = useState<Map<string, number>>(new Map());
@@ -217,6 +219,45 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
     }
   };
 
+  // Renews the consent on the existing connection: accounts stay linked, so no
+  // disconnect and no mapping wizard. The backend re-points the account uids.
+  const handleReconnect = async (connection: BankConnectionItem) => {
+    setReconnectingIds((prev) => new Set(prev).add(connection.id));
+    setReconnectError((prev) => {
+      const next = new Map(prev);
+      next.delete(connection.id);
+      return next;
+    });
+    try {
+      const result = await initiateAuth(
+        connection.aspspName,
+        connection.aspspCountry,
+        connection.id
+      );
+      if (!result.success || !result.url) {
+        setReconnectError((prev) =>
+          new Map(prev).set(connection.id, result.error || "Could not start reconnect")
+        );
+        setReconnectingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(connection.id);
+          return next;
+        });
+        return;
+      }
+      window.location.href = result.url;
+    } catch {
+      setReconnectError((prev) =>
+        new Map(prev).set(connection.id, "Could not start reconnect")
+      );
+      setReconnectingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(connection.id);
+        return next;
+      });
+    }
+  };
+
   const handleDisconnect = async (connectionId: string) => {
     setDisconnectingIds((prev) => new Set(prev).add(connectionId));
     try {
@@ -325,12 +366,14 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                       <RiAlertLine className="h-3 w-3" />
                       <span>
                         Connection expires in {daysUntilExpiry(connection)} days.{" "}
-                        <Link
-                          href="/settings/connect-bank"
-                          className="underline"
+                        <button
+                          type="button"
+                          onClick={() => handleReconnect(connection)}
+                          disabled={reconnectingIds.has(connection.id)}
+                          className="underline disabled:opacity-60"
                         >
-                          Reconnect
-                        </Link>
+                          {reconnectingIds.has(connection.id) ? "Redirecting..." : "Reconnect"}
+                        </button>
                       </span>
                     </div>
                   )}
@@ -339,14 +382,21 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                       <RiAlertLine className="h-3 w-3" />
                       <span>
                         Connection expired.{" "}
-                        <Link
-                          href="/settings/connect-bank"
-                          className="underline"
+                        <button
+                          type="button"
+                          onClick={() => handleReconnect(connection)}
+                          disabled={reconnectingIds.has(connection.id)}
+                          className="underline disabled:opacity-60"
                         >
-                          Reconnect
-                        </Link>
+                          {reconnectingIds.has(connection.id) ? "Redirecting..." : "Reconnect"}
+                        </button>
                       </span>
                     </div>
+                  )}
+                  {reconnectError.has(connection.id) && (
+                    <p className="mt-1 text-xs text-destructive">
+                      {reconnectError.get(connection.id)}
+                    </p>
                   )}
                   {connection.lastSyncError && connection.status === "error" && (
                     <p className="mt-1 text-xs text-destructive">

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -133,9 +133,15 @@ export async function disconnectBank(
   }
 }
 
+/**
+ * Start a bank authorization. Pass connectionId to renew an existing
+ * connection's consent in place — its accounts stay mapped and the callback
+ * skips the mapping wizard.
+ */
 export async function initiateAuth(
   aspspName: string,
-  aspspCountry: string
+  aspspCountry: string,
+  connectionId?: string
 ): Promise<{ success: boolean; url?: string; error?: string }> {
   const session = await getAuthenticatedSession();
   const userId = session?.user?.id;
@@ -163,6 +169,7 @@ export async function initiateAuth(
       body: JSON.stringify({
         aspsp_name: aspspName,
         aspsp_country: aspspCountry,
+        connection_id: connectionId,
       }),
     });
 


### PR DESCRIPTION
## Problem

Renewing an expired Enable Banking consent required disconnecting the bank first and walking the account-mapping wizard again. That ordering is not discoverable — the "Reconnect" link went straight to `/settings/connect-bank` — and while the old connection still owns the accounts, "link to existing" is not even offered:

- `getLinkableAccounts()` filters on `bankConnectionId IS NULL` (`frontend/lib/actions/bank-connections.ts:206`)
- `map_accounts` rejects an account that already has a `bank_connection_id` (`backend/app/routes/enable_banking.py:347`)

So the wizard's only available action was **Create new** → a second account row for the same real account. This is what produced the duplicate `ABN AMRO` rows.

The `_build_suggested_mappings` pre-selection could not help either: it matches on `external_id_hash`, i.e. the EB account uid, and per e7924e7 EB mints a **new uid on every re-authorization**.

## Change

Renew in place, no disconnect and no wizard:

- `POST /auth` accepts an optional `connection_id`, ownership-checked, carried **server-side** in the OAuth state nonce so a tampered callback cannot re-point a connection the user did not choose.
- `POST /session` renews that connection: same row, new `session_id`, pushed-out expiry, `status="active"`, error cleared, sync dispatched, `reconnected: true`.
- `_repoint_account_uids` rewrites the mapped accounts' uids from the fresh consent — old uid first, IBAN fallback.
- The callback skips the mapping wizard on `reconnected`; the Reconnect affordance becomes a button that goes straight to the bank.

Each account resumes from its own `last_synced_at` (`enable_banking_tasks.py:58-62`), so the gap since the consent lapsed backfills without asking for a lookback window.

### Why the re-point lives in `/session`

`sync_bank_connection` never calls `SyncService.sync_accounts()` — it reads each account's stored uid directly, because EB returns rich account objects **only at OAuth time** (`enable_banking_tasks.py:154-158`). e7924e7's IBAN fallback is in `sync_accounts`, so it is not on this path. `/session` is the one moment those objects exist.

### Guards

- Authorizing a **different bank** is rejected (400) rather than taking the connection over — otherwise its accounts get re-pointed at another institution's uids.
- A renewal whose state cannot be stored fails **503** rather than degrading into a second connection.
- State TTL 10 min → 30 min: a PSU opening the bank app for 2FA can outlast 10 minutes, and an expired nonce silently drops the renewal onto the first-time-connect path.

## Testing

- 13 new tests in `backend/tests/test_enable_banking_reconnect.py`.
- Each guard mutation-checked — dropping the IBAN fallback, inverting the ASPSP check, removing the re-point call, removing the `active` reset, dropping the state user check, and removing the IBAN claimed-filter each fail a test. That pass also found dead code (an `account.id in claimed` clause that made the weaker IBAN match beat a uid match in one ordering); deleted.
- Full backend suite against a throwaway Postgres: **308 passed**, versus **295 passed** on pristine `main` with an identical pre-existing failure set (`test_mcp_discovery`, `test_holding_valuation_service`, `test_investment*`, `test_mcp_investments_tools`, and the `test_demo_seed_service` collection error). No regressions.
- Frontend `tsc --noEmit`: 0 errors. `eslint` on the changed files: 0 errors.

**Not tested:** the live bank redirect. Exercising it needs a real ASPSP consent and a human at the bank's login page, so the renewal should be run once against a real expiring consent before relying on it.

## Known limits

- Accounts new at the bank since the last consent are logged and left unmapped on renewal (no mapping step on this path).
- The IBAN leg needs encryption configured — IBAN is only ever stored as ciphertext + blind index. The uid leg works either way.
- Connections in `error` status still get no Reconnect button (only `expired` and expiring-soon), unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renewing an expired Enable Banking consent now happens in place on the existing connection, preventing duplicate accounts and skipping the mapping wizard. Previously, reconnecting created a new connection and forced remapping; now the same connection is renewed and its accounts keep their links.

- Backend: `POST /auth` accepts `connection_id` and stores it in server-side OAuth state (JSON, 30 min TTL, single-use, user-bound). If state cannot be stored during a reconnect, return 503. `POST /session` reads that state; when present, it renews the same connection (new `session_id`, updated expiry, `status="active"`, error cleared), rewrites mapped accounts’ UIDs via `_repoint_account_uids` (old UID first, then IBAN with currency tie‑breaker for multi‑currency accounts sharing an IBAN), dispatches a sync, and returns `reconnected: true`. If a state was supplied but cannot be read and the user already has a connection to that bank, return 409 to avoid duplicate accounts; a first‑time connect with no existing connection still proceeds.
- Frontend: the Reconnect button starts auth with `connection_id`; the callback redirects back to Settings when `reconnected` (no mapping wizard).
- Guards: reject cross‑bank reconnects (400); reject OAuth state from another user (403); state TTL is 30 min to survive 2FA detours. IBAN matching requires encryption; otherwise only UID matching applies.
- Tests: new backend suite covers unreadable-state 409 handling and multi‑currency IBAN matching; no regressions reported; frontend type/lint clean.

**Review & rollout notes**
- Focus on `_read_auth_state`, `_repoint_account_uids` (currency‑aware IBAN matching and claimed‑once semantics), the `create_session` unreadable‑state 409 branch, and the callback redirect.
- Run one live reconnect against a real expiring consent to verify the bank redirect flow. Accounts newly visible at the bank remain unmapped after reconnect; no migration actions required.

<sup>Written for commit 200760c471ea455939929196ea08767ba2fdd46b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

