### PR TITLE
fix(analytics): account-balances 500s on every unfiltered request

### DIFF
--- a/backend/app/routes/analytics.py
+++ b/backend/app/routes/analytics.py
@@ -373,8 +373,12 @@ def get_account_balances(
             ).scalar() or 0
             balance = float(balance)
         else:
-            # No date or category filters, use current balance
-            balance = float(account.balance_current)
+            # No date or category filters, use current balance.
+            # balance_current was removed from the Account model in favour of
+            # functional_balance (starting_balance + transactions); this branch
+            # was missed when the rest of the file was migrated at line 331,
+            # so it raised AttributeError on every unfiltered request.
+            balance = float(account.functional_balance) if account.functional_balance else 0.0
         
         result.append({
             "account_id": str(account.id),


### PR DESCRIPTION
`GET /api/analytics/account-balances` raises an unhandled `AttributeError` and returns a 500 on **any request without date or category filters**.

```python
else:
    # No date or category filters, use current balance
    balance = float(account.balance_current)   # AttributeError
```

`balance_current` was removed from the `Account` model in favour of `functional_balance` (`starting_balance` + transactions). The rest of this file was migrated at the time — line 331 already does it correctly and even carries the comment *"Use functional_balance instead of balance_current"* — but this `else` branch was missed.

The fix is byte-identical to that working branch, including the null guard, since `functional_balance` is nullable.

## Why it surfaced now

The web UI always passes date filters, so it takes the working branch and never hits this. The new mobile app calls the endpoint **unfiltered**, so it hits it every single time — the app signs in fine and then shows "Couldn't load accounts", because FastAPI's unhandled-exception response is a plain-text `Internal Server Error` that the Next.js proxy passes through verbatim.

## Scope

One file, one branch of one function, 6 insertions. Deliberately split out of #142 (the iOS widget branch) so the production fix can ship without waiting on the widget work.

## Verification

This commit is `551f8ef` from #142, cherry-picked cleanly with no conflicts. On that branch the full backend suite passes at **327 passed / 1 failed / 13 errors**, where the failure and errors are pre-existing and unrelated (tests building `sqlite:///:memory:` engines against models with JSONB columns, plus one MCP discovery route returning 404).

I did not re-run the suite on this branch: the cherry-pick is byte-identical, and a fresh worktree has no `.env` to reach a database.

## Related

`backend/app/routes/accounts.py:388` and `:396` still assign to and read the same removed attribute. Left alone here — the correct replacement there is ambiguous (`balance_sum` is transactions-only, whereas `functional_balance` includes `starting_balance`) and it is not on the path this fix unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500 errors on unfiltered GET /api/analytics/account-balances by using the `functional_balance` field instead of the removed `balance_current`. Previously, unfiltered requests raised AttributeError and returned 500; now they return the current functional balance (or 0 when null). This unblocks the mobile app, which calls the endpoint without filters.

- Update only the unfiltered branch: use `functional_balance` with a null guard; filtered logic remains unchanged.
- No schema or client changes required; no migrations.

<sup>Written for commit d6fb8afecdbb78ffd9d558c734db10e6437615e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

