### PR TITLE
fix(pipeline): isolate post-import steps so a failing step no longer freezes balances

### DIFF
--- a/backend/tasks/post_import_pipeline.py
+++ b/backend/tasks/post_import_pipeline.py
@@ -307,19 +307,46 @@ def _run_post_import_pipeline(
             is_initial_sync,
         )
 
+        # Steps are isolated: one failing step must not stop the ones after it.
+        # Before this, a failing LLM categorization (step 4) aborted the whole
+        # pipeline, so balances (step 5) were never recalculated and account
+        # functional_balance froze at its pre-import value until a human
+        # intervened. Every step is idempotent, so the task still re-raises at
+        # the end to keep Celery's retry semantics for the failed steps.
+        failed_steps: List[str] = []
+
+        def _step(name: str, fn) -> None:
+            try:
+                fn()
+            except Exception as e:
+                # A failed flush poisons the session; roll back so later
+                # steps can still query and commit.
+                db.rollback()
+                logger.error(
+                    "[POST_IMPORT_PIPELINE] Step %s failed for user=%s: %s",
+                    name, user_id, e, exc_info=True,
+                )
+                failed_steps.append(name)
+
         # Step 1: FX rate sync
-        _sync_exchange_rates(db, user_id, transaction_ids)
+        _step("fx_rates", lambda: _sync_exchange_rates(db, user_id, transaction_ids))
 
         # Step 2: Functional amount calculation
-        _update_functional_amounts(db, user_id, transaction_ids)
+        _step("functional_amounts", lambda: _update_functional_amounts(db, user_id, transaction_ids))
 
         # Step 3: Internal transfer detection (must run before LLM categorization)
-        detection = _detect_internal_transfers(db, user_id, transaction_ids)
-        logger.info(
-            "[POST_IMPORT_PIPELINE] Internal transfers detected: %d (touched %d pocket(s))",
-            detection["detected"],
-            len(detection["pocket_account_ids"]),
-        )
+        detection = {"detected": 0, "pocket_account_ids": []}
+
+        def _run_detection():
+            nonlocal detection
+            detection = _detect_internal_transfers(db, user_id, transaction_ids)
+            logger.info(
+                "[POST_IMPORT_PIPELINE] Internal transfers detected: %d (touched %d pocket(s))",
+                detection["detected"],
+                len(detection["pocket_account_ids"]),
+            )
+
+        _step("internal_transfers", _run_detection)
 
         # Mirror transactions created in step 3 live on the pocket account; if
         # that pocket isn't in the sync's original account_ids scope, its
