### PR TITLE
fix(sync): keep stored balance_available when adapter provides none

### DIFF
--- a/backend/app/integrations/base.py
+++ b/backend/app/integrations/base.py
@@ -16,7 +16,7 @@ class AccountData(BaseModel):
     institution: str
     currency: str
     iban: Optional[str] = None  # IBAN of this account (stripped, upper-cased; None if not IBAN-based)
-    balance_available: Optional[Decimal] = None
+    balance_available: Optional[Decimal] = None  # None = adapter has no balance (NOT zero); sync keeps the stored value
     metadata: dict = {}
 
 

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -206,8 +206,9 @@ class SyncService:
                 existing_account.account_type = account_data.account_type
                 existing_account.institution = account_data.institution
                 existing_account.currency = account_data.currency
-                # Only update balance if provided from CSV (not None), otherwise keep existing or calculate later
-                # balance_current removed - use functional_balance instead
+                # Keep the stored balance when the adapter carries none: None means
+                # "not provided", never "clear". The live caller (Revolut CSV via
+                # sync_all) never sets it — its balance comes from functional_balance.
                 if account_data.balance_available is not None:
                     existing_account.balance_available = account_data.balance_available
                 self._set_account_external_id_fields(existing_account, account_data.external_id)

--- a/backend/app/services/sync_service.py
+++ b/backend/app/services/sync_service.py
@@ -208,7 +208,8 @@ class SyncService:
                 existing_account.currency = account_data.currency
                 # Only update balance if provided from CSV (not None), otherwise keep existing or calculate later
                 # balance_current removed - use functional_balance instead
-                existing_account.balance_available = account_data.balance_available
+                if account_data.balance_available is not None:
+                    existing_account.balance_available = account_data.balance_available
                 self._set_account_external_id_fields(existing_account, account_data.external_id)
                 self._set_account_iban_fields(existing_account, account_data.iban)
                 existing_account.is_active = True

--- a/backend/tests/test_account_iban_dedupe.py
+++ b/backend/tests/test_account_iban_dedupe.py
@@ -163,9 +163,11 @@ def test_reconsent_with_new_external_id_reuses_account_via_iban():
 def test_resync_without_balance_keeps_existing_balance():
     """A sync that carries no balance must not null the stored one.
 
-    Enable Banking's fetch_accounts never includes balances (they come from a
-    separate /balances call), so every account sync would otherwise wipe
-    balance_available until that second fetch happens to run.
+    None in AccountData.balance_available means "not provided", never
+    "clear". The live sync_accounts caller (the Revolut CSV import via
+    sync_all) never sets a balance, so before the guard every re-import
+    wiped the stored value; adapters that fetch balances separately
+    (e.g. Enable Banking) rely on the same contract.
     """
     _prev_env = _set_encryption_env()
     Base.metadata.create_all(bind=engine)
@@ -177,19 +179,29 @@ def test_resync_without_balance_keeps_existing_balance():
 
         iban = f"NL91ABNA{uuid.uuid4().hex[:10].upper()}"
 
-        _sync(db, user_id, [_account("eb-uid", iban, balance_available=Decimal("42.50"))])
-        assert _rows(db, user_id)[0].balance_available == Decimal("42.50")
+        _sync(db, user_id, [_account("uid-bal", iban, balance_available=Decimal("42.50"))])
+        rows = _rows(db, user_id)
+        assert len(rows) == 1 and rows[0].balance_available == Decimal("42.50")
 
