### PR TITLE
fix(bank-connections): identify each connection, and auto-link a returning account by IBAN

### DIFF
--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -504,8 +504,15 @@ def map_accounts(
     # first link already moved the account onto this very connection, which is
     # not "active" yet — and silently overwrite the uid written moments before,
     # leaving one bank account mapped to nothing.
-    for field, label in (("existing_account_id", "account"), ("bank_uid", "bank account")):
-        seen = [getattr(m, field) for m in request.mappings if getattr(m, field)]
+    # existing_account_id is compared case-insensitively: Postgres parses a UUID
+    # without regard to case, so two spellings of one id would slip past an exact
+    # match and both resolve to the same account. bank_uid is an opaque token
+    # from the bank and is compared as sent.
+    for field, label, normalize in (
+        ("existing_account_id", "account", lambda v: v.strip().lower()),
+        ("bank_uid", "bank account", lambda v: v),
+    ):
+        seen = [normalize(getattr(m, field)) for m in request.mappings if getattr(m, field)]
         duplicate = next((v for v in seen if seen.count(v) > 1), None)
         if duplicate:
             raise HTTPException(

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -499,6 +499,20 @@ def map_accounts(
             detail=f"Connection is not in pending_setup state (current: {connection.status})",
         )
 
+    # One account per bank account, both ways. Without this, a repeated
+    # existing_account_id would pass the link guard on its second use — the
+    # first link already moved the account onto this very connection, which is
+    # not "active" yet — and silently overwrite the uid written moments before,
+    # leaving one bank account mapped to nothing.
+    for field, label in (("existing_account_id", "account"), ("bank_uid", "bank account")):
+        seen = [getattr(m, field) for m in request.mappings if getattr(m, field)]
+        duplicate = next((v for v in seen if seen.count(v) > 1), None)
+        if duplicate:
+            raise HTTPException(
+                status_code=400,
+                detail=f"The same {label} '{duplicate}' appears in more than one mapping",
+            )
+
     # Index raw bank accounts by UID for quick lookup
     raw_accounts = connection.raw_session_data.get("accounts", []) if connection.raw_session_data else []
     raw_by_uid = {acc["uid"]: acc for acc in raw_accounts}
@@ -761,13 +775,24 @@ def _is_held_by_active_connection(db: Session, account: Account) -> bool:
     Such an account cannot be re-linked: moving it would silently break the
     working connection. An account held by an expired or errored consent is fair
     game — re-linking it is exactly how a renewal is meant to work.
+
+    A lapsed consent is treated as dead even while its row still says "active":
+    check_consent_expiry only runs daily, and until it does, the status lags
+    reality and would block exactly the relink the user came to do.
     """
     if account.bank_connection_id is None:
         return False
     holder = db.query(BankConnection).filter(
         BankConnection.id == account.bank_connection_id,
     ).first()
-    return holder is not None and holder.status == "active"
+    if holder is None or holder.status != "active":
+        return False
+    if holder.consent_expires_at is None:
+        return True
+    expires_at = holder.consent_expires_at
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    return expires_at > datetime.now(timezone.utc)
 
 
 def _find_account_for_bank_account(
@@ -775,6 +800,7 @@ def _find_account_for_bank_account(
     user_id: str,
     uid: str,
     iban: Optional[str],
+    currency: Optional[str] = None,
 ) -> Optional[Account]:
     """Locate the user's account for one bank account, by uid and then by IBAN.
 
@@ -788,23 +814,41 @@ def _find_account_for_bank_account(
     """
     query = db.query(Account).filter(Account.user_id == user_id)
 
-    candidates = []
+    # The uid identifies one account exactly, so it needs no tie-break.
     if uid:
         uid_hashes = blind_index_candidates(uid)
+        by_uid = []
         if uid_hashes:
-            candidates.extend(query.filter(Account.external_id_hash.in_(uid_hashes)).all())
-        # Deployments without encryption configured keep the uid in plaintext.
-        candidates.extend(query.filter(Account.external_id == uid).all())
+            by_uid = query.filter(Account.external_id_hash.in_(uid_hashes)).all()
+        if not by_uid:
+            # Deployments without encryption configured keep the uid in plaintext.
+            by_uid = query.filter(Account.external_id == uid).all()
+        for account in by_uid:
+            if not _is_held_by_active_connection(db, account):
+                return account
 
-    if iban:
-        iban_hashes = blind_index_candidates(iban)
-        if iban_hashes:
-            candidates.extend(query.filter(Account.iban_hash.in_(iban_hashes)).all())
+    if not iban:
+        return None
+    iban_hashes = blind_index_candidates(iban)
+    if not iban_hashes:
+        return None
+    candidates = [
+        account
+        for account in query.filter(Account.iban_hash.in_(iban_hashes)).all()
+        if not _is_held_by_active_connection(db, account)
+    ]
+    if not candidates:
+        return None
+    if len(candidates) == 1:
+        return candidates[0]
 
-    for account in candidates:
-        if not _is_held_by_active_connection(db, account):
-            return account
-    return None
+    # Multi-currency accounts share one IBAN, and .all() gives no meaningful
+    # order. Only currency can tell them apart; without it, auto-linking would
+    # file one currency's transactions under another currency's account, so
+    # leave it for the user to map by hand.
+    wanted = (currency or "").upper()
+    matches = [a for a in candidates if (a.currency or "").upper() == wanted]
+    return matches[0] if len(matches) == 1 else None
 
 
 def _build_suggested_mappings(
@@ -833,7 +877,9 @@ def _build_suggested_mappings(
             })
             continue
 
-        existing = _find_account_for_bank_account(db, user_id, uid, iban)
+        existing = _find_account_for_bank_account(
+            db, user_id, uid, iban, raw_acc.get("currency")
+        )
 
         if existing:
             results.append({

--- a/backend/app/routes/enable_banking.py
+++ b/backend/app/routes/enable_banking.py
@@ -554,10 +554,16 @@ def map_accounts(
                     status_code=404,
                     detail=f"Account '{mapping.existing_account_id}' not found",
                 )
-            if existing.bank_connection_id is not None:
+            # Only a live consent blocks re-linking. Refusing accounts held by an
+            # expired one is what forced users to disconnect before reconnecting,
+            # and that detour is where duplicate accounts came from.
+            if _is_held_by_active_connection(db, existing):
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Account '{mapping.existing_account_id}' is already linked to a bank connection",
+                    detail=(
+                        f"Account '{mapping.existing_account_id}' is already linked to an "
+                        "active bank connection"
+                    ),
                 )
             existing.bank_connection_id = connection.id
             existing.provider = "enable_banking"
@@ -749,18 +755,75 @@ def list_connections(
     return results
 
 
+def _is_held_by_active_connection(db: Session, account: Account) -> bool:
+    """True if another, still-live consent owns this account.
+
+    Such an account cannot be re-linked: moving it would silently break the
+    working connection. An account held by an expired or errored consent is fair
+    game — re-linking it is exactly how a renewal is meant to work.
+    """
+    if account.bank_connection_id is None:
+        return False
+    holder = db.query(BankConnection).filter(
+        BankConnection.id == account.bank_connection_id,
+    ).first()
+    return holder is not None and holder.status == "active"
+
+
+def _find_account_for_bank_account(
+    db: Session,
+    user_id: str,
+    uid: str,
+    iban: Optional[str],
+) -> Optional[Account]:
+    """Locate the user's account for one bank account, by uid and then by IBAN.
+
+    The IBAN leg is what makes re-connecting work at all: Enable Banking mints a
+    new account uid on every authorization, so uid alone misses whenever the user
+    reconnects, the wizard falls back to "create new", and the same real account
+    is added a second time.
+
+    Accounts held by a live connection are skipped — see
+    _is_held_by_active_connection.
+    """
+    query = db.query(Account).filter(Account.user_id == user_id)
+
+    candidates = []
+    if uid:
+        uid_hashes = blind_index_candidates(uid)
+        if uid_hashes:
+            candidates.extend(query.filter(Account.external_id_hash.in_(uid_hashes)).all())
+        # Deployments without encryption configured keep the uid in plaintext.
+        candidates.extend(query.filter(Account.external_id == uid).all())
+
+    if iban:
+        iban_hashes = blind_index_candidates(iban)
+        if iban_hashes:
+            candidates.extend(query.filter(Account.iban_hash.in_(iban_hashes)).all())
+
+    for account in candidates:
+        if not _is_held_by_active_connection(db, account):
+            return account
+    return None
+
+
 def _build_suggested_mappings(
     db: Session,
     user_id: str,
     raw_accounts: list,
 ) -> list:
-    """For each bank account UID, check if the user has an existing account with that external_id_hash."""
+    """Suggest, for each bank account, the user's existing account to link to.
+
+    Matching is by uid first and IBAN second, so an account the user already has
+    is recognized after a re-consent rather than duplicated.
+    """
     results = []
     for raw_acc in raw_accounts:
         uid = raw_acc.get("uid") or raw_acc.get("id") or ""
         bank_name = raw_acc.get("account_name") or raw_acc.get("name") or "Bank Account"
+        iban = _extract_iban(raw_acc) or _extract_iban(raw_acc.get("account_id"))
 
-        if not uid:
+        if not uid and not iban:
             results.append({
                 "bank_uid": uid,
                 "bank_name": bank_name,
@@ -770,15 +833,7 @@ def _build_suggested_mappings(
             })
             continue
 
-        uid_hash = blind_index(uid)
-        existing = (
-            db.query(Account)
-            .filter(
-                Account.user_id == user_id,
-                Account.external_id_hash == uid_hash,
-            )
-            .first()
-        )
+        existing = _find_account_for_bank_account(db, user_id, uid, iban)
 
         if existing:
             results.append({

--- a/backend/tests/test_bank_connectivity_fixes.py
+++ b/backend/tests/test_bank_connectivity_fixes.py
@@ -138,56 +138,10 @@ class TestPerAccountSyncStartDate(unittest.TestCase):
         self.assertEqual(start, expected)
 
 
-class TestSuggestedMappings(unittest.TestCase):
-    """GET /connections/{id}/suggested-mappings returns link suggestion for known accounts."""
-
-    def test_returns_link_suggestion_for_known_external_id(self):
-        from app.routes.enable_banking import _build_suggested_mappings
-
-        # Simulate: one known account (blind index matches), one unknown
-        existing_account = MagicMock()
-        existing_account.id = "acc-uuid-1"
-        existing_account.name = "My Savings"
-        existing_account.external_id_hash = "hash-abc"
-
-        mock_db = MagicMock()
-        mock_db.query.return_value.filter.return_value.first.return_value = existing_account
-
-        raw_accounts = [
-            {"uid": "bank-uid-1", "account_name": "Savings Account"},
-            {"uid": "bank-uid-2", "account_name": "New Current Account"},
-        ]
-
-        with patch("app.routes.enable_banking.blind_index") as mock_bi:
-            # bank-uid-1 matches existing_account hash, bank-uid-2 does not
-            mock_bi.side_effect = lambda uid: "hash-abc" if uid == "bank-uid-1" else "hash-xyz"
-
-            # We need different first() results per UID — adjust the mock
-            call_count = [0]
-            def first_side_effect():
-                call_count[0] += 1
-                if call_count[0] == 1:
-                    return existing_account  # bank-uid-1 matches
-                return None  # bank-uid-2 does not match
-
-            mock_db.query.return_value.filter.return_value.first.side_effect = first_side_effect
-
-            result = _build_suggested_mappings(
-                db=mock_db,
-                user_id="user-1",
-                raw_accounts=raw_accounts,
-            )
-
-        self.assertEqual(len(result), 2)
-        match = next(r for r in result if r["bank_uid"] == "bank-uid-1")
-        no_match = next(r for r in result if r["bank_uid"] == "bank-uid-2")
-
-        self.assertEqual(match["suggested_action"], "link")
-        self.assertEqual(match["suggested_account_id"], "acc-uuid-1")
-        self.assertEqual(match["suggested_account_name"], "My Savings")
-
-        self.assertEqual(no_match["suggested_action"], "create")
-        self.assertIsNone(no_match["suggested_account_id"])
+# The former TestSuggestedMappings lived here. It asserted against mocked
+# blind_index/.first() internals that _build_suggested_mappings no longer uses;
+# its behaviour is covered against a real database in
+# tests/test_enable_banking_autolink.py::TestSuggestedMappings.
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_enable_banking_autolink.py
+++ b/backend/tests/test_enable_banking_autolink.py
@@ -1,0 +1,233 @@
+"""Auto-linking a bank account to the user's existing account during setup.
+
+Enable Banking mints a new account uid on every authorization, so matching on
+uid alone misses whenever a user reconnects. The wizard then offers only
+"create new" and the same real account is added a second time. IBAN survives
+re-consent, so it is the fallback identity key.
+"""
+import os
+import sys
+import unittest
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class AutoLinkTestCase(unittest.TestCase):
+    """Real database: the matching runs in SQL over blind indexes."""
+
+    def setUp(self):
+        from app.database import Base, SessionLocal, engine
+        from app.db_helpers import get_or_create_system_user
+
+        Base.metadata.create_all(bind=engine)
+        self.db = SessionLocal()
+        self.user_id = str(get_or_create_system_user(self.db).id)
+        # Unique per test: the system user is shared across the suite.
+        self.iban = f"NL91ABNA{uuid.uuid4().hex[:10].upper()}"
+        self.old_uid = f"uid-old-{uuid.uuid4().hex[:8]}"
+        self.new_uid = f"uid-new-{uuid.uuid4().hex[:8]}"
+        self.created_accounts = []
+        self.created_connections = []
+
+    def tearDown(self):
+        from app.models import Account, BankConnection
+
+        for account in self.created_accounts:
+            self.db.query(Account).filter(Account.id == account).delete()
+        for connection in self.created_connections:
+            self.db.query(BankConnection).filter(BankConnection.id == connection).delete()
+        self.db.commit()
+        self.db.close()
+
+    def _connection(self, status):
+        from app.models import BankConnection
+
+        conn = BankConnection(
+            user_id=self.user_id,
+            provider="enable_banking",
+            session_id=f"sess-{uuid.uuid4().hex[:8]}",
+            aspsp_name="ABN AMRO",
+            aspsp_country="NL",
+            status=status,
+        )
+        self.db.add(conn)
+        self.db.commit()
+        self.created_connections.append(conn.id)
+        return conn
+
+    def _account(self, connection=None):
+        from app.models import Account
+        from app.services.sync_service import SyncService
+
+        acc = Account(
+            user_id=self.user_id,
+            name="ABN AMRO Giannis",
+            account_type="checking",
+            currency="EUR",
+            provider="enable_banking",
+            bank_connection_id=connection.id if connection else None,
+        )
+        SyncService._set_account_external_id_fields(acc, self.old_uid)
+        SyncService._set_account_iban_fields(acc, self.iban)
+        self.db.add(acc)
+        self.db.commit()
+        self.created_accounts.append(acc.id)
+        return acc
+
+    def _suggest(self):
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        return _build_suggested_mappings(
+            db=self.db,
+            user_id=self.user_id,
+            raw_accounts=[{
+                "uid": self.new_uid,          # rotated by the new consent
+                "iban": self.iban,            # survives re-consent
+                "account_name": "Betaalrekening",
+                "currency": "EUR",
+            }],
+        )[0]
+
+
+class TestSuggestedMappings(AutoLinkTestCase):
+    def test_rotated_uid_is_matched_by_iban(self):
+        """The core case: reconnecting must recognize the account, not duplicate it."""
+        account = self._account(self._connection("expired"))
+
+        suggestion = self._suggest()
+
+        self.assertEqual(suggestion["suggested_action"], "link")
+        self.assertEqual(suggestion["suggested_account_id"], str(account.id))
+        self.assertEqual(suggestion["suggested_account_name"], "ABN AMRO Giannis")
+
+    def test_unlinked_account_is_matched_by_iban(self):
+        """After a manual disconnect the account is unlinked but still the same account."""
+        account = self._account(connection=None)
+
+        suggestion = self._suggest()
+
+        self.assertEqual(suggestion["suggested_action"], "link")
+        self.assertEqual(suggestion["suggested_account_id"], str(account.id))
+
+    def test_account_held_by_a_live_connection_is_not_suggested(self):
+        """Re-linking it would silently break the connection that still works."""
+        self._account(self._connection("active"))
+
+        suggestion = self._suggest()
+
+        self.assertEqual(suggestion["suggested_action"], "create")
+        self.assertIsNone(suggestion["suggested_account_id"])
+
+    def test_an_unrelated_iban_is_not_matched(self):
+        """A genuinely new bank account must still be created, not linked to a stranger."""
+        self._account(self._connection("expired"))
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        suggestion = _build_suggested_mappings(
+            db=self.db,
+            user_id=self.user_id,
+            raw_accounts=[{
+                "uid": f"uid-other-{uuid.uuid4().hex[:8]}",
+                "iban": f"NL91RABO{uuid.uuid4().hex[:10].upper()}",
+                "account_name": "Spaarrekening",
+            }],
+        )[0]
+
+        self.assertEqual(suggestion["suggested_action"], "create")
+
+    def test_known_and_unknown_accounts_in_one_batch(self):
+        """A consent usually returns a mix; each account is judged on its own."""
+        account = self._account(self._connection("expired"))
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        known, unknown = _build_suggested_mappings(
+            db=self.db,
+            user_id=self.user_id,
+            raw_accounts=[
+                {"uid": self.new_uid, "iban": self.iban, "account_name": "Betaalrekening"},
+                {
+                    "uid": f"uid-fresh-{uuid.uuid4().hex[:8]}",
+                    "iban": f"NL91RABO{uuid.uuid4().hex[:10].upper()}",
+                    "account_name": "New Current Account",
+                },
+            ],
+        )
+
+        self.assertEqual(known["suggested_action"], "link")
+        self.assertEqual(known["suggested_account_id"], str(account.id))
+        self.assertEqual(known["suggested_account_name"], "ABN AMRO Giannis")
+        self.assertEqual(unknown["suggested_action"], "create")
+        self.assertIsNone(unknown["suggested_account_id"])
+
+    def test_unchanged_uid_still_matches(self):
+        """Banks that keep uids stable must not depend on the IBAN leg."""
+        account = self._account(self._connection("expired"))
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        suggestion = _build_suggested_mappings(
+            db=self.db,
+            user_id=self.user_id,
+            raw_accounts=[{"uid": self.old_uid, "account_name": "Betaalrekening"}],
+        )[0]
+
+        self.assertEqual(suggestion["suggested_action"], "link")
+        self.assertEqual(suggestion["suggested_account_id"], str(account.id))
+
+
+class TestMapAccountsLinkGuard(AutoLinkTestCase):
+    """The suggestion is worthless if submitting it is rejected."""
+
+    def _map(self, target_account, pending_connection):
+        from app.routes.enable_banking import map_accounts, MapAccountsRequest, AccountMapping
+
+        return map_accounts(
+            connection_id=str(pending_connection.id),
+            request=MapAccountsRequest(
+                mappings=[AccountMapping(
+                    bank_uid=self.new_uid,
+                    action="link",
+                    existing_account_id=str(target_account.id),
+                )],
+                initial_sync_days=90,
+            ),
+            db=self.db,
+            user_id=self.user_id,
+        )
+
+    def _pending(self):
+        conn = self._connection("pending_setup")
+        conn.raw_session_data = {"accounts": [{"uid": self.new_uid, "iban": self.iban}]}
+        self.db.commit()
+        return conn
+
+    def test_account_on_a_dead_consent_can_be_relinked(self):
+        account = self._account(self._connection("expired"))
+        pending = self._pending()
+
+        result = self._map(account, pending)
+
+        self.assertEqual(result.accounts_linked, 1)
+        self.db.refresh(account)
+        self.assertEqual(account.bank_connection_id, pending.id)
+
+    def test_account_on_a_live_consent_is_refused(self):
+        from fastapi import HTTPException
+
+        live = self._connection("active")
+        account = self._account(live)
+        pending = self._pending()
+
+        with self.assertRaises(HTTPException) as ctx:
+            self._map(account, pending)
+
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.db.rollback()
+        self.db.refresh(account)
+        self.assertEqual(
+            account.bank_connection_id, live.id, "the working connection must keep its account"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_enable_banking_autolink.py
+++ b/backend/tests/test_enable_banking_autolink.py
@@ -19,6 +19,13 @@ class AutoLinkTestCase(unittest.TestCase):
     def setUp(self):
         from app.database import Base, SessionLocal, engine
         from app.db_helpers import get_or_create_system_user
+        from app.security.data_encryption import blind_index
+
+        # IBAN exists only as ciphertext plus a blind index, so with encryption
+        # unconfigured _set_account_iban_fields silently writes nothing and the
+        # IBAN leg cannot match. Skip loudly rather than fail as "create".
+        if blind_index("probe") is None:
+            self.skipTest("DATA_ENCRYPTION_KEY_CURRENT unset; IBAN matching is unavailable")
 
         Base.metadata.create_all(bind=engine)
         self.db = SessionLocal()
@@ -40,8 +47,14 @@ class AutoLinkTestCase(unittest.TestCase):
         self.db.commit()
         self.db.close()
 
-    def _connection(self, status):
+    def _connection(self, status, consent_expires_at="future"):
+        from datetime import datetime, timedelta, timezone
         from app.models import BankConnection
+
+        if consent_expires_at == "future":
+            consent_expires_at = datetime.now(timezone.utc) + timedelta(days=60)
+        elif consent_expires_at == "past":
+            consent_expires_at = datetime.now(timezone.utc) - timedelta(days=1)
 
         conn = BankConnection(
             user_id=self.user_id,
@@ -50,25 +63,26 @@ class AutoLinkTestCase(unittest.TestCase):
             aspsp_name="ABN AMRO",
             aspsp_country="NL",
             status=status,
+            consent_expires_at=consent_expires_at,
         )
         self.db.add(conn)
         self.db.commit()
         self.created_connections.append(conn.id)
         return conn
 
-    def _account(self, connection=None):
+    def _account(self, connection=None, name="ABN AMRO Giannis", currency="EUR", uid=None):
         from app.models import Account
         from app.services.sync_service import SyncService
 
         acc = Account(
             user_id=self.user_id,
-            name="ABN AMRO Giannis",
+            name=name,
             account_type="checking",
-            currency="EUR",
+            currency=currency,
             provider="enable_banking",
             bank_connection_id=connection.id if connection else None,
         )
-        SyncService._set_account_external_id_fields(acc, self.old_uid)
+        SyncService._set_account_external_id_fields(acc, uid or self.old_uid)
         SyncService._set_account_iban_fields(acc, self.iban)
         self.db.add(acc)
         self.db.commit()
@@ -160,6 +174,46 @@ class TestSuggestedMappings(AutoLinkTestCase):
         self.assertEqual(unknown["suggested_action"], "create")
         self.assertIsNone(unknown["suggested_account_id"])
 
+    def test_lapsed_consent_still_marked_active_does_not_block(self):
+        """check_consent_expiry runs daily, so status lags a consent that just died."""
+        account = self._account(self._connection("active", consent_expires_at="past"))
+
+        suggestion = self._suggest()
+
+        self.assertEqual(suggestion["suggested_action"], "link")
+        self.assertEqual(suggestion["suggested_account_id"], str(account.id))
+
+    def test_shared_iban_is_split_by_currency(self):
+        """Multi-currency accounts share an IBAN; the wrong pick misfiles money."""
+        conn = self._connection("expired")
+        eur = self._account(conn, name="Revo EUR", currency="EUR", uid=f"u-{uuid.uuid4().hex[:8]}")
+        self._account(conn, name="Revo USD", currency="USD", uid=f"u-{uuid.uuid4().hex[:8]}")
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        suggestion = _build_suggested_mappings(
+            db=self.db,
+            user_id=self.user_id,
+            raw_accounts=[{"uid": self.new_uid, "iban": self.iban, "currency": "EUR"}],
+        )[0]
+
+        self.assertEqual(suggestion["suggested_action"], "link")
+        self.assertEqual(suggestion["suggested_account_id"], str(eur.id))
+
+    def test_shared_iban_with_no_currency_agreeing_is_left_to_the_user(self):
+        """Guessing between them would file one currency under the other's account."""
+        conn = self._connection("expired")
+        self._account(conn, name="Revo EUR", currency="EUR", uid=f"u-{uuid.uuid4().hex[:8]}")
+        self._account(conn, name="Revo USD", currency="USD", uid=f"u-{uuid.uuid4().hex[:8]}")
+        from app.routes.enable_banking import _build_suggested_mappings
+
+        suggestion = _build_suggested_mappings(
+            db=self.db,
+            user_id=self.user_id,
+            raw_accounts=[{"uid": self.new_uid, "iban": self.iban, "currency": "GBP"}],
+        )[0]
+
+        self.assertEqual(suggestion["suggested_action"], "create")
+
     def test_unchanged_uid_still_matches(self):
         """Banks that keep uids stable must not depend on the IBAN leg."""
         account = self._account(self._connection("expired"))
@@ -210,6 +264,44 @@ class TestMapAccountsLinkGuard(AutoLinkTestCase):
         self.assertEqual(result.accounts_linked, 1)
         self.db.refresh(account)
         self.assertEqual(account.bank_connection_id, pending.id)
+
+    def test_the_same_account_cannot_be_linked_twice_in_one_request(self):
+        """The first link moves the account onto this pending connection, which would
+        otherwise look un-held to the second and let it overwrite the uid."""
+        from fastapi import HTTPException
+        from app.routes.enable_banking import map_accounts, MapAccountsRequest, AccountMapping
+
+        account = self._account(self._connection("expired"))
+        pending = self._pending()
+        second_uid = f"uid-second-{uuid.uuid4().hex[:8]}"
+        pending.raw_session_data = {
+            "accounts": [{"uid": self.new_uid, "iban": self.iban}, {"uid": second_uid}]
+        }
+        self.db.commit()
+
+        with self.assertRaises(HTTPException) as ctx:
+            map_accounts(
+                connection_id=str(pending.id),
+                request=MapAccountsRequest(
+                    mappings=[
+                        AccountMapping(
+                            bank_uid=self.new_uid,
+                            action="link",
+                            existing_account_id=str(account.id),
+                        ),
+                        AccountMapping(
+                            bank_uid=second_uid,
+                            action="link",
+                            existing_account_id=str(account.id),
+                        ),
+                    ],
+                    initial_sync_days=90,
+                ),
+                db=self.db,
+                user_id=self.user_id,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
 
     def test_account_on_a_live_consent_is_refused(self):
         from fastapi import HTTPException

--- a/backend/tests/test_enable_banking_autolink.py
+++ b/backend/tests/test_enable_banking_autolink.py
@@ -16,16 +16,23 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 class AutoLinkTestCase(unittest.TestCase):
     """Real database: the matching runs in SQL over blind indexes."""
 
+    def _requires_iban_matching(self):
+        """Skip a test that can only work with encryption configured.
+
+        IBAN exists solely as ciphertext plus a blind index, so with no key
+        _set_account_iban_fields writes nothing and the IBAN leg cannot match.
+        Tests asserting "create" would then pass for the wrong reason, which is
+        worse than skipping. Applied per test: the uid-matching and
+        link-by-id tests work either way and must keep running.
+        """
+        from app.security.data_encryption import blind_index
+
+        if blind_index("probe") is None:
+            self.skipTest("DATA_ENCRYPTION_KEY_CURRENT unset; IBAN matching is unavailable")
+
     def setUp(self):
         from app.database import Base, SessionLocal, engine
         from app.db_helpers import get_or_create_system_user
-        from app.security.data_encryption import blind_index
-
-        # IBAN exists only as ciphertext plus a blind index, so with encryption
-        # unconfigured _set_account_iban_fields silently writes nothing and the
-        # IBAN leg cannot match. Skip loudly rather than fail as "create".
-        if blind_index("probe") is None:
-            self.skipTest("DATA_ENCRYPTION_KEY_CURRENT unset; IBAN matching is unavailable")
 
         Base.metadata.create_all(bind=engine)
         self.db = SessionLocal()
@@ -107,6 +114,7 @@ class AutoLinkTestCase(unittest.TestCase):
 class TestSuggestedMappings(AutoLinkTestCase):
     def test_rotated_uid_is_matched_by_iban(self):
         """The core case: reconnecting must recognize the account, not duplicate it."""
+        self._requires_iban_matching()
         account = self._account(self._connection("expired"))
 
         suggestion = self._suggest()
@@ -117,6 +125,7 @@ class TestSuggestedMappings(AutoLinkTestCase):
 
     def test_unlinked_account_is_matched_by_iban(self):
         """After a manual disconnect the account is unlinked but still the same account."""
+        self._requires_iban_matching()
         account = self._account(connection=None)
 
         suggestion = self._suggest()
@@ -126,6 +135,7 @@ class TestSuggestedMappings(AutoLinkTestCase):
 
     def test_account_held_by_a_live_connection_is_not_suggested(self):
         """Re-linking it would silently break the connection that still works."""
+        self._requires_iban_matching()
         self._account(self._connection("active"))
 
         suggestion = self._suggest()
@@ -135,6 +145,7 @@ class TestSuggestedMappings(AutoLinkTestCase):
 
     def test_an_unrelated_iban_is_not_matched(self):
         """A genuinely new bank account must still be created, not linked to a stranger."""
+        self._requires_iban_matching()
         self._account(self._connection("expired"))
         from app.routes.enable_banking import _build_suggested_mappings
 
@@ -152,6 +163,7 @@ class TestSuggestedMappings(AutoLinkTestCase):
 
     def test_known_and_unknown_accounts_in_one_batch(self):
         """A consent usually returns a mix; each account is judged on its own."""
+        self._requires_iban_matching()
         account = self._account(self._connection("expired"))
         from app.routes.enable_banking import _build_suggested_mappings
 
@@ -176,6 +188,7 @@ class TestSuggestedMappings(AutoLinkTestCase):
 
     def test_lapsed_consent_still_marked_active_does_not_block(self):
         """check_consent_expiry runs daily, so status lags a consent that just died."""
+        self._requires_iban_matching()
         account = self._account(self._connection("active", consent_expires_at="past"))
 
         suggestion = self._suggest()
@@ -185,6 +198,7 @@ class TestSuggestedMappings(AutoLinkTestCase):
 
     def test_shared_iban_is_split_by_currency(self):
         """Multi-currency accounts share an IBAN; the wrong pick misfiles money."""
+        self._requires_iban_matching()
         conn = self._connection("expired")
         eur = self._account(conn, name="Revo EUR", currency="EUR", uid=f"u-{uuid.uuid4().hex[:8]}")
         self._account(conn, name="Revo USD", currency="USD", uid=f"u-{uuid.uuid4().hex[:8]}")
@@ -201,6 +215,7 @@ class TestSuggestedMappings(AutoLinkTestCase):
 
     def test_shared_iban_with_no_currency_agreeing_is_left_to_the_user(self):
         """Guessing between them would file one currency under the other's account."""
+        self._requires_iban_matching()
         conn = self._connection("expired")
         self._account(conn, name="Revo EUR", currency="EUR", uid=f"u-{uuid.uuid4().hex[:8]}")
         self._account(conn, name="Revo USD", currency="USD", uid=f"u-{uuid.uuid4().hex[:8]}")
@@ -293,6 +308,43 @@ class TestMapAccountsLinkGuard(AutoLinkTestCase):
                             bank_uid=second_uid,
                             action="link",
                             existing_account_id=str(account.id),
+                        ),
+                    ],
+                    initial_sync_days=90,
+                ),
+                db=self.db,
+                user_id=self.user_id,
+            )
+
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_duplicate_detection_ignores_uuid_casing(self):
+        """Postgres parses a UUID regardless of case, so two spellings are one account."""
+        from fastapi import HTTPException
+        from app.routes.enable_banking import map_accounts, MapAccountsRequest, AccountMapping
+
+        account = self._account(self._connection("expired"))
+        pending = self._pending()
+        second_uid = f"uid-second-{uuid.uuid4().hex[:8]}"
+        pending.raw_session_data = {
+            "accounts": [{"uid": self.new_uid, "iban": self.iban}, {"uid": second_uid}]
+        }
+        self.db.commit()
+
+        with self.assertRaises(HTTPException) as ctx:
+            map_accounts(
+                connection_id=str(pending.id),
+                request=MapAccountsRequest(
+                    mappings=[
+                        AccountMapping(
+                            bank_uid=self.new_uid,
+                            action="link",
+                            existing_account_id=str(account.id).lower(),
+                        ),
+                        AccountMapping(
+                            bank_uid=second_uid,
+                            action="link",
+                            existing_account_id=str(account.id).upper(),
                         ),
                     ],
                     initial_sync_days=90,

--- a/frontend/components/settings/bank-connections-manager.tsx
+++ b/frontend/components/settings/bank-connections-manager.tsx
@@ -35,6 +35,7 @@ type BankConnectionItem = {
   lastSyncError: string | null;
   consentExpiresAt: Date | null;
   createdAt: Date | null;
+  accounts: { id: string; name: string; currency: string | null }[];
 };
 
 interface BankConnectionsManagerProps {
@@ -361,6 +362,16 @@ export function BankConnectionsManager({ connections }: BankConnectionsManagerPr
                       </>
                     )}
                   </div>
+                  {/* Two connections to the same bank look identical without this. */}
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {connection.accounts.length > 0 ? (
+                      connection.accounts
+                        .map((a) => (a.currency ? `${a.name} (${a.currency})` : a.name))
+                        .join(" · ")
+                    ) : (
+                      <span className="italic">No accounts linked</span>
+                    )}
+                  </p>
                   {isConsentExpiringSoon(connection) && (
                     <div className="mt-1 flex items-center gap-1 text-xs text-amber-600">
                       <RiAlertLine className="h-3 w-3" />

--- a/frontend/components/settings/settings-tabs.tsx
+++ b/frontend/components/settings/settings-tabs.tsx
@@ -45,6 +45,7 @@ interface SettingsTabsProps {
     lastSyncError: string | null;
     consentExpiresAt: Date | null;
     createdAt: Date | null;
+    accounts: { id: string; name: string; currency: string | null }[];
   }>;
   people: Person[];
 }

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, and, or, ne, desc, isNull, isNotNull } from "drizzle-orm";
+import { eq, and, or, ne, lt, desc, isNull, isNotNull } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { bankConnections, accounts } from "@/lib/db/schema";
 import { requireAuth, getAuthenticatedSession } from "@/lib/auth-helpers";
@@ -255,11 +255,18 @@ export async function getLinkableAccounts() {
     // Accounts held by a dead consent must stay selectable, otherwise the only
     // option the wizard can offer after an expiry is "create new" — a duplicate.
     // A live connection still owns its accounts and they are excluded.
+    // A lapsed consent counts as dead even while its row still says "active":
+    // check_consent_expiry only runs daily, so the status lags reality and would
+    // otherwise hide the very account the user is trying to relink.
     .leftJoin(bankConnections, eq(accounts.bankConnectionId, bankConnections.id))
     .where(
       and(
         eq(accounts.userId, userId),
-        or(isNull(accounts.bankConnectionId), ne(bankConnections.status, "active"))
+        or(
+          isNull(accounts.bankConnectionId),
+          ne(bankConnections.status, "active"),
+          lt(bankConnections.consentExpiresAt, new Date())
+        )
       )
     )
     .orderBy(accounts.name);

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, and, desc, isNull, isNotNull } from "drizzle-orm";
+import { eq, and, or, ne, desc, isNull, isNotNull } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { bankConnections, accounts } from "@/lib/db/schema";
 import { requireAuth, getAuthenticatedSession } from "@/lib/auth-helpers";
@@ -252,10 +252,14 @@ export async function getLinkableAccounts() {
       bankConnectionId: accounts.bankConnectionId,
     })
     .from(accounts)
+    // Accounts held by a dead consent must stay selectable, otherwise the only
+    // option the wizard can offer after an expiry is "create new" — a duplicate.
+    // A live connection still owns its accounts and they are excluded.
+    .leftJoin(bankConnections, eq(accounts.bankConnectionId, bankConnections.id))
     .where(
       and(
         eq(accounts.userId, userId),
-        isNull(accounts.bankConnectionId)
+        or(isNull(accounts.bankConnectionId), ne(bankConnections.status, "active"))
       )
     )
     .orderBy(accounts.name);

--- a/frontend/lib/actions/bank-connections.ts
+++ b/frontend/lib/actions/bank-connections.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { eq, and, desc, isNull } from "drizzle-orm";
+import { eq, and, desc, isNull, isNotNull } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { bankConnections, accounts } from "@/lib/db/schema";
 import { requireAuth, getAuthenticatedSession } from "@/lib/auth-helpers";
@@ -13,23 +13,51 @@ export async function getBankConnections() {
   const userId = await requireAuth();
   if (!userId) return [];
 
-  return db
-    .select({
-      id: bankConnections.id,
-      userId: bankConnections.userId,
-      provider: bankConnections.provider,
-      aspspName: bankConnections.aspspName,
-      aspspCountry: bankConnections.aspspCountry,
-      consentExpiresAt: bankConnections.consentExpiresAt,
-      status: bankConnections.status,
-      lastSyncedAt: bankConnections.lastSyncedAt,
-      lastSyncError: bankConnections.lastSyncError,
-      createdAt: bankConnections.createdAt,
-      updatedAt: bankConnections.updatedAt,
-    })
-    .from(bankConnections)
-    .where(eq(bankConnections.userId, userId))
-    .orderBy(desc(bankConnections.createdAt));
+  const [connections, linkedAccounts] = await Promise.all([
+    db
+      .select({
+        id: bankConnections.id,
+        userId: bankConnections.userId,
+        provider: bankConnections.provider,
+        aspspName: bankConnections.aspspName,
+        aspspCountry: bankConnections.aspspCountry,
+        consentExpiresAt: bankConnections.consentExpiresAt,
+        status: bankConnections.status,
+        lastSyncedAt: bankConnections.lastSyncedAt,
+        lastSyncError: bankConnections.lastSyncError,
+        createdAt: bankConnections.createdAt,
+        updatedAt: bankConnections.updatedAt,
+      })
+      .from(bankConnections)
+      .where(eq(bankConnections.userId, userId))
+      .orderBy(desc(bankConnections.createdAt)),
+    // Several connections to the same bank are otherwise indistinguishable —
+    // same name, same country. The mapped accounts are what tells them apart.
+    // IBAN can't be shown: it is only stored encrypted, and the key is server-side.
+    db
+      .select({
+        id: accounts.id,
+        name: accounts.name,
+        currency: accounts.currency,
+        bankConnectionId: accounts.bankConnectionId,
+      })
+      .from(accounts)
+      .where(and(eq(accounts.userId, userId), isNotNull(accounts.bankConnectionId)))
+      .orderBy(accounts.name),
+  ]);
+
+  const byConnection = new Map<string, { id: string; name: string; currency: string | null }[]>();
+  for (const account of linkedAccounts) {
+    const key = account.bankConnectionId!;
+    const list = byConnection.get(key) ?? [];
+    list.push({ id: account.id, name: account.name, currency: account.currency });
+    byConnection.set(key, list);
+  }
+
+  return connections.map((connection) => ({
+    ...connection,
+    accounts: byConnection.get(connection.id) ?? [],
+  }));
 }
 
 export async function getActiveBankConnectionsWithExpiry(): Promise<


### PR DESCRIPTION
Two related fixes to the bank-connection setup flow, both driven by real symptoms on `app.syllogic.ai`.

## 1. You cannot tell the connections apart

Five connections, two banks, every card rendering identically — same name, same country, same layout:

| Bank | Status | Synced | Accounts (new) |
|---|---|---|---|
| ABN AMRO | Active | 8/22 | ABN AMRO Giannis |
| ABN AMRO | Expired | 7/22 | ABN Partner |
| Revolut | Expired | 7/22 | Revo Partner |
| Revolut | Expired | 7/17 | Revo Giannis · Revo Joint · Revo Pocket · Revo Pro |
| ABN AMRO | Expired | 7/17 | **— no accounts —** |

Each card now lists the accounts it covers, and says "No accounts linked" when it holds none — which is what identifies the orphan left behind by an earlier disconnect/reconnect cycle, i.e. the one that is safe to remove.

IBAN is deliberately not shown: it is only ever stored as ciphertext plus a blind index, and the key lives server-side, so the frontend cannot render it. Account name + currency is the identifier available.

## 2. A returning account is duplicated instead of linked

`_build_suggested_mappings` matched the user's existing accounts on the Enable Banking account uid alone. EB mints a **new uid on every authorization**, so the match missed on any reconnect, the wizard defaulted to "create new", and the same real account was added a second time.

The suggestion now falls back to IBAN, which survives re-consent. Three things had to change together, or the suggestion could not be honoured:

- **`_find_account_for_bank_account`** — matches uid then IBAN, using blind-index *candidates* so a rotated encryption key still matches, and falling back to plaintext `external_id` where encryption is not configured.
- **`map_accounts`** — refused any account that already had a `bank_connection_id`. That refusal is what forced a disconnect before reconnecting, and that detour is where the duplicates came from. Only a still-**active** connection blocks re-linking now; an account held by an expired or errored consent moves to the new one.
- **`getLinkableAccounts`** — hid those same accounts from the picker, so even a correct suggestion had nothing to select. It now includes accounts whose connection is no longer active.

An account held by a live connection is never suggested and never moved: taking it would silently break a connection that still works.

## Testing

- 8 new tests in `test_enable_banking_autolink.py`, against a real database — the matching runs in SQL over blind indexes, so a mocked session cannot verify it.
- Mutation-verified in both directions: removing the IBAN leg, making the active-connection guard always-false (which would steal accounts from live connections), and reverting the link guard each fail a test.
- Full backend suite **322 passed**, against **295 on `main`** with an identical pre-existing failure set (`test_mcp_discovery`, `test_holding_valuation_service`, `test_investment*`, `test_mcp_investments_tools`, and the `test_demo_seed_service` collection error). No regressions.
- Frontend `tsc --noEmit` and `eslint` on changed files: 0 errors.

### One test removed

`TestSuggestedMappings` in `test_bank_connectivity_fixes.py` asserted against mocked `blind_index` / `.first()` internals that `_build_suggested_mappings` no longer uses. Rewriting it would only re-create the brittleness, so its behaviour — including the mixed known/unknown batch it checked — is now covered against a real database. A comment at the old location points to the replacement.

## Known limit

Verified against live data: 6 of 7 Enable Banking accounts have an IBAN recorded and will auto-link. **Revo Pocket has none** (normal for Revolut pockets — the bank issues no IBAN), so it can only ever match on the rotating uid and will still default to "create new". The `getLinkableAccounts` widening is what rescues that case: it is held by an expired connection, so previously it was not even offered in the picker and a duplicate was the only option. It can now be selected manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Identify each bank connection in Settings and auto-link returning accounts by IBAN to prevent duplicates. Before, setup matched only on a rotating provider uid and cards looked identical; now matching tries uid then IBAN, cards list linked accounts, and only live consents block re-linking.

- UI: Each connection shows its mapped accounts as name (+ currency) or “No accounts linked”; IBAN is not shown.
- Matching: uid first, then IBAN via blind-index candidates; falls back to plaintext external_id when encryption is off. Currency breaks ties for shared IBANs; ambiguous cases are left for manual mapping.
- Relinking rules: You can move an account from an expired/errored consent; accounts held by a live or unexpired consent are refused. getLinkableAccounts includes accounts on non-live consents and treats consent_expires_at as authoritative even if status still says “active.”
- Safety: map_accounts rejects duplicate mappings in one request by repeated existing_account_id (case-insensitive UUID) or bank_uid.
- Limits: Accounts without an IBAN still default to “create new,” but are now selectable due to the widened picker. IBAN-matching tests skip when encryption is not configured.

<sup>Written for commit 13e50c4159a0517899b9fd4cd4ce40717409b69e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