@@ -329,18 +356,23 @@ def _run_post_import_pipeline(
         recalc_account_ids = list({*account_ids, *touched_pocket_ids})
 
         # Step 4: Batch AI categorization (overwrites wrong system categories; preserves user overrides)
-        _batch_categorize_transactions(db, user_id, transaction_ids)
+        _step("categorization", lambda: _batch_categorize_transactions(db, user_id, transaction_ids))
 
         # Step 5: Balance calculation
-        _calculate_balances(db, user_id, recalc_account_ids)
+        _step("balances", lambda: _calculate_balances(db, user_id, recalc_account_ids))
 
         # Step 6: Balance timeseries
-        _calculate_timeseries(db, user_id, recalc_account_ids)
+        _step("timeseries", lambda: _calculate_timeseries(db, user_id, recalc_account_ids))
 
         # Step 7: Subscription detection
         # For initial sync, pass None so the detector scans ALL user transactions
         effective_txn_ids = None if is_initial_sync else transaction_ids
-        _detect_subscriptions(db, user_id, effective_txn_ids, account_ids)
+        _step("subscriptions", lambda: _detect_subscriptions(db, user_id, effective_txn_ids, account_ids))
+
+        if failed_steps:
+            raise RuntimeError(
+                f"post-import pipeline steps failed: {', '.join(failed_steps)}"
+            )
 
         logger.info("[POST_IMPORT_PIPELINE] Completed for user=%s", user_id)
 

--- a/backend/tests/test_post_import_pipeline.py
+++ b/backend/tests/test_post_import_pipeline.py
@@ -553,3 +553,87 @@ if __name__ == "__main__":
             all_passed = False
 
     sys.exit(0 if all_passed else 1)
+
+
+def test_pipeline_step_failure_does_not_block_balance_calculation():
+    """A failing categorization step (e.g. LLM outage) must not stop the
+    balance recalculation that runs after it — that freeze left account
+    functional_balance stale in prod. The pipeline still re-raises at the
+    end so Celery retries the failed step."""
+    print("Running test_pipeline_step_failure_does_not_block_balance_calculation...")
+
+    import pytest
+
+    with patch("tasks.post_import_pipeline.SessionLocal") as mock_session_local, \
+         patch("tasks.post_import_pipeline.set_request_user_id") as mock_set_user, \
+         patch("tasks.post_import_pipeline.clear_request_user_id"), \
+         patch("tasks.post_import_pipeline._sync_exchange_rates"), \
+         patch("tasks.post_import_pipeline._update_functional_amounts"), \
+         patch("tasks.post_import_pipeline._detect_internal_transfers") as mock_it, \
+         patch("tasks.post_import_pipeline._batch_categorize_transactions") as mock_cat, \
+         patch("tasks.post_import_pipeline._calculate_balances") as mock_balances, \
+         patch("tasks.post_import_pipeline._calculate_timeseries") as mock_timeseries, \
+         patch("tasks.post_import_pipeline._detect_subscriptions") as mock_subs:
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+        mock_set_user.return_value = "test-token"
+        mock_it.return_value = {"detected": 0, "pocket_account_ids": []}
+        mock_cat.side_effect = RuntimeError("LLM API unavailable")
+
+        from tasks.post_import_pipeline import _run_post_import_pipeline
+
+        with pytest.raises(RuntimeError, match="categorization"):
+            _run_post_import_pipeline(
+                user_id="user-123",
+                account_ids=["acc-1"],
+                transaction_ids=["txn-1"],
+            )
+
+        # The steps after the failure still ran.
+        mock_balances.assert_called_once()
+        mock_timeseries.assert_called_once()
+        mock_subs.assert_called_once()
+        # The poisoned session was rolled back before continuing.
+        mock_db.rollback.assert_called()
+
+    print("PASSED")
+
+
+def test_pipeline_detection_failure_still_recalculates_original_accounts():
+    """If internal-transfer detection fails, balances are still recalculated
+    for the sync's original accounts (pocket extension degrades to empty)."""
+    print("Running test_pipeline_detection_failure_still_recalculates_original_accounts...")
+
+    import pytest
+
+    with patch("tasks.post_import_pipeline.SessionLocal") as mock_session_local, \
+         patch("tasks.post_import_pipeline.set_request_user_id") as mock_set_user, \
+         patch("tasks.post_import_pipeline.clear_request_user_id"), \
+         patch("tasks.post_import_pipeline._sync_exchange_rates"), \
+         patch("tasks.post_import_pipeline._update_functional_amounts"), \
+         patch("tasks.post_import_pipeline._detect_internal_transfers") as mock_it, \
+         patch("tasks.post_import_pipeline._batch_categorize_transactions"), \
+         patch("tasks.post_import_pipeline._calculate_balances") as mock_balances, \
+         patch("tasks.post_import_pipeline._calculate_timeseries"), \
+         patch("tasks.post_import_pipeline._detect_subscriptions"):
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+        mock_set_user.return_value = "test-token"
+        mock_it.side_effect = RuntimeError("detector blew up")
+
+        from tasks.post_import_pipeline import _run_post_import_pipeline
+
+        with pytest.raises(RuntimeError, match="internal_transfers"):
+            _run_post_import_pipeline(
+                user_id="user-123",
+                account_ids=["acc-1", "acc-2"],
+                transaction_ids=["txn-1"],
+            )
+
+        args, kwargs = mock_balances.call_args
+        recalc_ids = args[2] if len(args) > 2 else kwargs.get("account_ids")
+        assert sorted(recalc_ids) == ["acc-1", "acc-2"]
+
+    print("PASSED")


### PR DESCRIPTION
The post-import pipeline ran its 7 steps in strict order with no isolation. When batch LLM categorization (step 4) raised — an LLM outage or quota error — balance recalculation (step 5) and timeseries (step 6) never ran, and the task's retries re-hit the same failure. Net effect in prod: newly imported transactions stayed uncategorized and `functional_balance` froze at its pre-import value (the ABN AMRO 814-vs-614 symptom, still reproducing after #142 and #144 because the reconciliation step simply never executed).

Each step now runs best-effort with a session rollback on failure, later steps always execute, and the task re-raises at the end so Celery still retries the failed (idempotent) steps. Detection failure degrades to recalculating the sync's original account set.

Tests: two new cases prove a failing categorization/detection step no longer blocks balance recalculation (7/7 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates each post-import pipeline step so one failure no longer blocks later steps. Previously, a categorization outage stopped balance recalculation and timeseries, leaving transactions uncategorized and `functional_balance` frozen; now later steps always run and the task re-raises at the end to preserve retries.

- Wrap each step with failure handling: rollback the session, log the step name, continue, and collect failed steps for a final RuntimeError.
- Always recalc balances and timeseries even if categorization or detection fails; when detection fails, recalc only the original account set.
- Preserve Celery retry semantics; all steps remain idempotent.
- Add tests proving categorization/detection failures do not block balance recalculation and that rollbacks occur.

<sup>Written for commit 9052a95d62834bb94a9e91462fa9cbc9d1c5cafe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

