### PR TITLE
fix(reports): save edits before sending a test report

### DIFF
--- a/frontend/components/reports/ReportForm.tsx
+++ b/frontend/components/reports/ReportForm.tsx
@@ -66,6 +66,8 @@ export function ReportForm({
     handleSubmit,
     watch,
     setValue,
+    getValues,
+    trigger,
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
@@ -97,6 +99,10 @@ export function ReportForm({
     setSendTestError(null);
     setSendTestSuccess(false);
     try {
+      // The backend renders the test from the SAVED report, so unsaved edits
+      // would silently send the old config. Persist first.
+      if (!(await trigger())) return;
+      await updateReport(report.id, getValues());
       await sendTestReport(report.id);
       setSendTestSuccess(true);
     } catch (err) {

--- a/frontend/components/reports/ReportForm.tsx
+++ b/frontend/components/reports/ReportForm.tsx
@@ -101,8 +101,10 @@ export function ReportForm({
     try {
       // The backend renders the test from the SAVED report, so unsaved edits
       // would silently send the old config. Persist first.
+      // schema.parse, not getValues(): getValues is uncoerced, so number
+      // fields would go out as strings — unlike the normal save path.
       if (!(await trigger())) return;
-      await updateReport(report.id, getValues());
+      await updateReport(report.id, schema.parse(getValues()));
       await sendTestReport(report.id);
       setSendTestSuccess(true);
     } catch (err) {


### PR DESCRIPTION
Editing a report's accounts and clicking **Send test now** emailed the *old* config.

`handleSendTest` called `sendTestReport(report.id)` and nothing else. The backend renders the test from the persisted report (`report_service.send_test_report` reads `report.account_ids`), so unsaved form state was never seen. Not a caching issue.

Validate, save, then send:

```ts
if (!(await trigger())) return;
await updateReport(report.id, getValues());
await sendTestReport(report.id);
```

Reuses the existing `updateReport` and react-hook-form's `trigger`/`getValues` — no new state, no new deps. Existing error handling covers a failed save.

No test: would need mocking both API calls plus rhf for a 3-line ordering fix. `tsc --noEmit` clean, `components/reports/` 6 passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Saves report edits and validates before sending a test so the test email uses the current saved config. Previously, Send test now used the last persisted report and ignored unsaved changes; now it validates, saves with schema-parsed values, then sends.

- Call order: `trigger()` → `updateReport(report.id, schema.parse(getValues()))` → `sendTestReport(report.id)`; abort on validation failure.
- Matches the normal save path’s types, avoiding numeric fields being sent as strings.
- Scope: only the test-send path; no new state or dependencies; error handling unchanged.

<sup>Written for commit 6afd57e41ec424cd1b5a25055725b23e62381440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/syllogic-ai/syllogic/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