-        # Re-sync with no balance in the payload (Enable Banking's shape).
-        _sync(db, user_id, [_account("eb-uid", iban, balance_available=None)])
-        assert _rows(db, user_id)[0].balance_available == Decimal("42.50"), (
+        # Re-sync with no balance in the payload.
+        _sync(db, user_id, [_account("uid-bal", iban, balance_available=None)])
+        rows = _rows(db, user_id)
+        assert len(rows) == 1
+        assert rows[0].balance_available == Decimal("42.50"), (
             "sync_accounts nulled balance_available when the adapter "
             "provided no balance; it must keep the stored value."
         )
 
         # A sync that does carry a balance still updates it.
-        _sync(db, user_id, [_account("eb-uid", iban, balance_available=Decimal("13.37"))])
-        assert _rows(db, user_id)[0].balance_available == Decimal("13.37")
+        _sync(db, user_id, [_account("uid-bal", iban, balance_available=Decimal("13.37"))])
+        rows = _rows(db, user_id)
+        assert len(rows) == 1 and rows[0].balance_available == Decimal("13.37")
+
+        # A genuine zero is an update too — pins `is not None` against a
+        # truthiness refactor, which would silently keep the stale 13.37.
+        _sync(db, user_id, [_account("uid-bal", iban, balance_available=Decimal("0.00"))])
+        rows = _rows(db, user_id)
+        assert len(rows) == 1 and rows[0].balance_available == Decimal("0.00")
     finally:
         if user_id:
             _cleanup(db, user_id)

--- a/backend/tests/test_account_iban_dedupe.py
+++ b/backend/tests/test_account_iban_dedupe.py
@@ -87,7 +87,12 @@ class _Adapter(BankAdapter):
         raise NotImplementedError
 
 
-def _account(external_id: str, iban: Optional[str], name: str = "Current Account") -> AccountData:
+def _account(
+    external_id: str,
+    iban: Optional[str],
+    name: str = "Current Account",
+    balance_available: Optional[Decimal] = Decimal("10.00"),
+) -> AccountData:
     return AccountData(
         external_id=external_id,
         name=name,
@@ -95,7 +100,7 @@ def _account(external_id: str, iban: Optional[str], name: str = "Current Account
         institution="Test Bank",
         currency="EUR",
         iban=iban,
-        balance_available=Decimal("10.00"),
+        balance_available=balance_available,
     )
 
 
@@ -148,6 +153,43 @@ def test_reconsent_with_new_external_id_reuses_account_via_iban():
         )
         # The stale uid must be refreshed so later syncs match on external_id again.
         assert rows[0].external_id == "eb-uid-second"
+    finally:
+        if user_id:
+            _cleanup(db, user_id)
+        db.close()
+        _restore_encryption_env(_prev_env)
+
+
+def test_resync_without_balance_keeps_existing_balance():
+    """A sync that carries no balance must not null the stored one.
+
+    Enable Banking's fetch_accounts never includes balances (they come from a
+    separate /balances call), so every account sync would otherwise wipe
+    balance_available until that second fetch happens to run.
+    """
+    _prev_env = _set_encryption_env()
+    Base.metadata.create_all(bind=engine)
+    db = SessionLocal()
+    user_id = None
+    try:
+        user_id = str(get_or_create_system_user(db).id)
+        _cleanup(db, user_id)
+
+        iban = f"NL91ABNA{uuid.uuid4().hex[:10].upper()}"
+
+        _sync(db, user_id, [_account("eb-uid", iban, balance_available=Decimal("42.50"))])
+        assert _rows(db, user_id)[0].balance_available == Decimal("42.50")
+
+        # Re-sync with no balance in the payload (Enable Banking's shape).
+        _sync(db, user_id, [_account("eb-uid", iban, balance_available=None)])
+        assert _rows(db, user_id)[0].balance_available == Decimal("42.50"), (
+            "sync_accounts nulled balance_available when the adapter "
+            "provided no balance; it must keep the stored value."
+        )
+
+        # A sync that does carry a balance still updates it.
+        _sync(db, user_id, [_account("eb-uid", iban, balance_available=Decimal("13.37"))])
+        assert _rows(db, user_id)[0].balance_available == Decimal("13.37")
     finally:
         if user_id:
             _cleanup(db, user_id)


### PR DESCRIPTION
## Summary
- `sync_accounts` assigned `account_data.balance_available` unconditionally in the existing-account branch, contradicting the comment above it. The only live caller is the Revolut CSV import via `sync_all`, whose adapter never sets `balance_available` — so **every CSV re-import nulled the stored balance**. Now the balance is only assigned when the adapter actually provided one: `None` means "not provided", never "clear".
- `AccountData.balance_available` now documents that contract, since adapters that fetch balances separately (e.g. Enable Banking) rely on it too. (Note: EB accounts don't flow through `sync_accounts` — the original EB-centric framing of this fix was corrected during review.)

## Test plan
- New `test_resync_without_balance_keeps_existing_balance` in `backend/tests/test_account_iban_dedupe.py`: a balance-less re-sync keeps the stored value, a balance-carrying sync still updates it, and a genuine `0.00` update pins the `is not None` guard against a truthiness refactor. Watched it fail before the fix (`assert None == Decimal('42.50')`), passes after.
- All sync/adapter/balance-related backend test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)