### PR TITLE
fix(sync): only anchor balances fetched by this run

### DIFF
--- a/backend/tasks/enable_banking_tasks.py
+++ b/backend/tasks/enable_banking_tasks.py
@@ -237,6 +237,7 @@ def sync_bank_connection(self, connection_id: str):
             # matches what the user's banking app shows. Trade-off: the shown
             # balance then includes pending transactions that are not yet in
             # the transaction list — the list catches up when they book.
+            fresh_balance_fetched = False
             try:
                 balance_data = adapter.fetch_balances(account_uid)
                 balances = balance_data.get("balances", [])
@@ -250,6 +251,7 @@ def sync_bank_connection(self, connection_id: str):
                 if chosen is not None:
                     account.balance_available = chosen["balance_amount"]["amount"]
                     account.balance_is_anchored = True
+                    fresh_balance_fetched = True
                 else:
                     logger.warning(
                         f"No balances returned by Enable Banking for account {account.id}"
@@ -287,7 +289,12 @@ def sync_bank_connection(self, connection_id: str):
 
             # Anchor balance: back-calculate starting_balance so functional_balance = balance_available.
             # This fixes the displayed balance for accounts that only have partial history imported.
-            if account.balance_is_anchored and account.balance_available is not None:
+            # Gate on THIS run having fetched a balance: when two syncs overlap and the
+            # loser's balance fetch fails (Enable Banking rate-limits back-to-back calls),
+            # its session still holds the pre-sync balance_available, and anchoring to
+            # that stale value clobbers the winner's freshly-anchored starting_balance /
+            # functional_balance on commit (observed in prod, 2026-08-23).
+            if fresh_balance_fetched and account.balance_available is not None:
                 from sqlalchemy import func as _sa_func2
                 from app.models import Transaction
                 _txn_sum_result = db.query(_sa_func2.sum(Transaction.amount)).filter(


### PR DESCRIPTION
Two overlapping syncs of the same connection race: the loser's balance fetch fails (Enable Banking rate-limits back-to-back calls), but its anchor block still ran using the stale `balance_available` loaded before the winner committed — back-writing the old `starting_balance`/`functional_balance` over the winner's fresh anchor.

Observed in prod on 2026-08-23 after deploying #142: `balance_available` carried the new XPCD value (614.39) while `functional_balance` reverted to the pre-sync CLBD number (814.39), with `starting_balance` matching the stale anchor math to the cent (922.46 = 814.39 + 108.07).

Fix: gate the anchor block on this run having actually fetched a balance, so a failed fetch can never anchor to a stale session value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale balance anchors during overlapping Enable Banking syncs by anchoring only when this run fetched a balance. Previously, a failed fetch could anchor a stale `balance_available` and overwrite the winner’s `starting_balance`/`functional_balance`; now the anchor runs only when this process selected a balance.

- Adds a per-run flag `fresh_balance_fetched` in `sync_bank_connection`; set when a balance is chosen, and required (with `balance_available`) to run the anchor block.
- Keeps balance selection logic and priority unchanged.

<sup>Written for commit 8abc4519540da0253c095c17c03ae451d75d33e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

